### PR TITLE
Fixed multiline dialog layout

### DIFF
--- a/Terminal.Gui/Dialogs/MessageBox.cs
+++ b/Terminal.Gui/Dialogs/MessageBox.cs
@@ -52,7 +52,7 @@ namespace Terminal.Gui {
 
 		static int QueryFull (bool useErrorColors, int width, int height, string title, string message, params string [] buttons)
 		{
-			int lines = Label.MeasureLines (message, width);
+			int textWidth = Label.MaxWidth (message, width);
 			int clicked = -1, count = 0;
 
 			var d = new Dialog (title, width, height);
@@ -69,7 +69,7 @@ namespace Terminal.Gui {
 				d.AddButton (b);
 			}
 			if (message != null) {
-				var l = new Label ((width - 4 - message.Length) / 2, 0, message);
+				var l = new Label ((width - 4 - textWidth) / 2, 0, message);
 				d.Add (l);
 			}
 

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -210,6 +210,19 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
+		/// Computes the the max width of a line or multilines needed to render by the Label control
+		/// </summary>
+		/// <returns>Max width of lines.</returns>
+		/// <param name="text">Text, may contain newlines.</param>
+		/// <param name="width">The width for the text.</param>
+		public static int MaxWidth(ustring text, int width)
+		{
+			var result = new List<ustring>();
+			Recalc(text, result, width, TextAlignment.Left);
+			return result.Max(s => s.RuneCount);
+		}
+
+		/// <summary>
 		///   The text displayed by this widget.
 		/// </summary>
 		public virtual ustring Text {


### PR DESCRIPTION
Multiline dialogs were still using the full width of the text line, not counting newlines. This lead to extremely wide dialogs with all the text left justified.

This fixes the issue by correctly calculating the width of a multiline label and using that as the dialog width.