### PR TITLE
Textfield backspace remove character not working on wsl

### DIFF
--- a/Terminal.Gui/Driver.cs
+++ b/Terminal.Gui/Driver.cs
@@ -566,6 +566,7 @@ namespace Terminal.Gui {
 			case Curses.KeyDeleteChar: return Key.DeleteChar;
 			case Curses.KeyInsertChar: return Key.InsertChar;
 			case Curses.KeyBackTab: return Key.BackTab;
+			case Curses.KeyBackspace: return Key.Backspace;
 			default: return Key.Unknown;
 			}
 		}

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -160,6 +160,14 @@ namespace Terminal.Gui {
 		{
 			switch (kb.Key) {
 			case Key.Delete:
+			case Key.DeleteChar:
+				if (text.Length == 0 || text.Length == point)
+					return true;
+
+				SetText (text [0, point] + text [point + 1, null]);
+				Adjust ();
+				break;
+
 			case Key.Backspace:
 				if (point == 0)
 					return true;


### PR DESCRIPTION
 **Summary:**
Backspace not removing characters in TextField on wsl console. 

I did a bit of debugging and it looks like the `MapCursesKey` function (https://github.com/migueldeicaza/gui.cs/blob/master/Terminal.Gui/Driver.cs#L545) maps the backspace key to `Key.Unkown` on wsl. Confirmed to also be broken on a native Linux box.

It does work as expected on windows cmd or powershell console.

Verified in dotnet core 2.1.0 and mono 5.10.1.47 

**Environment**:
Windows:
Microsoft Windows [Version 10.0.17134.1]

WSL:
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.4 LTS
Release:        16.04
Codename:       xenial

Linux:
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04 LTS
Release:	18.04
Codename:	bionic