### PR TITLE
Upgrade from PackageLicenseUrl to PackageLicenseExpression

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -12,7 +12,7 @@
     <PackageId>Terminal.Gui</PackageId>
     <PackageVersion>0.24</PackageVersion>
     <Authors>Miguel de Icaza</Authors>
-    <PackageLicenseUrl>https://github.com/migueldeicaza/gui.cs/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/migueldeicaza/gui.cs/</PackageProjectUrl>
     <PackageTags>csharp, terminal, c#, f#, gui, toolkit, console</PackageTags>
     <Description>Console-based user interface toolkit for .NET applications.</Description>


### PR DESCRIPTION
The existing property is now considered legacy and results in a build warning: 

```
##[warning]C:\Program Files\dotnet\sdk\3.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(198,5): Warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
```