### PR TITLE
Add indent_size which is honored by VS2019 and behaves like tab_width

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*.cs]
 indent_style = tab
-tab_width = 8 
+indent_size = 8
+tab_width = 8
 csharp_new_line_before_open_brace = methods,local_functions
 csharp_new_line_before_else = false
 csharp_new_line_before_catch = false


### PR DESCRIPTION
`indent_size` came before `tab_width` and the latter is basically a fallback for the former, 
as far as I can understand https://github.com/microsoft/vscode-editorconfig/blob/master/src/editorConfigMain.ts#L248. 

However, VS behaves weirdly when one is defined and not the other. It gets the tabs 
completely wrong. If both have the same value, however, it works as expected. So make 
it easy for contributors on VS to contribute by adding this value. 

Hopefully, this will be a no-op on VSM.