### PR TITLE
chore(frameview removall): To avoid infitinte loop for removeall

### DIFF
--- a/Terminal.Gui/Views/FrameView.cs
+++ b/Terminal.Gui/Views/FrameView.cs
@@ -101,6 +101,16 @@ namespace Terminal.Gui {
 				this.CanFocus = false;
 		}
 
+		/// <summary>
+		///   Removes all widgets from this container.
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		public override void RemoveAll()
+		{
+			contentView.RemoveAll();
+		}
+
 		public override void Redraw (Rect bounds)
 		{
 			if (!NeedDisplay.IsEmpty) {


### PR DESCRIPTION
For Frameview, `contentView` is the first and only subview. In case of `RemoveAll`, `contentView` was sent from `View.RemoveAll` to overridden `Remove` function in `FrameView`. Hence, `contentView` was trying to remove itself from itself thereby actually not removing any subviews as well `contentView` from `FrameView` parent. And thus the code was going in an infinite loop.

Added overridden `RemoveAll` which would call `View.RemoveAll` on `contentView` to remove all the subviews from `contentView` but not the `contentView` from `FrameView`.

Fixes: https://github.com/migueldeicaza/gui.cs/issues/125