### PR TITLE
Fixed and Enabled Library reinitialization

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -243,7 +243,7 @@ namespace Terminal.Gui {
 		/// Points to the current driver in use by the view, it is a convenience property
 		/// for simplifying the development of new views.
 		/// </summary>
-		public static ConsoleDriver Driver = Application.Driver;
+		public static ConsoleDriver Driver { get { return Application.Driver; } }
 
 		static IList<View> empty = new List<View> (0).AsReadOnly ();
 
@@ -1741,13 +1741,15 @@ namespace Terminal.Gui {
 		/// </summary>
 		public static void Init () => Init (() => Toplevel.Create ());
 
+		static bool _initialized = false;
+
 		/// <summary>
 		/// Initializes the Application
 		/// </summary>
 		static void Init (Func<Toplevel> topLevelFactory)
 		{
-			if (Top != null)
-				return;
+			if (_initialized) return;
+			_initialized = true;
 
 			var p = Environment.OSVersion.Platform;
 			Mono.Terminal.IMainLoopDriver mainLoopDriver;
@@ -1978,9 +1980,10 @@ namespace Terminal.Gui {
 			runState.Dispose ();
 		}
 
-		static void Shutdown ()
+		public static void Shutdown ()
 		{
 			Driver.End ();
+			_initialized = false;
 		}
 
 		static void Redraw (View view)

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -100,6 +100,11 @@ namespace Terminal.Gui {
 				var err = Marshal.GetLastWin32Error ();
 				Console.WriteLine ("Error: {0}", err);
 			}
+
+			if (ScreenBuffer != IntPtr.Zero)
+				CloseHandle(ScreenBuffer);
+
+			ScreenBuffer = IntPtr.Zero;
 		}
 
 		private bool ContinueListeningForConsoleEvents = true;
@@ -351,6 +356,9 @@ namespace Terminal.Gui {
 
 		[DllImport ("kernel32.dll", SetLastError = true)]
 		static extern IntPtr GetStdHandle (int nStdHandle);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		static extern bool CloseHandle(IntPtr handle);
 
 		[DllImport ("kernel32.dll", EntryPoint = "ReadConsoleInputW", CharSet = CharSet.Unicode)]
 		public static extern bool ReadConsoleInput (


### PR DESCRIPTION
_These changes allows the library to be shutdown, returning to the initial Console configuration, and then reinitialized again at any time. Changes are cross-platform and tested on Windows and Linux/OSX._

Changes:
- Replaced static driver initialization with property getter for reference passing in Core.cs::View class, this allows the library to be reinitialized at any time.
- Made the Shutdown method on Core.cs::Application class public, since there is no reason to keep it private. Applications can shutdown the library and revert the console to the initial stage by calling it on demand.
- Fixed a memory-leak on Drivers/WindowsDriver class by destroying the generated screen buffers at driver shutdown by calling CloseHandle.
- Minor change to Core.cs::Application.Init(Func<Toplevel>) for better initialization-status tracking, via backend property instead of relying on the Top field of the class.