### PR TITLE
Make API for UI construction more fluent

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -479,10 +479,10 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
-		public virtual void Add (View view)
+		public virtual TView Add<TView> (TView view) where TView : View
 		{
 			if (view == null)
-				return;
+				return null;
 			if (subviews == null)
 				subviews = new List<View> ();
 			subviews.Add (view);
@@ -491,6 +491,7 @@ namespace Terminal.Gui {
 				CanFocus = true;
 			SetNeedsLayout ();
 			SetNeedsDisplay ();
+			return view;
 		}
 
 		/// <summary>
@@ -1411,11 +1412,12 @@ namespace Terminal.Gui {
 		/// Add the specified view to the ContentView.
 		/// </summary>
 		/// <param name="view">View to add to the window.</param>
-		public override void Add (View view)
+		public override TView Add<TView> (TView view)
 		{
 			contentView.Add (view);
 			if (view.CanFocus)
 				CanFocus = true;
+			return view;
 		}
 
 

--- a/Terminal.Gui/Views/FrameView.cs
+++ b/Terminal.Gui/Views/FrameView.cs
@@ -75,11 +75,12 @@ namespace Terminal.Gui {
 		/// Add the specified view to the ContentView.
 		/// </summary>
 		/// <param name="view">View to add to the window.</param>
-		public override void Add (View view)
+		public override TView Add<TView> (TView view)
 		{
 			contentView.Add (view);
 			if (view.CanFocus)
 				CanFocus = true;
+			return view;
 		}
 
 

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -295,9 +295,10 @@ namespace Terminal.Gui {
 		/// Adds the view to the scrollview.
 		/// </summary>
 		/// <param name="view">The view to add to the scrollview.</param>
-		public override void Add (View view)
+		public override TView Add<TView> (TView view)
 		{
 			contentView.Add (view);
+			return view;
 		}
 
 		/// <summary>


### PR DESCRIPTION
The main API for constructing UIs is `Add(view)`. By making the
API return the view (typed to the received view type), we allow
further operations on the view (i.e. save it to a variable, set
additional properties, etc.).

This makes the calling patterns more concise, so instead of:

```
var label = new Label("...");
Add(label);
```

You can just do:

```
var label = Add(new Label("..."));
```

for example. Or:

```
Add(new TextField("")
{
  Y = Pos.Right(Add(new Label("Password: ")))
});
```

This API change is backwards compatible and none of the existing
demo code had to change.