### PR TITLE
Allow key events to traverse the TopLevel hierarchy

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1315,6 +1315,13 @@ namespace Terminal.Gui {
 			get => true;
 		}
 
+		/// <summary>
+		/// Determines whether the <see cref="Toplevel"/> is modal or not. 
+		/// Causes <see cref="ProcessKey(KeyEvent)"/> to propagate keys upwards 
+		/// by default unless set to <see langword="true"/>.
+		/// </summary>
+		public bool Modal { get; set; }
+
 		public override bool ProcessKey (KeyEvent keyEvent)
 		{
 			if (base.ProcessKey (keyEvent))
@@ -1782,15 +1789,28 @@ namespace Terminal.Gui {
 
 		static void ProcessKeyEvent (KeyEvent ke)
 		{
-			if (Current.ProcessHotKey (ke))
-				return;
+			var chain = toplevels.ToList();
+			foreach (var topLevel in chain) {
+				if (topLevel.Modal)
+					break;
+				if (topLevel.ProcessHotKey (ke))
+					return;
+			}
 
-			if (Current.ProcessKey (ke))
-				return;
-			
-			// Process the key normally
-			if (Current.ProcessColdKey (ke))
-				return;
+			foreach (var topLevel in chain) {
+				if (topLevel.Modal)
+					break;
+				if (topLevel.ProcessKey (ke))
+					return;
+			}
+
+			foreach (var topLevel in chain) {
+				if (topLevel.Modal)
+					break;
+				// Process the key normally
+				if (topLevel.ProcessColdKey (ke))
+					return;
+			}
 		}
 
 		static View FindDeepestView (View start, int x, int y, out int resx, out int resy)

--- a/Terminal.Gui/Dialogs/Dialog.cs
+++ b/Terminal.Gui/Dialogs/Dialog.cs
@@ -38,6 +38,7 @@ namespace Terminal.Gui {
 			Width = width;
 			Height = height;
 			ColorScheme = Colors.Dialog;
+			Modal = true;
 
 			if (buttons != null) {
 				foreach (var b in buttons) {


### PR DESCRIPTION
It's quite common for key events to flow up the containment
hierarchy in UI frameworks. This could simplify management
of global hotkeys that can be placed in a top-level "App"
and have all views shown subsequently just "inherit" that
behavior as long as they let the key event to flow.

Make sure we make a copy of the items since a key handler
could modify the top-level collection (i.e. by closing a
dialog in between this processing).