### PR TITLE
Add support FullColor (24bit) for Windows

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -6,6 +6,9 @@ static class Demo {
 	class Box10x : View {
 		public Box10x (int x, int y) : base (new Rect (x, y, 10, 10))
 		{
+		    ColorScheme = new ColorScheme();
+		    ColorScheme.Focus = new FullAttribute(new FullColor(0, 0, 0),
+			new FullColor(255, 177, 177));
 		}
 
 		public override void Redraw (Rect region)

--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -6,9 +6,9 @@ static class Demo {
 	class Box10x : View {
 		public Box10x (int x, int y) : base (new Rect (x, y, 10, 10))
 		{
-		    ColorScheme = new ColorScheme();
-		    ColorScheme.Focus = new FullAttribute(new FullColor(0, 0, 0),
-			new FullColor(255, 177, 177));
+			ColorScheme = new ColorScheme();
+			ColorScheme.Focus = new Terminal.Gui.Attribute(new TrueColor(0, 0, 0),
+				new TrueColor(255, 177, 177));
 		}
 
 		public override void Redraw (Rect region)

--- a/Terminal.Gui/Drivers/ConsoleDriver.cs
+++ b/Terminal.Gui/Drivers/ConsoleDriver.cs
@@ -156,6 +156,11 @@ namespace Terminal.Gui {
 			ans = i;
 		return ans;
 	    }
+	    public static int WinToLinux(int code) {
+		if (code == 0 || code == 7 || code == 8 || code == 15)
+		    return code;
+		return (code & 8) + (code & 2) + 4 * (code & 1) + (code & 4) / 4;
+	    }	   
 	}
     
 	/// <summary>

--- a/Terminal.Gui/Drivers/ConsoleDriver.cs
+++ b/Terminal.Gui/Drivers/ConsoleDriver.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using Mono.Terminal;
 using NStack;
 using Unix.Terminal;
-using System.Drawing;
 
 namespace Terminal.Gui {
 

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -823,7 +823,7 @@ namespace Terminal.Gui {
 			var position = crow * Cols + ccol;
 
 			if (Clip.Contains (ccol, crow)) {
-				OutputBuffer [position].Attributes = (ushort)currentAttribute;
+				OutputBuffer [position].Attributes = currentAttribute;
 				OutputBuffer [position].Char = (char)rune;
 				WindowsConsole.SmallRect.Update (ref damageRegion, (short)ccol, (short)crow);
 			}
@@ -844,10 +844,10 @@ namespace Terminal.Gui {
 				AddRune (rune);
 		}
 
-		int currentAttribute;
+		Attribute currentAttribute;
 		public override void SetAttribute (Attribute c)
 		{
-			currentAttribute = c.value;
+			currentAttribute = c;
 		}
 
 		private Attribute MakeColor (ConsoleColor f, ConsoleColor b)


### PR DESCRIPTION
I add api for support 24bit color and 8bit color(256 color). Change struct Attribute to class Attribute and add class FullAttibute : Attribute. Add FullColor class (just r-g-b) and static method to convert 24bit color &larr;&rarr; 8bit color (Linux-like) &larr;&rarr; 4bit color (Old-windows-like). 
Change WindowsDriver implementation for support 24bit color.
But i can't implement checking windows version (old verson don't support 24bit color). I tried to use registry, but .Net Core don't support it. (see SetSupportFullColor() in WindowsConsole)
Change background of Box10x in example.
![image](https://user-images.githubusercontent.com/16323654/41192878-c6283e38-6c0d-11e8-892f-522eeef1924f.png)
