### PR TITLE
Handle shift-modifier if tab is pressed on System.Console and Windows drivers

### DIFF
--- a/Terminal.Gui/Drivers/NetDriver.cs
+++ b/Terminal.Gui/Drivers/NetDriver.cs
@@ -244,7 +244,7 @@ namespace Terminal.Gui {
 			case ConsoleKey.Escape:
 				return Key.Esc;
 			case ConsoleKey.Tab:
-				return Key.Tab;
+				return keyInfo.Modifiers == ConsoleModifiers.Shift ? Key.BackTab : Key.Tab;
 			case ConsoleKey.Home:
 				return Key.Home;
 			case ConsoleKey.End:

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -604,7 +604,7 @@ namespace Terminal.Gui {
 			case ConsoleKey.Escape:
 				return Key.Esc;
 			case ConsoleKey.Tab:
-				return Key.Tab;
+				return keyInfo.Modifiers == ConsoleModifiers.Shift ? Key.BackTab : Key.Tab;
 			case ConsoleKey.Home:
 				return Key.Home;
 			case ConsoleKey.End:


### PR DESCRIPTION
- This fixes backtab not working on Windows and System.Console.