### PR TITLE
Fix null pointer deref

### DIFF
--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -261,8 +261,10 @@ namespace Terminal.Gui {
 				break;
 
 			case Key.ControlY: // Control-y, yank
+				if (Clipboard.Contents == null)
+					return true;
 				var clip = TextModel.ToRunes (Clipboard.Contents);
-				if (clip== null)
+				if (clip == null)
 					return true;
 
 				if (point == text.Count) {


### PR DESCRIPTION
Hi,

We may hit an exception when type in `ctrl+y` inside an empty textfield, because the Contents field is null. This patch fixes the issue.

Thanks,
Sang Kil