### PR TITLE
Avoid throwing when the tokenSource is cancelled

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -506,7 +506,8 @@ namespace Terminal.Gui {
 			tokenSource.Dispose();
 			tokenSource = new CancellationTokenSource();
 			try {
-				eventReady.Wait(waitTimeout, tokenSource.Token);
+				if(!tokenSource.IsCancellationRequested)
+					eventReady.Wait(waitTimeout, tokenSource.Token);
 			} catch (OperationCanceledException) {
 				return true;
 			} finally {


### PR DESCRIPTION
When invoking an action in the main loop, the token will be cancelled (see
`MainLoop.Invoke` and `WindowsDriver.Wakeup`). At this point when the
EventsPending is running we must avoid throwing by waiting using a cancelled token:

`eventReady.Wait(waitTimeout, tokenSource.Token)`

And make sure we reach the disposal of the token source. Otherwise we keep throwing
over and over and cause a severe performance problem for the running app.