### PR TITLE
Windows: restore console mode on exit

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -93,6 +93,7 @@ namespace Terminal.Gui {
 
 		public void Cleanup ()
 		{
+			ConsoleMode = originalConsoleMode;
 			ContinueListeningForConsoleEvents = false;
 			if (!SetConsoleActiveScreenBuffer (OutputHandle)) {
 				var err = Marshal.GetLastWin32Error ();


### PR DESCRIPTION
At the moment we are not restoring the `ConsoleMode` when exiting the application. This leads to a 'broken' console.  This restores the console mode back to it's original state.

Also thanks for finishing off the windows driver, it's running super smoothly now on windows 🙌
