### PR TITLE
Feature/MenuItemSeparator

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -279,6 +279,7 @@ static class Demo {
 				new MenuItem ("_Open", "", Open),
 				new MenuItem ("_Hex", "", () => ShowHex (top)),
 				new MenuItem ("_Close", "", () => Close ()),
+				null,
 				new MenuItem ("_Quit", "", () => { if (Quit ()) top.Running = false; })
 			}),
 			new MenuBarItem ("_Edit", new MenuItem [] {

--- a/StandaloneExample/Program.cs
+++ b/StandaloneExample/Program.cs
@@ -185,6 +185,7 @@ class Demo {
 				new MenuItem ("_New", "Creates new file", NewFile),
 				new MenuItem ("_Open", "", null),
 				new MenuItem ("_Close", "", () => Close ()),
+				null,
 				new MenuItem ("_Quit", "", () => { if (Quit ()) top.Running = false; })
 			}),
 			new MenuBarItem ("_Edit", new MenuItem [] {

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -131,13 +131,13 @@ namespace Terminal.Gui {
 				maxW = Math.Max (l, maxW);
 			}
 
-			current = -1;
+			/* current = -1;
 			for (int i = 0; i < items.Length; i++) {
 				if (items [i] != null) {
 					current = i;
 					break;
 				}
-			}
+			} */
 			return new Rect (x, y, maxW + 2, items.Length + 2);
 		}
 
@@ -205,7 +205,7 @@ namespace Terminal.Gui {
 					current--;
 					if (current < 0)
 						current = barItems.Children.Length - 1;
-				} while (barItems.Children [current] == null)
+				} while (barItems.Children [current] == null);
 				SetNeedsDisplay ();
 				break;
 			case Key.CursorDown:
@@ -213,7 +213,7 @@ namespace Terminal.Gui {
 					current++;
 					if (current == barItems.Children.Length)
 						current = 0;
-				} while (barItems.Children [current] == null)
+				} while (barItems.Children [current] == null);
 				SetNeedsDisplay ();
 				break;
 			case Key.CursorLeft:
@@ -421,36 +421,36 @@ namespace Terminal.Gui {
 			OpenMenu (selected);
 		}
 
-                internal bool FindAndOpenMenuByHotkey(KeyEvent kb)
-                {
-                    int pos = 0;
-                    var c = ((uint)kb.Key & (uint)Key.CharMask);
-	            for (int i = 0; i < Menus.Length; i++)
-                    {
-			    // TODO: this code is duplicated, hotkey should be part of the MenuBarItem
-                            var mi = Menus[i];
-                            int p = mi.Title.IndexOf('_');
-                            if (p != -1 && p + 1 < mi.Title.Length) {
-                                    if (mi.Title[p + 1] == c) {
-			                    OpenMenu(i);
-			                    return true;
-                                    }
-                            }
-                    }
-	            return false;
-                }
+		internal bool FindAndOpenMenuByHotkey(KeyEvent kb)
+		{
+			int pos = 0;
+			var c = ((uint)kb.Key & (uint)Key.CharMask);
+			for (int i = 0; i < Menus.Length; i++)
+			{
+				// TODO: this code is duplicated, hotkey should be part of the MenuBarItem
+				var mi = Menus[i];
+				int p = mi.Title.IndexOf('_');
+				if (p != -1 && p + 1 < mi.Title.Length) {
+					if (mi.Title[p + 1] == c) {
+						OpenMenu(i);
+						return true;
+					}
+				}
+			}
+			return false;
+		}
 
-	        public override bool ProcessHotKey (KeyEvent kb)
+		public override bool ProcessHotKey (KeyEvent kb)
 		{
 			if (kb.Key == Key.F9) {
 				StartMenu ();
 				return true;
 			}
 
-                        if (kb.IsAlt)
-                        {
-                            if (FindAndOpenMenuByHotkey(kb)) return true;
-                        }
+			if (kb.IsAlt)
+			{
+				if (FindAndOpenMenuByHotkey(kb)) return true;
+			}
 			var kc = kb.KeyValue;
 
 			return base.ProcessHotKey (kb);

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -127,6 +127,7 @@ namespace Terminal.Gui {
 			int maxW = 0;
 
 			foreach (var item in items) {
+				if (item == null) continue;
 				var l = item.Width;
 				maxW = Math.Max (l, maxW);
 			}
@@ -154,18 +155,27 @@ namespace Terminal.Gui {
 			Driver.SetAttribute (ColorScheme.Normal);
 			DrawFrame (region, padding: 0, fill: true);
 
-			for (int i = 0; i < barItems.Children.Length; i++){
+			for (int i = 0; i < barItems.Children.Length; i++) {
 				var item = barItems.Children [i];
-				Move (1, i+1);
-				Driver.SetAttribute (item == null ? Colors.Base.Focus : i == current ? ColorScheme.Focus : ColorScheme.Normal);
+				Driver.SetAttribute(item == null ? ColorScheme.Normal : i == current ? ColorScheme.Focus : ColorScheme.Normal);
+				if (item == null) {
+					Move(0, i + 1);
+					Driver.AddRune(Driver.LeftTee);
+				}
+				else
+					Move(1, i+1);
+
 				for (int p = 0; p < Frame.Width-2; p++)
 					if (item == null)
 						Driver.AddRune (Driver.HLine);
 					else
 						Driver.AddRune (' ');
 
-				if (item == null)
+				if (item == null) {
+					Move(region.Right-1, i + 1);
+					Driver.AddRune(Driver.RightTee);
 					continue;
+				}
 
 				Move (2, i + 1);
 				DrawHotString (item.Title,
@@ -235,6 +245,7 @@ namespace Terminal.Gui {
 					var x = Char.ToUpper ((char)kb.KeyValue);
 
 					foreach (var item in barItems.Children) {
+						if (item == null) continue;
 						if (item.HotKey == x) {
 							host.CloseMenu ();
 							Run (item.Action);


### PR DESCRIPTION
Fixing menu item separator (#192)

- do not crash when item is null
- when using cursor, do not activate line if item is empty
- use the right color scheme