### PR TITLE
Correct the ScrollView behaviour for vertical scrolling

### DIFF
--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -208,7 +208,7 @@ namespace Terminal.Gui {
 				if (location == 0) {
 					if (pos > 0)
 						SetPosition (pos - 1);
-				} else if (location == Bounds.Width - 1){
+				} else if (location == barsize + 1){
 					if (pos + 1 + barsize < Size)
 						SetPosition (pos + 1);
 				} else {


### PR DESCRIPTION
Corrected the ScrollView behavior for vertical scrolling. In case of a vertical scrollbar the position of the "arrow" can not be determinated by the Bound.Width.