### PR TITLE
[guit] Add NETStandard 2.0 support

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Terminal.Gui</RootNamespace>
     <AssemblyName>Terminal.Gui</AssemblyName>
     <DocumentationFile>bin\Release\Terminal.Gui.xml</DocumentationFile>


### PR DESCRIPTION
In order to allow libraries (i.e. control libraries) to target
NS2 and work simultaneously on .NET and .NETCore versions of
guit, we add it as a target framework too, which automatically
causes the package to include that when referenced from a NS2
package.

The upgrade to net472 makes gui.cs fully compatible with
netstandard2.0 without the need for any facade assemblies.
This simplifies and streamlines package installation and
reduces dependencies on other packages.