### PR TITLE
Fixed key events traversal for modal dialogs

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1812,25 +1812,25 @@ namespace Terminal.Gui {
 		{
 			var chain = toplevels.ToList();
 			foreach (var topLevel in chain) {
-				if (topLevel.Modal)
-					break;
 				if (topLevel.ProcessHotKey (ke))
 					return;
+				if (topLevel.Modal)
+					break;
 			}
 
 			foreach (var topLevel in chain) {
-				if (topLevel.Modal)
-					break;
 				if (topLevel.ProcessKey (ke))
 					return;
+				if (topLevel.Modal)
+					break;
 			}
 
 			foreach (var topLevel in chain) {
-				if (topLevel.Modal)
-					break;
 				// Process the key normally
 				if (topLevel.ProcessColdKey (ke))
 					return;
+				if (topLevel.Modal)
+					break;
 			}
 		}
 


### PR DESCRIPTION
The key must be propagated initially to the first chain element
before evaluating if we should stop because of the handled or
the Modal condition. Otherwise the modal dialog
won't get any process key notification.

This fixes https://github.com/migueldeicaza/gui.cs/commit/c072e29a684068af50e1b9e284213b3839dad804