### PR TITLE
Windows: Implementing mouse events and writing to console buffers

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1590,14 +1590,12 @@ namespace Terminal.Gui {
 			if (Top != null)
 				return;
 
-			if (!UseSystemConsole) {
-				var p = Environment.OSVersion.Platform;
-				if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows)
-					UseSystemConsole = true;
-			}
-			//UseSystemConsole = true;
+			var p = Environment.OSVersion.Platform;
+
 			if (UseSystemConsole)
 				Driver = new NetDriver ();
+			else if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows)
+				Driver = new WindowsDriver();
 			else
 				Driver = new CursesDriver ();
 			Driver.Init (TerminalResized);

--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1599,7 +1599,7 @@ namespace Terminal.Gui {
 			else
 				Driver = new CursesDriver ();
 			Driver.Init (TerminalResized);
-			MainLoop = new Mono.Terminal.MainLoop (Driver is CursesDriver);
+			MainLoop = new Mono.Terminal.MainLoop (Driver is CursesDriver, UseSystemConsole);
 			SynchronizationContext.SetSynchronizationContext (new MainLoopSyncContext (MainLoop));
 			Top = Toplevel.Create ();
 			Current = Top;

--- a/Terminal.Gui/Drivers/NetDriver.cs
+++ b/Terminal.Gui/Drivers/NetDriver.cs
@@ -238,7 +238,7 @@ namespace Terminal.Gui {
 			currentAttribute = c.value;
 		}
 
-		Key MapKey (ConsoleKeyInfo keyInfo)
+		public Key MapKey (ConsoleKeyInfo keyInfo)
 		{
 			switch (keyInfo.Key) {
 			case ConsoleKey.Escape:

--- a/Terminal.Gui/Drivers/NetDriver.cs
+++ b/Terminal.Gui/Drivers/NetDriver.cs
@@ -238,7 +238,7 @@ namespace Terminal.Gui {
 			currentAttribute = c.value;
 		}
 
-		public Key MapKey (ConsoleKeyInfo keyInfo)
+		Key MapKey (ConsoleKeyInfo keyInfo)
 		{
 			switch (keyInfo.Key) {
 			case ConsoleKey.Escape:

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -1,4 +1,30 @@
-﻿using System;
+﻿//
+// WindowsDriver.cs: Windows specific driver 
+//
+// Authors:
+//   Nick Van Dyck (vandyck.nick@outlook.com)
+//
+// Copyright (c) 2018
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Mono.Terminal;

--- a/Terminal.Gui/MonoCurses/mainloop.cs
+++ b/Terminal.Gui/MonoCurses/mainloop.cs
@@ -119,7 +119,7 @@ namespace Mono.Terminal {
 		{
 		}
 
-		public MainLoop (bool useUnix)
+		public MainLoop (bool useUnix, bool useNet=false)
 		{
 			this.useUnix = useUnix;
 			if (useUnix) {
@@ -128,6 +128,9 @@ namespace Mono.Terminal {
 					read (wakeupPipes [0], ignore, (IntPtr)1);
 					return true;
 				});
+			} else if (useNet) {
+				Thread readThread = new Thread (WindowsKeyReader); 
+				readThread.Start (); 
 			}
 		}
 

--- a/Terminal.Gui/MonoCurses/mainloop.cs
+++ b/Terminal.Gui/MonoCurses/mainloop.cs
@@ -128,10 +128,13 @@ namespace Mono.Terminal {
 					read (wakeupPipes [0], ignore, (IntPtr)1);
 					return true;
 				});
-			} else {
-				Thread readThread = new Thread (WindowsKeyReader);
-				readThread.Start ();
 			}
+			// Using this results in buggy behavior when we are hooking into ReadConsoleInput api ourselves
+			// Because if left in both custom code and this one tries to read from the consoleInput
+			// else {
+			// 	Thread readThread = new Thread (WindowsKeyReader);
+			// 	readThread.Start ();
+			// }
 		}
 
 		void Wakeup ()

--- a/Terminal.Gui/MonoCurses/mainloop.cs
+++ b/Terminal.Gui/MonoCurses/mainloop.cs
@@ -129,12 +129,6 @@ namespace Mono.Terminal {
 					return true;
 				});
 			}
-			// Using this results in buggy behavior when we are hooking into ReadConsoleInput api ourselves
-			// Because if left in both custom code and this one tries to read from the consoleInput
-			// else {
-			// 	Thread readThread = new Thread (WindowsKeyReader);
-			// 	readThread.Start ();
-			// }
 		}
 
 		void Wakeup ()

--- a/Terminal.Gui/MonoCurses/mainloop.cs
+++ b/Terminal.Gui/MonoCurses/mainloop.cs
@@ -129,8 +129,8 @@ namespace Mono.Terminal {
 					return true;
 				});
 			} else if (useNet) {
-				Thread readThread = new Thread (WindowsKeyReader); 
-				readThread.Start (); 
+				Thread readThread = new Thread (WindowsKeyReader);
+				readThread.Start ();
 			}
 		}
 


### PR DESCRIPTION
This is a first initial implementation of making mouse events work on windows. Related to #67 although this does not solve the resizing issues.

It still pretty rough at the moment, just wondering what you think. It is built upon the initial work that was already in place, just had to wire some bits up.

Currently tested on .net core 2.1.0.rc1 and full framework 471.
Also verified that I didn't break any unix stuff. Ubuntu 16.04 dotnet core 2.1.0.rc1 and mono 5.10.
Don't have a mac, so haven't tested that one. But given that the changes or isolated to the windowsdriver this should be fairly safe. 😁 (famous last words)
