### PR TITLE
[Core - Subviews]: added InternalSubview property without allocations

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -252,6 +252,8 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <value>The subviews.</value>
 		public IList<View> Subviews => subviews == null ? empty : subviews.AsReadOnly ();
+		internal IList<View> InternalSubviews => subviews ?? empty;
+
 		internal Rect NeedDisplay { get; private set; } = Rect.Empty;
 
 		// The frame for the object
@@ -297,7 +299,7 @@ namespace Terminal.Gui {
 		/// <returns>The enumerator.</returns>
 		public IEnumerator GetEnumerator ()
 		{
-			foreach (var v in Subviews)
+			foreach (var v in InternalSubviews)
 				yield return v;
 		}
 
@@ -1220,7 +1222,7 @@ namespace Terminal.Gui {
 			var nodes = new HashSet<View> ();
 			var edges = new HashSet<(View, View)> ();
 
-			foreach (var v in Subviews) {
+			foreach (var v in InternalSubviews) {
 				nodes.Add (v);
 				if (v.LayoutStyle == LayoutStyle.Computed) {
 					if (v.X is Pos.PosView)
@@ -1509,7 +1511,7 @@ namespace Terminal.Gui {
 			var touched = view.Frame;
 			contentView.Remove (view);
 
-			if (contentView.Subviews.Count < 1)
+			if (contentView.InternalSubviews.Count < 1)
 				this.CanFocus = false;
 		}
 
@@ -1803,13 +1805,13 @@ namespace Terminal.Gui {
 				return null;
 			}
 
-			if (start.Subviews != null){
-				int count = start.Subviews.Count;
+			if (start.InternalSubviews != null){
+				int count = start.InternalSubviews.Count;
 				if (count > 0) {
 					var rx = x - startFrame.X;
 					var ry = y - startFrame.Y;
 					for (int i = count - 1; i >= 0; i--) {
-						View v = start.Subviews [i];
+						View v = start.InternalSubviews [i];
 						if (v.Frame.Contains (rx, ry)) {
 							var deep = FindDeepestView (v, rx, ry, out resx, out resy);
 							if (deep == null)
@@ -2016,8 +2018,8 @@ namespace Terminal.Gui {
 		static void DrawBounds (View v)
 		{
 			v.DrawFrame (v.Frame, padding: 0, fill: false);
-			if (v.Subviews != null && v.Subviews.Count > 0)
-				foreach (var sub in v.Subviews)
+			if (v.InternalSubviews != null && v.InternalSubviews.Count > 0)
+				foreach (var sub in v.InternalSubviews)
 					DrawBounds (sub);
 		}
 

--- a/Terminal.Gui/Views/FrameView.cs
+++ b/Terminal.Gui/Views/FrameView.cs
@@ -97,7 +97,7 @@ namespace Terminal.Gui {
 			var touched = view.Frame;
 			contentView.Remove (view);
 
-			if (contentView.Subviews.Count < 1)
+			if (contentView.InternalSubviews.Count < 1)
 				this.CanFocus = false;
 		}
 

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -365,7 +365,7 @@ namespace Terminal.Gui {
 
 		public override void PositionCursor()
 		{
-			if (Subviews.Count == 0)
+			if (InternalSubviews.Count == 0)
 				Driver.Move (0, 0);
 			else
 				base.PositionCursor ();


### PR DESCRIPTION
Added InternalSubview property without allocations (the calling to subviews.AsReadOnly() actually allocates and Copy the List) for internal usages and keeps the public Subviews property for api compatibility.