### PR TITLE
Fixed a bug with multiline labels not calculating their bounds correctly

### DIFF
--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -57,7 +57,10 @@ namespace Terminal.Gui {
 				} else
 					cols++;
 			}
-			return new Rect (x, y, cols, ml);
+			if (cols > mw)
+				mw = cols;
+
+			return new Rect (x, y, mw, ml);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I noticed multiline labels didn't seem to be calculating their bounding rectangle correctly.  I've updated Label.GetRect to return a Rect using the mw variable instead of cols, which will cause the width to be calculated based on the longest line in the label, instead of the last one.