### PR TITLE
Fixed HexView Display Offset Bug

### DIFF
--- a/Terminal.Gui/Views/HexView.cs
+++ b/Terminal.Gui/Views/HexView.cs
@@ -167,7 +167,7 @@ namespace Terminal.Gui {
 						else
 							SetAttribute (ColorScheme.Normal);
 
-						Driver.AddStr (offset >= n ? "   " : string.Format ("{0:x2}", value));
+						Driver.AddStr (offset >= n ? "  " : string.Format ("{0:x2}", value));
 						SetAttribute (ColorScheme.Normal);
 						Driver.AddRune (' ');
 					}


### PR DESCRIPTION
This pull request is in response to the open issue #83 "HexViewer pending issues".

The HexView would previously display lines that don't contain any data with a longer offset than lines that displayed hexadecimal data. This was due to filling in three spaces per byte instead of two. After correcting this the HexView has been displaying lines evenly in my tests.

I have included a comparison displaying the original issue and the results of the change.

![hexviewfix](https://user-images.githubusercontent.com/4957200/42487660-9616ba86-83c7-11e8-8dcf-a999d1ed812e.png)
