### PR TITLE
Fixing bug in TextView, clicking line below text end causes IndexOutOfRangeException

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1091,8 +1091,10 @@ namespace Terminal.Gui {
 			if (!HasFocus)
 				SuperView.SetFocus (this);
 
-			if (ev.Y + topRow >= model.Count) {
-				currentRow = model.Count - topRow;
+
+			var maxCursorPositionableLine = (model.Count - 1) - topRow;
+			if (ev.Y > maxCursorPositionableLine) {
+				currentRow = maxCursorPositionableLine;
 			} else {
 				currentRow = ev.Y + topRow;
 			}


### PR DESCRIPTION
To reproduce bug in original, take following application and click any line below text end (for example, line 8).

 ```
                    Application.Init();
		    var top = Application.Top;

		    top.Add(new TextView() {
			Text = @"11111
	22222222222
	3333333333
	4444444444444
	555555555555"
		    });

		    Application.Run();
```