### PR TITLE
Fixed subview layout

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -473,6 +473,7 @@ namespace Terminal.Gui {
 			view.container = this;
 			if (view.CanFocus)
 				CanFocus = true;
+			SetNeedsLayout ();
 			SetNeedsDisplay ();
 		}
 
@@ -513,6 +514,7 @@ namespace Terminal.Gui {
 			if (view == null || subviews == null)
 				return;
 
+			SetNeedsLayout ();
 			SetNeedsDisplay ();
 			var touched = view.Frame;
 			subviews.Remove (view);


### PR DESCRIPTION
When adding or removing child views the parent view was not recalculating it's size, or relaying the items. This fixes that problem.