### PR TITLE
demo bug #409 - Invoke does not cause Wakeup

### DIFF
--- a/UICatalog/Scenarios/Progress.cs
+++ b/UICatalog/Scenarios/Progress.cs
@@ -83,12 +83,10 @@ namespace UICatalog {
 			_activityProgressBar.Fraction = 0F;
 			_pulseProgressBar.Fraction = 0F;
 
-			_timer = new Timer ((o) => Application.MainLoop.Invoke (() => Pulse ()), null, 0, 250);
-
-			// BUGBUG: This timeout does nothing but return true, however it trigger the Application.MainLoop
-			// to run the Action. Without this timeout, the display updates are random, 
-			// or triggered by user interaction with the UI. See #155
-			//_timeoutToken = Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (10), loop => true);
+			_timer = new Timer ((o) => {
+				// BUGBUG: #409 - Invoke does not cause Wakeup as it should
+				Application.MainLoop.Invoke (() => Pulse ());
+			}, null, 0, 250);
 		}
 
 		private void Stop ()


### PR DESCRIPTION
I've tried to make this as clear as I can, because I'm obviously not getting my point across. The GIF below shows Windows (in cmd.exe) on top and Linux (in Windows Terminal) on bottom.

![](https://i.imgur.com/ForsPts.gif)

Both clearly show that I have to move the mouse or press the keyboard to cause the ProgressBar to move. This is incorrect behavior (assuming I am not doing something stupid) based on this code:

```csharp
			_timer = new Timer ((o) => {
				// BUGBUG: #409 - Invoke does not cause Wakeup as it should
				Application.MainLoop.Invoke (() => Pulse ());
			}, null, 0, 250);
```

The call above to `Application.MakinLoop.Invoke` should cause `Mainloop` to wakeup. As can be clearly seen from the GIF, this is not happening on either Windows or Linux.