### PR TITLE
Updated and fixed all XML documentation

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -27,13 +27,13 @@ namespace Terminal.Gui {
 	/// </summary>
 	public class Responder {
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.Responder"/> can focus.
+		/// Gets or sets a value indicating whether this <see cref="Responder"/> can focus.
 		/// </summary>
 		/// <value><c>true</c> if can focus; otherwise, <c>false</c>.</value>
 		public virtual bool CanFocus { get; set; }
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.Responder"/> has focus.
+		/// Gets or sets a value indicating whether this <see cref="Responder"/> has focus.
 		/// </summary>
 		/// <value><c>true</c> if has focus; otherwise, <c>false</c>.</value>
 		public virtual bool HasFocus { get; internal set; }
@@ -226,10 +226,10 @@ namespace Terminal.Gui {
 	/// <para>
 	///    When you do not specify a Rect frame you can use the more flexible
 	///    Dim and Pos objects that can dynamically update the position of a view.
-	///    The X and Y properties are of type <see cref="T:Terminal.Gui.Pos"/>
+	///    The X and Y properties are of type <see cref="Pos"/>
 	///    and you can use either absolute positions, percentages or anchor
 	///    points.   The Width and Height properties are of type
-	///    <see cref="T:Terminal.Gui.Dim"/> and can use absolute position,
+	///    <see cref="Dim"/> and can use absolute position,
 	///    percentages and anchors.  These are useful as they will take
 	///    care of repositioning your views if your view's frames are resized
 	///    or if the terminal size changes.
@@ -351,13 +351,13 @@ namespace Terminal.Gui {
 		public ustring Id { get; set; } = "";
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.View"/> want mouse position reports.
+		/// Gets or sets a value indicating whether this <see cref="View"/> want mouse position reports.
 		/// </summary>
 		/// <value><c>true</c> if want mouse position reports; otherwise, <c>false</c>.</value>
 		public virtual bool WantMousePositionReports { get; set; } = false;
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.View"/> want continuous button pressed event.
+		/// Gets or sets a value indicating whether this <see cref="View"/> want continuous button pressed event.
 		/// </summary>
 		public virtual bool WantContinuousButtonPressed { get; set; } = false;
 		/// <summary>
@@ -481,7 +481,7 @@ namespace Terminal.Gui {
 		public View SuperView => container;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.View"/> class with the absolute
+		/// Initializes a new instance of the <see cref="View"/> class with the absolute
 		/// dimensions specified in the frame.   If you want to have Views that can be positioned with
 		/// Pos and Dim properties on X, Y, Width and Height, use the empty constructor.
 		/// </summary>
@@ -494,7 +494,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.View"/> class and sets the
+		/// Initializes a new instance of the <see cref="View"/> class and sets the
 		/// view up for Computed layout, which will use the values in X, Y, Width and Height to
 		/// compute the View's Frame.
 		/// </summary>
@@ -1484,20 +1484,20 @@ namespace Terminal.Gui {
 	/// </remarks>
 	public class Toplevel : View {
 		/// <summary>
-		/// Gets or sets whether the <see cref="T:Terminal.Gui.MainLoop"/> for this <see cref="T:Terminal.Gui.Toplevel"/> is running or not. Setting
+		/// Gets or sets whether the Mainloop for this <see cref="Toplevel"/> is running or not. Setting
 		/// this property to false will cause the MainLoop to exit. 
 		/// </summary>
 		public bool Running { get; set; }
 
 		/// <summary>
-		/// Fired once the Toplevel's <see cref="T:Terminal.Gui.MainLoop"/> has started it's first iteration. 
-		/// Subscribe to this event to perform tasks when the <see cref="T:Terminal.Gui.Toplevel"/> has been laid out and focus has been set.
-		/// changes. A Ready event handler is a good place to finalize initialization after calling `<see cref="T:Terminal.Gui.Application.Run"/>(topLevel)`. 
+		/// Fired once the Toplevel's MainLoop has started it's first iteration. 
+		/// Subscribe to this event to perform tasks when the <see cref="Toplevel"/> has been laid out and focus has been set.
+		/// changes. A Ready event handler is a good place to finalize initialization after calling `<see cref="Application.Run()"/>(topLevel)`. 
 		/// </summary>
 		public event EventHandler Ready;
 
 		/// <summary>
-		/// Called from Application.RunLoop after the <see cref="T:Terminal.Gui.Toplevel"/> has entered it's first iteration of the loop. 
+		/// Called from Application.RunLoop after the <see cref="Toplevel"/> has entered it's first iteration of the loop. 
 		/// </summary>
 		internal virtual void OnReady ()
 		{
@@ -1505,7 +1505,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Toplevel"/> class with the specified absolute layout.
+		/// Initializes a new instance of the <see cref="Toplevel"/> class with the specified absolute layout.
 		/// </summary>
 		/// <param name="frame">Frame.</param>
 		public Toplevel (Rect frame) : base (frame)
@@ -1514,7 +1514,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Toplevel"/> class with Computed layout, defaulting to <see langword="async"/> full screen.
+		/// Initializes a new instance of the <see cref="Toplevel"/> class with Computed layout, defaulting to <see langword="async"/> full screen.
 		/// </summary>
 		public Toplevel () : base ()
 		{
@@ -1538,7 +1538,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.Toplevel"/> can focus.
+		/// Gets or sets a value indicating whether this <see cref="Toplevel"/> can focus.
 		/// </summary>
 		/// <value><c>true</c> if can focus; otherwise, <c>false</c>.</value>
 		public override bool CanFocus {
@@ -1734,7 +1734,7 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// A toplevel view that draws a frame around its region and has a "ContentView" subview where the contents are added.
+	/// A <see cref="Toplevel"/> <see cref="View"/> that draws a frame around its region and has a "ContentView" subview where the contents are added.
 	/// </summary>
 	public class Window : Toplevel, IEnumerable {
 		View contentView;
@@ -1772,7 +1772,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Gui.Window"/> class with an optional title and a set frame.
+		/// Initializes a new instance of the <see cref="Gui.Window"/> class with an optional title and a set frame.
 		/// </summary>
 		/// <param name="frame">Frame.</param>
 		/// <param name="title">Title.</param>
@@ -1781,7 +1781,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Window"/> class with an optional title.
+		/// Initializes a new instance of the <see cref="Window"/> class with an optional title.
 		/// </summary>
 		/// <param name="title">Title.</param>
 		public Window (ustring title = null) : this (title, padding: 0)
@@ -1790,7 +1790,7 @@ namespace Terminal.Gui {
 
 		int padding;
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Window"/> with
+		/// Initializes a new instance of the <see cref="Window"/> with
 		/// the specified frame for its location, with the specified border
 		/// an optional title.
 		/// </summary>
@@ -1808,7 +1808,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Window"/> with
+		/// Initializes a new instance of the <see cref="Window"/> with
 		/// the specified frame for its location, with the specified border
 		/// an optional title.
 		/// </summary>
@@ -1829,7 +1829,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Enumerates the various views in the ContentView.
+		/// Enumerates the various <see cref="View"/>s in the embedded <see cref="ContentView"/>.
 		/// </summary>
 		/// <returns>The enumerator.</returns>
 		public new IEnumerator GetEnumerator ()
@@ -1843,7 +1843,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Add the specified view to the ContentView.
+		/// Add the specified view to the <see cref="ContentView"/>.
 		/// </summary>
 		/// <param name="view">View to add to the window.</param>
 		public override void Add (View view)
@@ -1976,7 +1976,7 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// The application driver for gui.cs
+	/// The application driver for Terminal.Gui.
 	/// </summary>
 	/// <remarks>
 	///   <para>
@@ -1994,30 +1994,30 @@ namespace Terminal.Gui {
 	/// </remarks>
 	public static class Application {
 		/// <summary>
-		/// The current Console Driver in use.
+		/// The current <see cref="ConsoleDriver"/> in use.
 		/// </summary>
 		public static ConsoleDriver Driver;
 
 		/// <summary>
-		/// The Toplevel object used for the application on startup.
+		/// The <see cref="Toplevel"/> object used for the application on startup (<seealso cref="Application.Top"/>)
 		/// </summary>
 		/// <value>The top.</value>
 		public static Toplevel Top { get; private set; }
 
 		/// <summary>
-		/// The current toplevel object. This is updated when Application.Run enters and leaves and points to the current toplevel.
+		/// The current <see cref="Toplevel"/> object. This is updated when <see cref="Application.Run()"/> enters and leaves to point to the current <see cref="Toplevel"/> .
 		/// </summary>
 		/// <value>The current.</value>
 		public static Toplevel Current { get; private set; }
 
 		/// <summary>
-		/// TThe current view object being redrawn.
+		/// TThe current <see cref="View"/> object being redrawn.
 		/// </summary>
 		/// /// <value>The current.</value>
 		public static View CurrentView { get; set; }
 
 		/// <summary>
-		/// The mainloop driver for the applicaiton
+		/// The <see cref="MainLoop"/>  driver for the applicaiton
 		/// </summary>
 		/// <value>The main loop.</value>
 		public static Mono.Terminal.MainLoop MainLoop { get; private set; }
@@ -2025,8 +2025,7 @@ namespace Terminal.Gui {
 		static Stack<Toplevel> toplevels = new Stack<Toplevel> ();
 
 		/// <summary>
-		///   This event is raised on each iteration of the
-		///   main loop.
+		///   This event is raised on each iteration of the <see cref="MainLoop"/> 
 		/// </summary>
 		/// <remarks>
 		///   See also <see cref="Timeout"/>
@@ -2044,7 +2043,7 @@ namespace Terminal.Gui {
 		}
 
 		//
-		// provides the sync context set while executing code in gui.cs, to let
+		// provides the sync context set while executing code in Terminal.Gui, to let
 		// users use async/await on their code
 		//
 		class MainLoopSyncContext : SynchronizationContext {
@@ -2083,14 +2082,25 @@ namespace Terminal.Gui {
 		public static bool UseSystemConsole;
 
 		/// <summary>
-		/// Initializes the Application
+		/// Initializes a new instance of <see cref="Terminal.Gui"/> Application. 
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Call this method once per instance (or after <see cref="Shutdown"/> has been called).
+		/// </para>
+		/// <para>
+		/// Loads the right <see cref="ConsoleDriver"/> for the platform.
+		/// </para>
+		/// <para>
+		/// Creates a <see cref="Toplevel"/> and assigns it to <see cref="Top"/> and <see cref="CurrentView"/>
+		/// </para>
+		/// </remarks>
 		public static void Init () => Init (() => Toplevel.Create ());
 
 		internal static bool _initialized = false;
 
 		/// <summary>
-		/// Initializes the Application
+		/// Initializes the Terminal.Gui application
 		/// </summary>
 		static void Init (Func<Toplevel> topLevelFactory)
 		{
@@ -2120,7 +2130,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Captures the execution state for the provided TopLevel view.
+		/// Captures the execution state for the provided <see cref="Toplevel"/>  view.
 		/// </summary>
 		public class RunState : IDisposable {
 			internal RunState (Toplevel view)
@@ -2130,13 +2140,13 @@ namespace Terminal.Gui {
 			internal Toplevel Toplevel;
 
 			/// <summary>
-			/// Releases alTop = l resource used by the <see cref="T:Terminal.Gui.Application.RunState"/> object.
+			/// Releases alTop = l resource used by the <see cref="Application.RunState"/> object.
 			/// </summary>
-			/// <remarks>Call <see cref="Dispose()"/> when you are finished using the <see cref="T:Terminal.Gui.Application.RunState"/>. The
-			/// <see cref="Dispose()"/> method leaves the <see cref="T:Terminal.Gui.Application.RunState"/> in an unusable state. After
+			/// <remarks>Call <see cref="Dispose()"/> when you are finished using the <see cref="Application.RunState"/>. The
+			/// <see cref="Dispose()"/> method leaves the <see cref="Application.RunState"/> in an unusable state. After
 			/// calling <see cref="Dispose()"/>, you must release all references to the
-			/// <see cref="T:Terminal.Gui.Application.RunState"/> so the garbage collector can reclaim the memory that the
-			/// <see cref="T:Terminal.Gui.Application.RunState"/> was occupying.</remarks>
+			/// <see cref="Application.RunState"/> so the garbage collector can reclaim the memory that the
+			/// <see cref="Application.RunState"/> was occupying.</remarks>
 			public void Dispose ()
 			{
 				Dispose (true);
@@ -2342,15 +2352,15 @@ namespace Terminal.Gui {
 		public static event EventHandler<ResizedEventArgs> Loaded;
 
 		/// <summary>
-		/// Building block API: Prepares the provided toplevel for execution.
+		/// Building block API: Prepares the provided <see cref="Toplevel"/>  for execution.
 		/// </summary>
-		/// <returns>The runstate handle that needs to be passed to the End() method upon completion.</returns>
+		/// <returns>The runstate handle that needs to be passed to the <see cref="End(RunState)"/> method upon completion.</returns>
 		/// <param name="toplevel">Toplevel to prepare execution for.</param>
 		/// <remarks>
 		///  This method prepares the provided toplevel for running with the focus,
 		///  it adds this to the list of toplevels, sets up the mainloop to process the
 		///  event, lays out the subviews, focuses the first element, and draws the
-		///  toplevel in the screen.   This is usually followed by executing
+		///  toplevel in the screen. This is usually followed by executing
 		///  the <see cref="RunLoop"/> method, and then the <see cref="End(RunState)"/> method upon termination which will
 		///   undo these changes.
 		/// </remarks>
@@ -2385,7 +2395,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Building block API: completes the execution of a Toplevel that was started with Begin.
+		/// Building block API: completes the execution of a <see cref="Toplevel"/>  that was started with <see cref="Begin(Toplevel)"/> .
 		/// </summary>
 		/// <param name="runState">The runstate returned by the <see cref="Begin(Toplevel)"/> method.</param>
 		public static void End (RunState runState)
@@ -2397,7 +2407,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Finalize the driver.
+		/// Shutdown an application initalized with <see cref="Init()"/>
 		/// </summary>
 		public static void Shutdown ()
 		{
@@ -2500,7 +2510,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Runs the application with the built-in toplevel view
+		/// Runs the application by calling <see cref="Run(Toplevel)"/> with the value of <see cref="Top"/>
 		/// </summary>
 		public static void Run ()
 		{
@@ -2508,7 +2518,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Runs the application with a new instance of the specified toplevel view
+		/// Runs the application by calling <see cref="Run(Toplevel)"/> with a new instance of the specified <see cref="Toplevel"/>-derived class
 		/// </summary>
 		public static void Run<T> () where T : Toplevel, new()
 		{
@@ -2517,27 +2527,26 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Runs the main loop on the given container.
+		///   Runs the main loop on the given <see cref="Toplevel"/> container.
 		/// </summary>
 		/// <remarks>
 		///   <para>
 		///     This method is used to start processing events
 		///     for the main application, but it is also used to
-		///     run modal dialog boxes.
+		///     run other modal <see cref="View"/>s such as <see cref="Dialog"/> boxes.
 		///   </para>
 		///   <para>
-		///     To make a toplevel stop execution, set the "Running"
-		///     property to false.
+		///     To make a <see cref="Run(Toplevel)"/> stop execution, call <see cref="Application.RequestStop"/>.
 		///   </para>
 		///   <para>
-		///     This is equivalent to calling Begin on the toplevel view, followed by RunLoop with the
-		///     returned value, and then calling end on the return value.
+		///     Calling <see cref="Run(Toplevel)"/> is equivalent to calling <see cref="Begin(Toplevel)"/>, followed by <see cref="RunLoop(RunState, bool)"/>,
+		///     and then calling <see cref="End(RunState)"/>.
 		///   </para>
 		///   <para>
-		///     Alternatively, if your program needs to control the main loop and needs to
-		///     process events manually, you can invoke Begin to set things up manually and then
-		///     repeatedly call RunLoop with the wait parameter set to false.   By doing this
-		///     the RunLoop method will only process any pending events, timers, idle handlers and
+		///     Alternatively, to have a program control the main loop and 
+		///     process events manually, call <see cref="Begin(Toplevel)"/> to set things up manually and then
+		///     repeatedly call <see cref="RunLoop(RunState, bool)"/> with the wait parameter set to false.   By doing this
+		///     the <see cref="RunLoop(RunState, bool)"/> method will only process any pending events, timers, idle handlers and
 		///     then return control immediately.
 		///   </para>
 		/// </remarks>
@@ -2549,15 +2558,23 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Stops running the most recent toplevel
+		/// Stops running the most recent <see cref="Toplevel"/>. 
 		/// </summary>
+		/// <remarks>
+		///   <para>
+		///   This will cause <see cref="Application.Run()"/> to return.
+		///   </para>
+		///   <para>
+		///     Calling <see cref="Application.RequestStop"/> is equivalent to setting the <see cref="Toplevel.Running"/> property on the curently running <see cref="Toplevel"/> to false.
+		///   </para>
+		/// </remarks>
 		public static void RequestStop ()
 		{
 			Current.Running = false;
 		}
 
 		/// <summary>
-		/// Event arguments for the <see cref="T:Terminal.Gui.Application.Resized"/> event.
+		/// Event arguments for the <see cref="Application.Resized"/> event.
 		/// </summary>
 		public class ResizedEventArgs : EventArgs {
 			/// <summary>

--- a/Terminal.Gui/Dialogs/Dialog.cs
+++ b/Terminal.Gui/Dialogs/Dialog.cs
@@ -11,21 +11,20 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// The dialog box is a window that by default is centered and contains one 
-	/// or more buttons.  It defaults to the Colors.Dialog color scheme and has a
-	///  1 cell padding around the edges.
+	/// The <see cref="Dialog"/> <see cref="View"/> is a <see cref="Window"/> that by default is centered and contains one 
+	/// or more <see cref="Button"/>. It defaults to the <see cref="Colors.Dialog"/> color scheme and has a 1 cell padding around the edges.
 	/// </summary>
 	/// <remarks>
-	///  To run the dialog modally, create the Dialog, and pass this to Application.Run which
-	/// will execute the dialog until it terminates via the [ESC] key, or when one of the views
-	/// or buttons added to the dialog set the Running property on the Dialog to false.
+	///  To run the <see cref="Dialog"/> modally, create the <see cref="Dialog"/>, and pass it to <see cref="Application.Run()"/>. 
+	///  This will execute the dialog until it terminates via the [ESC] or [CTRL-Q] key, or when one of the views
+	///  or buttons added to the dialog calls <see cref="Application.RequestStop"/>.
 	/// </remarks>
 	public class Dialog : Window {
 		List<Button> buttons = new List<Button> ();
 		const int padding = 1;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Dialog"/> class with an optional set of buttons to display
+		/// Initializes a new instance of the <see cref="Dialog"/> class with an optional set of <see cref="Button"/>s to display
 		/// </summary>
 		/// <param name="title">Title for the dialog.</param>
 		/// <param name="width">Width for the dialog.</param>
@@ -49,7 +48,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Adds a button to the dialog, its layout will be controled by the dialog
+		/// Adds a <see cref="Button"/> to the <see cref="Dialog"/>, its layout will be controled by the <see cref="Dialog"/>
 		/// </summary>
 		/// <param name="button">Button to add.</param>
 		public void AddButton (Button button)
@@ -61,9 +60,7 @@ namespace Terminal.Gui {
 			Add (button);
 		}
 
-		/// <summary>
-		/// Lays out the subviews for the Dialog. 
-		/// </summary>
+		///<inheritdoc cref="LayoutSubviews"/>
 		public override void LayoutSubviews ()
 		{
 			base.LayoutSubviews ();

--- a/Terminal.Gui/Dialogs/FileDialog.cs
+++ b/Terminal.Gui/Dialogs/FileDialog.cs
@@ -417,7 +417,7 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// Base class for the OpenDialog and the SaveDialog
+	/// Base class for the <see cref="OpenDialog"/> and the <see cref="SaveDialog"/>
 	/// </summary>
 	public class FileDialog : Dialog {
 		Button prompt, cancel;
@@ -426,7 +426,7 @@ namespace Terminal.Gui {
 		internal DirListView dirListView;
 
 		/// <summary>
-		/// Constructor for the OpenDialog and the SaveDialog.
+		/// Initializes a new instance of <see cref="FileDialog"/>
 		/// </summary>
 		/// <param name="title">The title.</param>
 		/// <param name="prompt">The prompt.</param>
@@ -502,7 +502,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets the prompt label for the button displayed to the user
+		/// Gets or sets the prompt label for the <see cref="Button"/> displayed to the user
 		/// </summary>
 		/// <value>The prompt.</value>
 		public ustring Prompt {
@@ -535,13 +535,13 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.FileDialog"/> can create directories.
+		/// Gets or sets a value indicating whether this <see cref="FileDialog"/> can create directories.
 		/// </summary>
 		/// <value><c>true</c> if can create directories; otherwise, <c>false</c>.</value>
 		public bool CanCreateDirectories { get; set; }
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.FileDialog"/> is extension hidden.
+		/// Gets or sets a value indicating whether this <see cref="FileDialog"/> is extension hidden.
 		/// </summary>
 		/// <value><c>true</c> if is extension hidden; otherwise, <c>false</c>.</value>
 		public bool IsExtensionHidden { get; set; }
@@ -569,7 +569,7 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.FileDialog"/> allows the file to be saved with a different extension
+		/// Gets or sets a value indicating whether this <see cref="FileDialog"/> allows the file to be saved with a different extension
 		/// </summary>
 		/// <value><c>true</c> if allows other file types; otherwise, <c>false</c>.</value>
 		public bool AllowsOtherFileTypes { get; set; }
@@ -592,20 +592,20 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	///  The save dialog provides an interactive dialog box for users to pick a file to 
+	///  The <see cref="SaveDialog"/> provides an interactive dialog box for users to pick a file to 
 	///  save.
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	///   To use it, create an instance of the SaveDialog, and then
-	///   call Application.Run on the resulting instance.   This will run the dialog modally,
-	///   and when this returns, the FileName property will contain the selected value or 
+	///   To use, create an instance of <see cref="SaveDialog"/>, and pass it to
+	///   <see cref="Application.Run()"/>. This will run the dialog modally,
+	///   and when this returns, the <see cref="FileName"/>property will contain the selected file name or 
 	///   null if the user canceled. 
 	/// </para>
 	/// </remarks>
 	public class SaveDialog : FileDialog {
 		/// <summary>
-		/// Constructor of the save dialog.
+		/// Initializes a new <see cref="SaveDialog"/>
 		/// </summary>
 		/// <param name="title">The title.</param>
 		/// <param name="message">The message.</param>
@@ -615,7 +615,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Gets the name of the file the user selected for saving, or null
-		/// if the user canceled the dialog box.
+		/// if the user canceled the <see cref="SaveDialog"/>.
 		/// </summary>
 		/// <value>The name of the file.</value>
 		public ustring FileName {
@@ -628,7 +628,7 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// The Open Dialog provides an interactive dialog box for users to select files or directories.
+	/// The <see cref="OpenDialog"/>provides an interactive dialog box for users to select files or directories.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -637,9 +637,9 @@ namespace Terminal.Gui {
 	///   you can control whether this should allow files or directories to be selected.
 	/// </para>
 	/// <para>
-	///   To use it, create an instance of the OpenDialog, configure its properties, and then
-	///   call Application.Run on the resulting instance.   This will run the dialog modally,
-	///   and when this returns, the list of filds will be available on the FilePaths property.
+	///   To use, create an instance of <see cref="OpenDialog"/>, and pass it to
+	///   <see cref="Application.Run()"/>. This will run the dialog modally,
+	///   and when this returns, the list of filds will be available on the <see cref="FilePaths"/> property.
 	/// </para>
 	/// <para>
 	/// To select more than one file, users can use the spacebar, or control-t.
@@ -647,7 +647,7 @@ namespace Terminal.Gui {
 	/// </remarks>
 	public class OpenDialog : FileDialog {
 		/// <summary>
-		/// Constructor of the Open Dialog.
+		/// Initializes a new <see cref="OpenDialog"/>
 		/// </summary>
 		/// <param name="title"></param>
 		/// <param name="message"></param>
@@ -656,7 +656,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.OpenDialog"/> can choose files.
+		/// Gets or sets a value indicating whether this <see cref="Terminal.Gui.OpenDialog"/> can choose files.
 		/// </summary>
 		/// <value><c>true</c> if can choose files; otherwise, <c>false</c>.  Defaults to <c>true</c></value>
 		public bool CanChooseFiles {
@@ -668,7 +668,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.OpenDialog"/> can choose directories.
+		/// Gets or sets a value indicating whether this <see cref="OpenDialog"/> can choose directories.
 		/// </summary>
 		/// <value><c>true</c> if can choose directories; otherwise, <c>false</c> defaults to <c>false</c>.</value>
 		public bool CanChooseDirectories {
@@ -680,7 +680,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.OpenDialog"/> allows multiple selection.
+		/// Gets or sets a value indicating whether this <see cref="OpenDialog"/> allows multiple selection.
 		/// </summary>
 		/// <value><c>true</c> if allows multiple selection; otherwise, <c>false</c>, defaults to false.</value>
 		public bool AllowsMultipleSelection {

--- a/Terminal.Gui/Dialogs/MessageBox.cs
+++ b/Terminal.Gui/Dialogs/MessageBox.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 namespace Terminal.Gui {
-
 	/// <summary>
-	/// Message box displays a modal message to the user, with a title, a message and a series of options that the user can choose from.
+	/// MessageBox displays a modal message to the user, with a title, a message and a series of options that the user can choose from.
 	/// </summary>
 	/// <para>
-	///   The difference between the Query and ErrorQuery method is the default set of colors used for the message box.
+	///   The difference between the <see cref="Query"/> and <see cref="ErrorQuery"/> method is the default set of colors used for the message box.
 	/// </para>
 	/// <para>
-	/// The following example pops up a Message Box with 50 columns, and 7 lines, with the specified title and text, plus two buttons.
-	/// The value -1 is returned when the user cancels the dialog by pressing the ESC key.
+	/// The following example pops up a <see cref="MessageBox"/> with 50 columns, and 7 lines, with the specified title and text, plus two <see cref="Button"/>s.
+	/// The value -1 is returned when the user cancels the <see cref="MessageBox"/> by pressing the ESC key.
 	/// </para>
 	/// <example>
 	/// <code lang="c#">
@@ -18,12 +17,11 @@ namespace Terminal.Gui {
 	///    quit = true;
 	/// else
 	///    quit = false;
-	/// 
 	/// </code>
 	/// </example>
 	public static class MessageBox {
 		/// <summary>
-		/// Presents a message with the specified title and message and a list of buttons to show to the user.
+		/// Presents a normal <see cref="MessageBox"/> with the specified title and message and a list of buttons to show to the user.
 		/// </summary>
 		/// <returns>The index of the selected button, or -1 if the user pressed ESC to close the dialog.</returns>
 		/// <param name="width">Width for the window.</param>
@@ -37,7 +35,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Presents an error message box with the specified title and message and a list of buttons to show to the user.
+		/// Presents an error <see cref="MessageBox"/> with the specified title and message and a list of buttons to show to the user.
 		/// </summary>
 		/// <returns>The index of the selected button, or -1 if the user pressed ESC to close the dialog.</returns>
 		/// <param name="width">Width for the window.</param>

--- a/Terminal.Gui/Drivers/ConsoleDriver.cs
+++ b/Terminal.Gui/Drivers/ConsoleDriver.cs
@@ -98,7 +98,7 @@ namespace Terminal.Gui {
 		internal Color background;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Attribute"/> struct.
+		/// Initializes a new instance of the <see cref="Attribute"/> struct.
 		/// </summary>
 		/// <param name="value">Value.</param>
 		/// <param name="foreground">Foreground</param>
@@ -111,7 +111,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Attribute"/> struct.
+		/// Initializes a new instance of the <see cref="Attribute"/> struct.
 		/// </summary>
 		/// <param name="foreground">Foreground</param>
 		/// <param name="background">Background</param>

--- a/Terminal.Gui/Event.cs
+++ b/Terminal.Gui/Event.cs
@@ -9,7 +9,7 @@ using System;
 namespace Terminal.Gui {
 
 	/// <summary>
-	/// The Key enumeration contains special encoding for some keys, but can also
+	/// The <see cref="Key"/> enumeration contains special encoding for some keys, but can also
 	/// encode all the unicode values that can be passed.   
 	/// </summary>
 	/// <remarks>
@@ -320,18 +320,23 @@ namespace Terminal.Gui {
 		//public bool IsCtrl => ((uint)Key >= 1) && ((uint)Key <= 26);
 		public bool IsCtrl => (Key & Key.CtrlMask) != 0;
 
+		/// <summary>
+		/// Constructs a new <see cref="KeyEvent"/>
+		/// </summary>
 		public KeyEvent ()
 		{
 			Key = Key.Unknown;
 		}
+
 		/// <summary>
-		///   Constructs a new KeyEvent from the provided Key value - can be a rune cast into a Key value
+		///   Constructs a new <see cref="KeyEvent"/> from the provided Key value - can be a rune cast into a Key value
 		/// </summary>
 		public KeyEvent (Key k)
 		{
 			Key = k;
 		}
 
+		///<inheritdoc cref="ToString"/>
 		public override string ToString ()
 		{
 			string msg = "";
@@ -508,9 +513,9 @@ namespace Terminal.Gui {
 		public View View;
 
 		/// <summary>
-		/// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:Terminal.Gui.MouseEvent"/>.
+		/// Returns a <see cref="T:System.String"/> that represents the current <see cref="MouseEvent"/>.
 		/// </summary>
-		/// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:Terminal.Gui.MouseEvent"/>.</returns>
+		/// <returns>A <see cref="T:System.String"/> that represents the current <see cref="MouseEvent"/>.</returns>
 		public override string ToString ()
 		{
 			return $"({X},{Y}:{Flags}";

--- a/Terminal.Gui/Types/PosDim.cs
+++ b/Terminal.Gui/Types/PosDim.cs
@@ -8,25 +8,25 @@
 using System;
 namespace Terminal.Gui {
 	/// <summary>
-	/// Describes a position which can be an absolute value, a percentage, centered, or 
-	/// relative to the ending dimension.   Integer values are implicitly convertible to
-	/// an absolute Pos.    These objects are created using the static methods Percent,
-	/// AnchorEnd and Center.   The Pos objects can be combined with the addition and 
+	/// Describes the position of a <see cref="View"/> which can be an absolute value, a percentage, centered, or 
+	/// relative to the ending dimension. Integer values are implicitly convertible to
+	/// an absolute <see cref="Pos"/>. These objects are created using the static methods Percent,
+	/// AnchorEnd, and Center. The <see cref="Pos"/> objects can be combined with the addition and 
 	/// subtraction operators.
 	/// </summary>
 	/// <remarks>
 	///   <para>
-	///     Use the Pos objects on the X or Y properties of a view to control the position.
+	///     Use the <see cref="Pos"/> objects on the X or Y properties of a view to control the position.
 	///   </para>
 	///   <para>
 	///     These can be used to set the absolute position, when merely assigning an
-	///     integer value (via the implicit integer to Pos conversion), and they can be combined
+	///     integer value (via the implicit integer to <see cref="Pos"/> conversion), and they can be combined
 	///     to produce more useful layouts, like: Pos.Center - 3, which would shift the postion
-	///     of the view 3 characters to the left after centering for example.
+	///     of the <see cref="View"/> 3 characters to the left after centering for example.
 	///   </para>
 	///   <para>
 	///     It is possible to reference coordinates of another view by using the methods
-	///     Left(View), Right(View), Bottom(View), Top(View).   The X(View) and Y(View) are
+	///     Left(View), Right(View), Bottom(View), Top(View). The X(View) and Y(View) are
 	///     aliases to Left(View) and Top(View) respectively.
 	///   </para>
 	/// </remarks>
@@ -56,10 +56,22 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Creates a percentage Pos object
+		/// Creates a percentage <see cref="Pos"/> object
 		/// </summary>
-		/// <returns>The percent Pos object.</returns>
+		/// <returns>The percent <see cref="Pos"/> object.</returns>
 		/// <param name="n">A value between 0 and 100 representing the percentage.</param>
+		/// <example>
+		/// This creates a <see cref="TextField"/>that is centered horizontally, is 50% of the way down, 
+		/// is 30% the height, and is 80% the width of the <see cref="View"/> it added to.
+		/// <code>
+		/// var textView = new TextView () {
+		///	X = Pos.Center (),
+		///	Y = Pos.Percent (50),
+		///	Width = Dim.Percent (80),
+		/// 	Height = Dim.Percent (30),
+		/// };
+		/// </code>
+		/// </example>
 		public static Pos Percent (float n)
 		{
 			if (n < 0 || n > 100)
@@ -90,11 +102,18 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Creates a Pos object that is anchored to the end of the dimension, useful to flush 
-		/// the layout from the end.
+		/// Creates a <see cref="Pos"/> object that is anchored to the end (right side or bottom) of the dimension, 
+		/// useful to flush the layout from the right or bottom.
 		/// </summary>
-		/// <returns>The Pos object anchored to the end (the bottom or the right side).</returns>
-		/// <param name="margin">Optional margin to set aside.</param>
+		/// <returns>The <see cref="Pos"/> object anchored to the end (the bottom or the right side).</returns>
+		/// <param name="margin">Optional margin to place to the right or below.</param>
+		/// <example>
+		/// This sample shows how align a <see cref="Button"/> to the bottom-right of a <see cref="View"/>.
+		/// <code>
+		/// anchorButton.X = Pos.AnchorEnd () - (Pos.Right (anchorButton) - Pos.Left (anchorButton));
+		/// anchorButton.Y = Pos.AnchorEnd () - 1;
+		/// </code>
+		/// </example>
 		public static Pos AnchorEnd (int margin = 0)
 		{
 			if (margin < 0)
@@ -123,9 +142,21 @@ namespace Terminal.Gui {
 		static PosCenter pCenter;
 
 		/// <summary>
-		/// Returns a Pos object that can be used to center the views.
+		/// Returns a <see cref="Pos"/> object that can be used to center the <see cref="View"/>
 		/// </summary>
 		/// <returns>The center Pos.</returns>
+		/// <example>
+		/// This creates a <see cref="TextField"/>that is centered horizontally, is 50% of the way down, 
+		/// is 30% the height, and is 80% the width of the <see cref="View"/> it added to.
+		/// <code>
+		/// var textView = new TextView () {
+		///	X = Pos.Center (),
+		///	Y = Pos.Percent (50),
+		///	Width = Dim.Percent (80),
+		/// 	Height = Dim.Percent (30),
+		/// };
+		/// </code>
+		/// </example>
 		public static Pos Center ()
 		{
 			if (pCenter == null)
@@ -149,20 +180,20 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Creates an Absolute Pos from the specified integer value.
+		/// Creates an Absolute <see cref="Pos"/> from the specified integer value.
 		/// </summary>
-		/// <returns>The Absolute Pos.</returns>
-		/// <param name="n">The value to convert to the pos.</param>
+		/// <returns>The Absolute <see cref="Pos"/>.</returns>
+		/// <param name="n">The value to convert to the <see cref="Pos"/> .</param>
 		public static implicit operator Pos (int n)
 		{
 			return new PosAbsolute (n);
 		}
 
 		/// <summary>
-		/// Creates an Absolute Pos from the specified integer value.
+		/// Creates an Absolute <see cref="Pos"/> from the specified integer value.
 		/// </summary>
-		/// <returns>The Absolute Pos.</returns>
-		/// <param name="n">The value to convert to the pos.</param>
+		/// <returns>The Absolute <see cref="Pos"/>.</returns>
+		/// <param name="n">The value to convert to the <see cref="Pos"/>.</param>
 		public static Pos At (int n)
 		{
 			return new PosAbsolute (n);
@@ -190,7 +221,7 @@ namespace Terminal.Gui {
 
 			public override string ToString ()
 			{
-				return $"Pos.Combine ({left.ToString ()}{(add?'+':'-')}{right.ToString ()})";
+				return $"Pos.Combine ({left.ToString ()}{(add ? '+' : '-')}{right.ToString ()})";
 			}
 
 		}
@@ -262,65 +293,65 @@ namespace Terminal.Gui {
 				case 3: tside = "bottom"; break;
 				default: tside = "unknown"; break;
 				}
-				return $"Pos.View(side={tside}, target={Target.ToString()}";
+				return $"Pos.View(side={tside}, target={Target.ToString ()}";
 			}
 		}
 
 		/// <summary>
-		/// Returns a Pos object tracks the Left (X) position of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Left (X) position of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos Left (View view) => new PosView (view, 0);
 
 		/// <summary>
-		/// Returns a Pos object tracks the Left (X) position of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Left (X) position of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos X (View view) => new PosView (view, 0);
 
 		/// <summary>
-		/// Returns a Pos object tracks the Top (Y) position of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Top (Y) position of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos Top (View view) => new PosView (view, 1);
 
 		/// <summary>
-		/// Returns a Pos object tracks the Top (Y) position of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Top (Y) position of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos Y (View view) => new PosView (view, 1);
 
 		/// <summary>
-		/// Returns a Pos object tracks the Right (X+Width) coordinate of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Right (X+Width) coordinate of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos Right (View view) => new PosView (view, 2);
 
 		/// <summary>
-		/// Returns a Pos object tracks the Bottom (Y+Height) coordinate of the specified view.
+		/// Returns a <see cref="Pos"/> object tracks the Bottom (Y+Height) coordinate of the specified <see cref="View"/> 
 		/// </summary>
-		/// <returns>The Position that depends on the other view.</returns>
-		/// <param name="view">The view that will be tracked.</param>
+		/// <returns>The <see cref="Pos"/> that depends on the other view.</returns>
+		/// <param name="view">The <see cref="View"/>  that will be tracked.</param>
 		public static Pos Bottom (View view) => new PosView (view, 3);
 	}
 
 	/// <summary>
-	/// Dim properties of a view to control the position.
+	/// Dim properties of a <see cref="View"/> to control the position.
 	/// </summary>
 	/// <remarks>
 	///   <para>
-	///     Use the Dim objects on the Width or Height properties of a view to control the position.
+	///     Use the Dim objects on the Width or Height properties of a <see cref="View"/> to control the position.
 	///   </para>
 	///   <para>
 	///     These can be used to set the absolute position, when merely assigning an
 	///     integer value (via the implicit integer to Pos conversion), and they can be combined
 	///     to produce more useful layouts, like: Pos.Center - 3, which would shift the postion
-	///     of the view 3 characters to the left after centering for example.
+	///     of the <see cref="View"/> 3 characters to the left after centering for example.
 	///   </para>
 	/// </remarks>
 	public class Dim {
@@ -347,17 +378,29 @@ namespace Terminal.Gui {
 				return $"Dim.Factor({factor})";
 			}
 
-			public override int GetHashCode () => factor.GetHashCode();
+			public override int GetHashCode () => factor.GetHashCode ();
 
 			public override bool Equals (object other) => other is DimFactor f && f.factor == factor;
 
 		}
 
 		/// <summary>
-		/// Creates a percentage Dim object
+		/// Creates a percentage <see cref="Dim"/> object
 		/// </summary>
-		/// <returns>The percent Dim object.</returns>
+		/// <returns>The percent <see cref="Dim"/> object.</returns>
 		/// <param name="n">A value between 0 and 100 representing the percentage.</param>
+		/// <example>
+		/// This creates a <see cref="TextField"/>that is centered horizontally, is 50% of the way down, 
+		/// is 30% the height, and is 80% the width of the <see cref="View"/> it added to.
+		/// <code>
+		/// var textView = new TextView () {
+		///	X = Pos.Center (),
+		///	Y = Pos.Percent (50),
+		///	Width = Dim.Percent (80),
+		/// 	Height = Dim.Percent (30),
+		/// };
+		/// </code>
+		/// </example>
 		public static Dim Percent (float n)
 		{
 			if (n < 0 || n > 100)
@@ -380,7 +423,7 @@ namespace Terminal.Gui {
 				return n;
 			}
 
-			public override int GetHashCode () => n.GetHashCode();
+			public override int GetHashCode () => n.GetHashCode ();
 
 			public override bool Equals (object other) => other is DimAbsolute abs && abs.n == n;
 
@@ -397,10 +440,10 @@ namespace Terminal.Gui {
 
 			internal override int Anchor (int width)
 			{
-				return width-margin;
+				return width - margin;
 			}
 
-			public override int GetHashCode () => margin.GetHashCode();
+			public override int GetHashCode () => margin.GetHashCode ();
 
 			public override bool Equals (object other) => other is DimFill fill && fill.margin == margin;
 		}
@@ -408,7 +451,7 @@ namespace Terminal.Gui {
 		static DimFill zeroMargin;
 
 		/// <summary>
-		/// Creates a Dim object that fills the dimension, but leaves the specified number of colums for a margin.
+		/// Creates a <see cref="Dim"/> object that fills the dimension, but leaves the specified number of colums for a margin.
 		/// </summary>
 		/// <returns>The Fill dimension.</returns>
 		/// <param name="margin">Margin to use.</param>
@@ -423,9 +466,9 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Creates an Absolute Pos from the specified integer value.
+		/// Creates an Absolute <see cref="Dim"/> from the specified integer value.
 		/// </summary>
-		/// <returns>The Absolute Pos.</returns>
+		/// <returns>The Absolute <see cref="Dim"/>.</returns>
 		/// <param name="n">The value to convert to the pos.</param>
 		public static implicit operator Dim (int n)
 		{
@@ -433,10 +476,10 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Creates an Absolute Pos from the specified integer value.
+		/// Creates an Absolute <see cref="Dim"/> from the specified integer value.
 		/// </summary>
-		/// <returns>The Absolute Pos.</returns>
-		/// <param name="n">The value to convert to the pos.</param>
+		/// <returns>The Absolute <see cref="Dim"/>.</returns>
+		/// <param name="n">The value to convert to the <see cref="Dim"/>.</param>
 		public static Dim Sized (int n)
 		{
 			return new DimAbsolute (n);
@@ -464,22 +507,22 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Adds a <see cref="Terminal.Gui.Pos"/> to a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="T:Terminal.Gui.Pos"/>.
+		/// Adds a <see cref="Terminal.Gui.Dim"/> to a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="T:Terminal.Gui.Dim"/>.
 		/// </summary>
-		/// <param name="left">The first <see cref="Terminal.Gui.Pos"/> to add.</param>
-		/// <param name="right">The second <see cref="Terminal.Gui.Pos"/> to add.</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Pos"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
+		/// <param name="left">The first <see cref="Terminal.Gui.Dim"/> to add.</param>
+		/// <param name="right">The second <see cref="Terminal.Gui.Dim"/> to add.</param>
+		/// <returns>The <see cref="T:Terminal.Gui.Dim"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
 		public static Dim operator + (Dim left, Dim right)
 		{
 			return new DimCombine (true, left, right);
 		}
 
 		/// <summary>
-		/// Subtracts a <see cref="Terminal.Gui.Pos"/> from a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="T:Terminal.Gui.Pos"/>.
+		/// Subtracts a <see cref="Terminal.Gui.Dim"/> from a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="T:Terminal.Gui.Dim"/>.
 		/// </summary>
-		/// <param name="left">The <see cref="Terminal.Gui.Pos"/> to subtract from (the minuend).</param>
-		/// <param name="right">The <see cref="Terminal.Gui.Pos"/> to subtract (the subtrahend).</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Pos"/> that is the <c>left</c> minus <c>right</c>.</returns>
+		/// <param name="left">The <see cref="Terminal.Gui.Dim"/> to subtract from (the minuend).</param>
+		/// <param name="right">The <see cref="Terminal.Gui.Dim"/> to subtract (the subtrahend).</param>
+		/// <returns>The <see cref="T:Terminal.Gui.Dim"/> that is the <c>left</c> minus <c>right</c>.</returns>
 		public static Dim operator - (Dim left, Dim right)
 		{
 			return new DimCombine (false, left, right);
@@ -505,16 +548,16 @@ namespace Terminal.Gui {
 			}
 		}
 		/// <summary>
-		/// Returns a Dim object tracks the Width of the specified view.
+		/// Returns a <see cref="Dim"/> object tracks the Width of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The dimension of the other view.</returns>
+		/// <returns>The <see cref="Dim"/> of the other <see cref="View"/>.</returns>
 		/// <param name="view">The view that will be tracked.</param>
 		public static Dim Width (View view) => new DimView (view, 1);
 
 		/// <summary>
-		/// Returns a Dim object tracks the Height of the specified view.
+		/// Returns a <see cref="Dim"/> object tracks the Height of the specified <see cref="View"/>.
 		/// </summary>
-		/// <returns>The dimension of the other view.</returns>
+		/// <returns>The <see cref="Dim"/> of the other <see cref="View"/>.</returns>
 		/// <param name="view">The view that will be tracked.</param>
 		public static Dim Height (View view) => new DimView (view, 0);
 	}

--- a/Terminal.Gui/Types/PosDim.cs
+++ b/Terminal.Gui/Types/PosDim.cs
@@ -229,11 +229,11 @@ namespace Terminal.Gui {
 		static PosCombine posCombine;
 
 		/// <summary>
-		/// Adds a <see cref="Terminal.Gui.Pos"/> to a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="T:Terminal.Gui.Pos"/>.
+		/// Adds a <see cref="Terminal.Gui.Pos"/> to a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="Pos"/>.
 		/// </summary>
 		/// <param name="left">The first <see cref="Terminal.Gui.Pos"/> to add.</param>
 		/// <param name="right">The second <see cref="Terminal.Gui.Pos"/> to add.</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Pos"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
+		/// <returns>The <see cref="Pos"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
 		public static Pos operator + (Pos left, Pos right)
 		{
 			PosCombine newPos = new PosCombine (true, left, right);
@@ -247,11 +247,11 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Subtracts a <see cref="Terminal.Gui.Pos"/> from a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="T:Terminal.Gui.Pos"/>.
+		/// Subtracts a <see cref="Terminal.Gui.Pos"/> from a <see cref="Terminal.Gui.Pos"/>, yielding a new <see cref="Pos"/>.
 		/// </summary>
 		/// <param name="left">The <see cref="Terminal.Gui.Pos"/> to subtract from (the minuend).</param>
 		/// <param name="right">The <see cref="Terminal.Gui.Pos"/> to subtract (the subtrahend).</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Pos"/> that is the <c>left</c> minus <c>right</c>.</returns>
+		/// <returns>The <see cref="Pos"/> that is the <c>left</c> minus <c>right</c>.</returns>
 		public static Pos operator - (Pos left, Pos right)
 		{
 			PosCombine newPos = new PosCombine (false, left, right);
@@ -390,7 +390,7 @@ namespace Terminal.Gui {
 		/// <returns>The percent <see cref="Dim"/> object.</returns>
 		/// <param name="n">A value between 0 and 100 representing the percentage.</param>
 		/// <example>
-		/// This creates a <see cref="TextField"/>that is centered horizontally, is 50% of the way down, 
+		/// This initializes a <see cref="TextField"/>that is centered horizontally, is 50% of the way down, 
 		/// is 30% the height, and is 80% the width of the <see cref="View"/> it added to.
 		/// <code>
 		/// var textView = new TextView () {
@@ -451,7 +451,7 @@ namespace Terminal.Gui {
 		static DimFill zeroMargin;
 
 		/// <summary>
-		/// Creates a <see cref="Dim"/> object that fills the dimension, but leaves the specified number of colums for a margin.
+		/// Initializes a new instance of the <see cref="Dim"/> class that fills the dimension, but leaves the specified number of colums for a margin.
 		/// </summary>
 		/// <returns>The Fill dimension.</returns>
 		/// <param name="margin">Margin to use.</param>
@@ -507,22 +507,22 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Adds a <see cref="Terminal.Gui.Dim"/> to a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="T:Terminal.Gui.Dim"/>.
+		/// Adds a <see cref="Terminal.Gui.Dim"/> to a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="Dim"/>.
 		/// </summary>
 		/// <param name="left">The first <see cref="Terminal.Gui.Dim"/> to add.</param>
 		/// <param name="right">The second <see cref="Terminal.Gui.Dim"/> to add.</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Dim"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
+		/// <returns>The <see cref="Dim"/> that is the sum of the values of <c>left</c> and <c>right</c>.</returns>
 		public static Dim operator + (Dim left, Dim right)
 		{
 			return new DimCombine (true, left, right);
 		}
 
 		/// <summary>
-		/// Subtracts a <see cref="Terminal.Gui.Dim"/> from a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="T:Terminal.Gui.Dim"/>.
+		/// Subtracts a <see cref="Terminal.Gui.Dim"/> from a <see cref="Terminal.Gui.Dim"/>, yielding a new <see cref="Dim"/>.
 		/// </summary>
 		/// <param name="left">The <see cref="Terminal.Gui.Dim"/> to subtract from (the minuend).</param>
 		/// <param name="right">The <see cref="Terminal.Gui.Dim"/> to subtract (the subtrahend).</param>
-		/// <returns>The <see cref="T:Terminal.Gui.Dim"/> that is the <c>left</c> minus <c>right</c>.</returns>
+		/// <returns>The <see cref="Dim"/> that is the <c>left</c> minus <c>right</c>.</returns>
 		public static Dim operator - (Dim left, Dim right)
 		{
 			return new DimCombine (false, left, right);

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -10,18 +10,18 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	///   Button is a view that provides an item that invokes a callback when activated.
+	///   Button is a <see cref="View"/> that provides an item that invokes an <see cref="Action"/> when activated by the user.
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	///   Provides a button that can be clicked, or pressed with
-	///   the enter key and processes hotkeys (the first uppercase
-	///   letter in the button becomes the hotkey).
+	///   Provides a button showing text invokes an <see cref="Action"/> when clicked on with a mouse
+	///   or when the user presses SPACE, ENTER, or hotkey. The hotkey is specified by the first uppercase
+	///   letter in the button.
 	/// </para>
 	/// <para>
-	///   If the button is configured as the default (IsDefault) the button
-	///   will respond to the return key is no other view processes it, and
-	///   turns this into a clicked event.
+	///   When the button is configured as the default (<see cref="IsDefault"/>) and the user presses
+	///   the ENTER key, if no other <see cref="View"/> processes the <see cref="KeyEvent"/>, the <see cref="Button"/>'s
+	///   <see cref="Action"/> will be invoked.
 	/// </para>
 	/// </remarks>
 	public class Button : View {
@@ -32,7 +32,7 @@ namespace Terminal.Gui {
 		bool is_default;
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.Button"/> is the default action to activate on return on a dialog.
+		/// Gets or sets whether the <see cref="Button"/> is the default action to activate in a dialog.
 		/// </summary>
 		/// <value><c>true</c> if is default; otherwise, <c>false</c>.</value>
 		public bool IsDefault {
@@ -44,7 +44,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Clicked event, raised when the button is clicked.
+		///   Clicked <see cref="Action"/>, raised when the button is clicked.
 		/// </summary>
 		/// <remarks>
 		///   Client code can hook up to this event, it is
@@ -54,15 +54,14 @@ namespace Terminal.Gui {
 		public Action Clicked;
 
 		/// <summary>
-		///   Public constructor, creates a button based on
-		///   the given text at position 0,0
+		///   Initializes a new instance of <see cref="Button"/> based on the given text at position 0,0
 		/// </summary>
 		/// <remarks>
-		///   The size of the button is computed based on the
-		///   text length.   This button is not a default button.
+		///   The size of the <see cref="Button"/> is computed based on the
+		///   text length. 
 		/// </remarks>
 		/// <param name="text">The button's text</param>
-		/// <param name="is_default">If set, this makes the button the default button in the current view, which means that if the user presses return on a view that does not handle return, it will be treated as if he had clicked on the button</param>
+		/// <param name="is_default">If set, this makes the button the default button in the current view. <seealso cref="IsDefault"/></param>
 		public Button (ustring text, bool is_default = false) : base ()
 		{
 			CanFocus = true;
@@ -81,12 +80,11 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Public constructor, creates a button based on
-		///   the given text at the given position.
+		///   Initializes a new instance of <see cref="Button"/> at the given coordinates, based on the given text
 		/// </summary>
 		/// <remarks>
-		///   The size of the button is computed based on the
-		///   text length.   This button is not a default button.
+		///   The size of the <see cref="Button"/> is computed based on the
+		///   text length. 
 		/// </remarks>
 		/// <param name="x">X position where the button will be shown.</param>
 		/// <param name="y">Y position where the button will be shown.</param>
@@ -94,7 +92,7 @@ namespace Terminal.Gui {
 		public Button (int x, int y, ustring text) : this (x, y, text, false) { }
 
 		/// <summary>
-		///   The text displayed by this widget.
+		///   The text displayed by this <see cref="Button"/>.
 		/// </summary>
 		public ustring Text {
 			get {
@@ -132,8 +130,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Public constructor, creates a button based on
-		///   the given text at the given position.
+		///   Initializes a new instance of <see cref="Button"/> at the given coordinates, based on the given text, and with the specified <see cref="IsDefault"/> value
 		/// </summary>
 		/// <remarks>
 		///   If the value for is_default is true, a special

--- a/Terminal.Gui/Views/Checkbox.cs
+++ b/Terminal.Gui/Views/Checkbox.cs
@@ -10,7 +10,7 @@ using NStack;
 namespace Terminal.Gui {
 
 	/// <summary>
-	/// The Checkbox View shows an on/off toggle that the user can set
+	/// The <see cref="CheckBox"/> <see cref="View"/> shows an on/off toggle that the user can set
 	/// </summary>
 	public class CheckBox : View {
 		ustring text;
@@ -18,17 +18,17 @@ namespace Terminal.Gui {
 		Rune hot_key;
 
 		/// <summary>
-		///   Toggled event, raised when the CheckButton is toggled.
+		///   Toggled event, raised when the <see cref="CheckBox"/>  is toggled.
 		/// </summary>
 		/// <remarks>
 		///   Client code can hook up to this event, it is
-		///   raised when the checkbutton is activated either with
+		///   raised when the <see cref="CheckBox"/> is activated either with
 		///   the mouse or the keyboard.
 		/// </remarks>
 		public event EventHandler Toggled;
 
 		/// <summary>
-		/// Public constructor, creates a CheckButton based on the given text, uses Computed layout and sets the height and width.
+		/// Initializes a new instance of <see cref="CheckBox"/> based on the given text, uses Computed layout and sets the height and width.
 		/// </summary>
 		/// <param name="s">S.</param>
 		/// <param name="is_checked">If set to <c>true</c> is checked.</param>
@@ -42,23 +42,21 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Public constructor, creates a CheckButton based on
-		///   the given text at an absolute position.
+		/// Initializes a new instance of <see cref="CheckBox"/> based on the given text at the given position and a state.
 		/// </summary>
 		/// <remarks>
-		///   The size of CheckButton is computed based on the
-		///   text length. This CheckButton is not toggled.
+		///   The size of <see cref="CheckBox"/> is computed based on the
+		///   text length. This <see cref="CheckBox"/> is not toggled.
 		/// </remarks>
 		public CheckBox (int x, int y, ustring s) : this (x, y, s, false)
 		{
 		}
 
 		/// <summary>
-		///   Public constructor, creates a CheckButton based on
-		///   the given text at the given position and a state.
+		/// Initializes a new instance of <see cref="CheckBox"/> based on the given text at the given position and a state.
 		/// </summary>
 		/// <remarks>
-		///   The size of CheckButton is computed based on the
+		///   The size of <see cref="CheckBox"/> is computed based on the
 		///   text length. 
 		/// </remarks>
 		public CheckBox (int x, int y, ustring s, bool is_checked) : base (new Rect (x, y, s.Length + 4, 1))
@@ -70,12 +68,12 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///    The state of the checkbox.
+		///    The state of the <see cref="CheckBox"/>
 		/// </summary>
 		public bool Checked { get; set; }
 
 		/// <summary>
-		///   The text displayed by this widget.
+		///   The text displayed by this <see cref="CheckBox"/>
 		/// </summary>
 		public ustring Text {
 			get {

--- a/Terminal.Gui/Views/Clipboard.cs
+++ b/Terminal.Gui/Views/Clipboard.cs
@@ -3,7 +3,8 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// 
+	/// Provides cut, copy, and paste support for the clipboard. 
+	/// NOTE: Currently not implemented.
 	/// </summary>
 	public static class Clipboard {
 		/// <summary>

--- a/Terminal.Gui/Views/DateField.cs
+++ b/Terminal.Gui/Views/DateField.cs
@@ -11,12 +11,11 @@ using System.Linq;
 using NStack;
 
 namespace Terminal.Gui {
-
 	/// <summary>
-	///   Date edit widget
+	///   Date editing <see cref="View"/>
 	/// </summary>
 	/// <remarks>
-	///   This widget provides date editing functionality, and mouse support.
+	///   The <see cref="DateField"/> <see cref="View"/> provides date editing functionality with mouse support.
 	/// </remarks>
 	public class DateField : TextField {
 		bool isShort;
@@ -31,13 +30,13 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		///    Public constructor that creates a date edit field at an absolute position and fixed size.
+		///    Initializes a new instance of <see cref="DateField"/> at an absolute position and fixed size.
 		/// </summary>
 		/// <param name="x">The x coordinate.</param>
 		/// <param name="y">The y coordinate.</param>
 		/// <param name="date">Initial date contents.</param>
 		/// <param name="isShort">If true, shows only two digits for the year.</param>
-		public DateField(int x, int y, DateTime date, bool isShort = false) : base(x, y, isShort ? 10 : 12, "")
+		public DateField (int x, int y, DateTime date, bool isShort = false) : base(x, y, isShort ? 10 : 12, "")
 		{
 			CultureInfo cultureInfo = CultureInfo.CurrentCulture;
 			sepChar = cultureInfo.DateTimeFormat.DateSeparator;
@@ -75,7 +74,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Gets or sets the date in the widget.
+		///   Gets or sets the date of the <see cref="DateField"/>.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -189,6 +188,7 @@ namespace Terminal.Gui {
 				CursorPosition++;
 		}
 
+		///<inheritdoc cref="ProcessKey(KeyEvent)"/>
 		public override bool ProcessKey(KeyEvent kb)
 		{
 			switch (kb.Key) {
@@ -235,6 +235,7 @@ namespace Terminal.Gui {
 			return true;
 		}
 
+		///<inheritdoc cref="MouseEvent(Gui.MouseEvent)"/>
 		public override bool MouseEvent(MouseEvent ev)
 		{
 			if (!ev.Flags.HasFlag(MouseFlags.Button1Clicked))

--- a/Terminal.Gui/Views/FrameView.cs
+++ b/Terminal.Gui/Views/FrameView.cs
@@ -11,14 +11,15 @@
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// The FrameView is a container frame that draws a frame around the contents
+	/// The FrameView is a container frame that draws a frame around the contents. It is similar to
+	/// a GroupBox in Windows.
 	/// </summary>
 	public class FrameView : View {
 		View contentView;
 		ustring title;
 
 		/// <summary>
-		/// The title to be displayed for this window.
+		/// The title to be displayed for this <see cref="FrameView"/>.
 		/// </summary>
 		/// <value>The title.</value>
 		public ustring Title {
@@ -35,7 +36,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Gui.FrameView"/> class with
+		/// Initializes a new instance of the <see cref="Gui.FrameView"/> class with
 		/// an absolute position and a title.
 		/// </summary>
 		/// <param name="frame">Frame.</param>
@@ -49,8 +50,8 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Gui.FrameView"/> class with
-		/// an absolute position, a title and views.
+		/// Initializes a new instance of the <see cref="Gui.FrameView"/> class with
+		/// an absolute position, a title and <see cref="View"/>s.
 		/// </summary>
 		/// <param name="frame">Frame.</param>
 		/// <param name="title">Title.</param>
@@ -64,7 +65,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Gui.FrameView"/> class with
+		/// Initializes a new instance of the <see cref="Gui.FrameView"/> class with
 		/// a title and the result is suitable to have its X, Y, Width and Height properties computed.
 		/// </summary>
 		/// <param name="title">Title.</param>
@@ -91,9 +92,9 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Add the specified view to the ContentView.
+		/// Add the specified <see cref="View"/> to this container.
 		/// </summary>
-		/// <param name="view">View to add to the window.</param>
+		/// <param name="view"><see cref="View"/> to add to this container</param>
 		public override void Add (View view)
 		{
 			contentView.Add (view);
@@ -103,7 +104,7 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		///   Removes a widget from this container.
+		///   Removes a <see cref="View"/> from this container.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -121,7 +122,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Removes all widgets from this container.
+		///   Removes all <see cref="View"/>s from this container.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -130,6 +131,7 @@ namespace Terminal.Gui {
 			contentView.RemoveAll();
 		}
 
+		///<inheritdoc cref="Redraw(Rect)"/>
 		public override void Redraw (Rect bounds)
 		{
 			if (!NeedDisplay.IsEmpty) {

--- a/Terminal.Gui/Views/HexView.cs
+++ b/Terminal.Gui/Views/HexView.cs
@@ -11,27 +11,27 @@ using System.IO;
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// An Hex viewer an editor view over a System.IO.Stream
+	/// An hex viewer and editor <see cref="View"/> over a <see cref="System.IO.Stream"/>
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	/// This provides a hex editor on top of a seekable stream with the left side showing an hex
-	/// dump of the values in the stream and the right side showing the contents (filterd to 
-	/// non-control sequence ascii characters).    
+	/// <see cref="HexView"/> provides a hex editor on top of a seekable <see cref="Stream"/> with the left side showing an hex
+	/// dump of the values in the <see cref="Stream"/> and the right side showing the contents (filterd to 
+	/// non-control sequence ASCII characters).    
 	/// </para>
 	/// <para>
 	/// Users can switch from one side to the other by using the tab key.  
 	/// </para>
 	/// <para>
-	/// If you want to enable editing, set the AllowsEdits property, once that is done, the user
-	/// can make changes to the hexadecimal values of the stream.   Any changes done are tracked
-	/// in the Edits property which is a sorted dictionary indicating the position where the 
-	/// change was made and the new value.    A convenience ApplyEdits method can be used to c
-	/// apply the methods to the underlying stream.
+	/// To enable editing, set <see cref="AllowEdits"/> to true. When <see cref="AllowEdits"/> is true 
+	/// the user can make changes to the hexadecimal values of the <see cref="Stream"/>. Any changes are tracked
+	/// in the <see cref="Edits"/> property (a <see cref="SortedDictionary{TKey, TValue}"/>) indicating 
+	/// the position where the changes were made and the new values. A convenience method, <see cref="ApplyEdits"/>
+	/// will apply the edits to the <see cref="Stream"/>.
 	/// </para>
 	/// <para>
-	/// It is possible to control the first byte shown by setting the DisplayStart property 
-	/// to the offset that you want to start viewing.
+	/// Control the first byte shown by setting the <see cref="DisplayStart"/> property 
+	/// to an offset in the stream.
 	/// </para>
 	/// </remarks>
 	public class HexView : View {
@@ -41,9 +41,9 @@ namespace Terminal.Gui {
 		bool firstNibble, leftSide;
 
 		/// <summary>
-		/// Creates and instance of the HexView that will render a seekable stream in hex on the allocated view region.
+		/// Initialzies a <see cref="HexView"/>
 		/// </summary>
-		/// <param name="source">Source stream, this stream should support seeking, or this will raise an exceotion.</param>
+		/// <param name="source">The <see cref="Stream"/> to view and edit as hex, this <see cref="Stream"/> must support seeking, or an exception will be thrown.</param>
 		public HexView (Stream source) : base()
 		{
 			Source = source;
@@ -54,7 +54,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// The source stream to display on the hex view, the stream should support seeking.
+		/// Sets or gets the <see cref="Stream"/> the <see cref="HexView"/> is operating on; the stream must support seeking (<see cref="Stream.CanSeek"/> == true).
 		/// </summary>
 		/// <value>The source.</value>
 		public Stream Source {
@@ -82,7 +82,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Configures the initial offset to be displayed at the top
+		/// Sets or gets the offset into the <see cref="Stream"/> that will displayed at the top of the <see cref="HexView"/>
 		/// </summary>
 		/// <value>The display start.</value>
 		public long DisplayStart {
@@ -212,9 +212,7 @@ namespace Terminal.Gui {
 
 		}
 
-		/// <summary>
-		/// Positions the cursor based for the hex view
-		/// </summary>
+		///<inheritdoc cref="PositionCursor"/>
 		public override void PositionCursor ()
 		{
 			var delta = (int)(position - displayStart);
@@ -367,19 +365,22 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.HexView"/> allow editing of the contents of the underlying stream.
+		/// Gets or sets whether this <see cref="HexView"/> allow editing of the <see cref="Stream"/> 
+		/// of the underlying <see cref="Stream"/>.
 		/// </summary>
 		/// <value><c>true</c> if allow edits; otherwise, <c>false</c>.</value>
 		public bool AllowEdits { get; set; }
 
 		/// <summary>
-		/// Gets a list of the edits done to the buffer which is a sorted dictionary with the positions where the edit took place and the value that was set.
+		/// Gets a <see cref="SortedDictionary{TKey, TValue}"/> describing the edits done to the <see cref="HexView"/>. 
+		/// Each Key indicates an offset where an edit was made and the Value is the changed byte.
 		/// </summary>
 		/// <value>The edits.</value>
 		public IReadOnlyDictionary<long,byte> Edits => edits;
 
 		/// <summary>
-		/// This method applies the edits to the stream and resets the contents of the Edits property
+		/// This method applies andy edits made to the <see cref="Stream"/> and resets the 
+		/// contents of the <see cref="Edits"/> property
 		/// </summary>
 		public void ApplyEdits ()
 		{

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -28,13 +28,13 @@ namespace Terminal.Gui {
 		/// </summary>
 		Centered, 
 		/// <summary>
-		/// Shows the line as justified text in the line.
+		/// Shows the text as justified text in the frame.
 		/// </summary>
 		Justified
 	}
 
 	/// <summary>
-	/// Label view, displays a string at a given position, can include multiple lines.
+	/// The Label <see cref="View"/> displays a string at a given position and supports multiple lines separted by newline characters.
 	/// </summary>
 	public class Label : View {
 		List<ustring> lines = new List<ustring> ();
@@ -64,7 +64,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Public constructor: creates a label at the given
+		///   Initializes a new instance of <see cref="Label"/> at the given
 		///   coordinate with the given string, computes the bounding box
 		///   based on the size of the string, assumes that the string contains
 		///   newlines for multiple lines, no special breaking rules are used.
@@ -74,7 +74,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Public constructor: creates a label at the given
+		///   Initializes a new instance of <see cref="Label"/> at the given
 		///   coordinate with the given string and uses the specified
 		///   frame for the string.
 		/// </summary>
@@ -84,7 +84,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Public constructor: creates a label and configures the default Width and Height based on the text, the result is suitable for Computed layout.
+		/// Initializes a new instance of <see cref="Label"/> and configures the default Width and Height based on the text, the result is suitable for Computed layout.
 		/// </summary>
 		/// <param name="text">Text.</param>
 		public Label (ustring text) : base ()
@@ -200,7 +200,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Computes the number of lines needed to render the specified text by the Label control
+		/// Computes the number of lines needed to render the specified text by the <see cref="Label"/> view
 		/// </summary>
 		/// <returns>Number of lines.</returns>
 		/// <param name="text">Text, may contain newlines.</param>
@@ -226,7 +226,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   The text displayed by this widget.
+		///   The text displayed by the <see cref="Label"/>.
 		/// </summary>
 		public virtual ustring Text {
 			get => text;
@@ -238,7 +238,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Controls the text-alignemtn property of the label, changing it will redisplay the label.
+		/// Controls the text-alignemtn property of the label, changing it will redisplay the <see cref="Label"/>.
 		/// </summary>
 		/// <value>The text alignment.</value>
 		public TextAlignment TextAlignment {
@@ -251,7 +251,7 @@ namespace Terminal.Gui {
 
 		Attribute textColor = -1;
 		/// <summary>
-		///   The color used for the label
+		///   The color used for the <see cref="Label"/>.
 		/// </summary>
 		public Attribute TextColor {
 			get => textColor;

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -26,7 +26,7 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// Implement this interface to provide your own custom rendering for a list.
+	/// Implement <see cref="IListDataSource"/> to provide custom rendering for a <see cref="ListView"/>.
 	/// </summary>
 	public interface IListDataSource {
 		/// <summary>
@@ -72,33 +72,34 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// ListView widget renders a list of data.
+	/// ListView <see cref="View"/> renders a scrollable list of data where each item can be activated to perform an action.
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	///   The ListView displays lists of data and allows the user to scroll through the data
-	///   and optionally mark elements of the list (controlled by the AllowsMark property).
+	///   The <see cref="ListView"/> displays lists of data and allows the user to scroll through the data.
+	///   Items in the can be activated firing an event (with the ENTER key or a mouse double-click). 
+	///   If the <see cref="AllowsMarking"/> property is true, elements of the list can be marked by the user.
 	/// </para>
 	/// <para>
-	///   The ListView can either render an arbitrary IList object (for example, arrays, List&lt;T&gt;
-	///   and other collections) which are drawn by drawing the string/ustring contents or the
-	///   result of calling ToString().   Alternatively, you can provide you own IListDataSource
-	///   object that gives you full control of what is rendered.
+	///   By default <see cref="ListView"/> uses <see cref="object.ToString"/> to render the items of any
+	///   <see cref="IList"/> object (e.g. arrays, <see cref="List{T}"/>,
+	///   and other collections). Alternatively, an object that implements the <see cref="IListDataSource"/>
+	///   interface can be provided giving full control of what is rendered.
 	/// </para>
 	/// <para>
-	///   The ListView can display any object that implements the System.Collection.IList interface,
-	///   string values are converted into ustring values before rendering, and other values are
-	///   converted into ustrings by calling ToString() and then converting to ustring.
+	///   <see cref="ListView"/> can display any object that implements the <see cref="IList"/> interface.
+	///   <see cref="string"/> values are converted into <see cref="ustring"/> values before rendering, and other values are
+	///   converted into <see cref="string"/> by calling <see cref="object.ToString"/> and then converting to <see cref="ustring"/> .
 	/// </para>
 	/// <para>
-	///   If you must change the contents of the ListView, set the Source property (when you are
-	///   providing your own rendering via the IListDataSource implementation) or call SetSource
-	///   when you are providing an IList.
+	///   To change the contents of the ListView, set the <see cref="Source"/> property (when 
+	///   providing custom rendering via <see cref="IListDataSource"/>) or call <see cref="SetSource"/>
+	///   an <see cref="IList"/> is being used.
 	/// </para>
 	/// <para>
-	///   When AllowsMark is set to true, then the rendering will prefix the list rendering with
-	///   [x] or [ ] and bind the space character to toggle the selection.  If you desire a different
-	///   marking style do not set the property and provide your own custom rendering.
+	///   When <see cref="AllowsMarking"/> is set to true the rendering will prefix the rendered items with
+	///   [x] or [ ] and bind the SPACE key to toggle the selection. To implement a different
+	///   marking style set <see cref="AllowsMarking"/> to false and implement custom rendering.
 	/// </para>
 	/// </remarks>
 	public class ListView : View {
@@ -107,9 +108,12 @@ namespace Terminal.Gui {
 
 		IListDataSource source;
 		/// <summary>
-		/// Gets or sets the IListDataSource backing this view, use SetSource() if you want to set a new IList source.
+		/// Gets or sets the <see cref="IListDataSource"/> backing this <see cref="ListView"/>, enabling custom rendering.
 		/// </summary>
 		/// <value>The source.</value>
+		/// <remarks>
+		///  Use <see cref="SetSource"/> to set a new <see cref="IList"/> source.
+		/// </remarks>
 		public IListDataSource Source {
 			get => source;
 			set {
@@ -121,9 +125,12 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Sets the source to an IList value, if you want to set a full IListDataSource, use the Source property.
+		/// Sets the source of the <see cref="ListView"/> to an <see cref="IList"/>.
 		/// </summary>
-		/// <value>An item implementing the IList interface.</value>
+		/// <value>An object implementing the IList interface.</value>
+		/// <remarks>
+		///  Use the <see cref="Source"/> property to set a new <see cref="IListDataSource"/> source and use custome rendering.
+		/// </remarks>
 		public void SetSource (IList source)
 		{
 			if (source == null)
@@ -134,9 +141,12 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Sets the source to an IList value asynchronously, if you want to set a full IListDataSource, use the Source property.
+		/// Sets the source to an <see cref="IList"/> value asynchronously.
 		/// </summary>
 		/// <value>An item implementing the IList interface.</value>
+		/// <remarks>
+		///  Use the <see cref="Source"/> property to set a new <see cref="IListDataSource"/> source and use custome rendering.
+		/// </remarks>
 		public Task SetSourceAsync (IList source)
 		{
 			return Task.Factory.StartNew (() => {
@@ -150,14 +160,13 @@ namespace Terminal.Gui {
 
 		bool allowsMarking;
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="T:Terminal.Gui.ListView"/> allows items to be marked.
+		/// Gets or sets whether this <see cref="ListView"/> allows items to be marked.
 		/// </summary>
 		/// <value><c>true</c> if allows marking elements of the list; otherwise, <c>false</c>.
 		/// </value>
 		/// <remarks>
-		/// If set to true, this will default to rendering the marked with "[x]", and unmarked valued with "[ ]"
-		/// spaces.   If you desire a different rendering, you need to implement your own renderer.   This will
-		/// also by default process the space character as a toggle for the selection.
+		/// If set to true, <see cref="ListView"/> will render items marked items with "[x]", and unmarked items with "[ ]"
+		/// spaces. SPACE key will toggle marking.
 		/// </remarks>
 		public bool AllowsMarking {
 			get => allowsMarking;
@@ -173,7 +182,7 @@ namespace Terminal.Gui {
 		public bool AllowsMultipleSelection { get; set; } = true;
 
 		/// <summary>
-		/// Gets or sets the item that is displayed at the top of the listview
+		/// Gets or sets the item that is displayed at the top of the <see cref="ListView"/>.
 		/// </summary>
 		/// <value>The top item.</value>
 		public int TopItem {
@@ -190,7 +199,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets the currently selected item.
+		/// Gets or sets the index of the currently selected item.
 		/// </summary>
 		/// <value>The selected item.</value>
 		public int SelectedItem {
@@ -215,17 +224,20 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new ListView that will display the contents of the object implementing the IList interface, with relative positioning
+		/// Initializes a new instance of <see cref="ListView"/> that will display the contents of the object implementing the <see cref="IList"/> interface, 
+		/// with relative positioning.
 		/// </summary>
-		/// <param name="source">An IList data source, if the elements of the IList are strings or ustrings, the string is rendered, otherwise the ToString() method is invoked on the result.</param>
+		/// <param name="source">An <see cref="IList"/> data source, if the elements are strings or ustrings, the string is rendered, otherwise the ToString() method is invoked on the result.</param>
 		public ListView (IList source) : this (MakeWrapper (source))
 		{
 		}
 
 		/// <summary>
-		/// Initializes a new ListView that will display the provided data source, uses relative positioning.
+		/// Initializes a new instance of <see cref="ListView"/> that will display the provided data source, using relative positioning.
 		/// </summary>
-		/// <param name="source">IListDataSource object that provides a mechanism to render the data. The number of elements on the collection should not change, if you must change, set the "Source" property to reset the internal settings of the ListView.</param>
+		/// <param name="source"><see cref="IListDataSource"/> object that provides a mechanism to render the data. 
+		/// The number of elements on the collection should not change, if you must change, set 
+		/// the "Source" property to reset the internal settings of the ListView.</param>
 		public ListView (IListDataSource source) : base ()
 		{
 			Source = source;
@@ -233,14 +245,14 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.ListView"/> class.   You must set the Source property for this to show something.
+		/// Initializes a new instance of <see cref="ListView"/>. Set the <see cref="Source"/> property to display something.
 		/// </summary>
 		public ListView () : base ()
 		{
 		}
 
 		/// <summary>
-		/// Initializes a new ListView that will display the contents of the object implementing the IList interface with an absolute position.
+		/// Initializes a new instance of <see cref="ListView"/> that will display the contents of the object implementing the <see cref="IList"/> interface with an absolute position.
 		/// </summary>
 		/// <param name="rect">Frame for the listview.</param>
 		/// <param name="source">An IList data source, if the elements of the IList are strings or ustrings, the string is rendered, otherwise the ToString() method is invoked on the result.</param>
@@ -249,7 +261,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new ListView that will display the provided data source  with an absolute position
+		/// Initializes a new instance of <see cref="ListView"/> with the provided data source and an absolute position
 		/// </summary>
 		/// <param name="rect">Frame for the listview.</param>
 		/// <param name="source">IListDataSource object that provides a mechanism to render the data. The number of elements on the collection should not change, if you must change, set the "Source" property to reset the internal settings of the ListView.</param>
@@ -259,10 +271,7 @@ namespace Terminal.Gui {
 			CanFocus = true;
 		}
 
-		/// <summary>
-		/// Redraws the ListView
-		/// </summary>
-		/// <param name="region">Region.</param>
+		///<inheritdoc cref="Redraw(Rect)"/>
 		public override void Redraw (Rect region)
 		{
 			var current = ColorScheme.Focus;
@@ -296,20 +305,16 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// This event is raised when the cursor selection has changed.
+		/// This event is raised when the selected item in the <see cref="ListView"/> has changed.
 		/// </summary>
 		public event EventHandler<ListViewItemEventArgs> SelectedChanged;
 
 		/// <summary>
-		/// This event is raised on Enter key or Double Click to open the selected item.
+		/// This event is raised when the user Double Clicks on an item or presses ENTER to open the selected item.
 		/// </summary>
 		public event EventHandler<ListViewItemEventArgs> OpenSelectedItem;
 
-		/// <summary>
-		/// Handles cursor movement for this view, passes all other events.
-		/// </summary>
-		/// <returns><c>true</c>, if key was processed, <c>false</c> otherwise.</returns>
-		/// <param name="kb">Keyboard event.</param>
+		///<inheritdoc cref="ProcessKey(KeyEvent)"/>
 		public override bool ProcessKey (KeyEvent kb)
 		{
 			if (source == null)
@@ -380,7 +385,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves to the next page.
+		/// Moves the selected item index to the next page.
 		/// </summary>
 		/// <returns></returns>
 		public virtual bool MovePageUp ()
@@ -399,7 +404,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves to the previous page.
+		/// Moves the selected item index to the previous page.
 		/// </summary>
 		/// <returns></returns>
 		public virtual bool MovePageDown ()
@@ -421,7 +426,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves to the next row.
+		/// Moves the selected item index to the next row.
 		/// </summary>
 		/// <returns></returns>
 		public virtual bool MoveDown ()
@@ -438,7 +443,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Moves to the previous row.
+		/// Moves the selected item index to the previous row.
 		/// </summary>
 		/// <returns></returns>
 		public virtual bool MoveUp ()
@@ -484,9 +489,7 @@ namespace Terminal.Gui {
 			return true;
 		}
 
-		/// <summary>
-		/// Positions the cursor in this view
-		/// </summary>
+		///<inheritdoc cref="PositionCursor"/>
 		public override void PositionCursor ()
 		{
 			if (allowsMarking)
@@ -534,16 +537,16 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// This class is the built-in IListDataSource that renders arbitrary
-	/// IList instances
+	/// Implements an <see cref="IListDataSource"/> that renders arbitrary <see cref="IList"/> instances for <see cref="ListView"/>.
 	/// </summary>
+	/// <remarks>Implements support for rendering marked items.</remarks>
 	public class ListWrapper : IListDataSource {
 		IList src;
 		BitArray marks;
 		int count;
 
 		/// <summary>
-		/// Constructor based on a source.
+		/// Initializes a new instance of <see cref="ListWrapper"/> given an <see cref="IList"/>
 		/// </summary>
 		/// <param name="source"></param>
 		public ListWrapper (IList source)
@@ -554,7 +557,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Returns the amount of items in the source.
+		/// Gets the number of items in the <see cref="IList"/>.
 		/// </summary>
 		public int Count => src.Count;
 
@@ -577,7 +580,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Method that render to the appropriate type based on the type of the item passed to it.
+		/// Renders a <see cref="ListView"/> item to the appropriate type.
 		/// </summary>
 		/// <param name="container">The ListView.</param>
 		/// <param name="driver">The driver used by the caller.</param>
@@ -632,23 +635,23 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// Gets the item and value to use in an event handler.
+	/// <see cref="EventArgs"/> for <see cref="ListView"/> events.
 	/// </summary>
 	public class ListViewItemEventArgs : EventArgs {
 		/// <summary>
-		/// The item.
+		/// The index of the <see cref="ListView"/> item.
 		/// </summary>
 		public int Item { get; }
 		/// <summary>
-		/// The item value.
+		/// The the <see cref="ListView"/> item.
 		/// </summary>
 		public object Value { get; }
 
 		/// <summary>
-		/// Constructor to sets the item and value passed from.
+		/// Initializes a new instance of <see cref="ListViewItemEventArgs"/>
 		/// </summary>
-		/// <param name="item">The item.</param>
-		/// <param name="value">The item value</param>
+		/// <param name="item">The index of the the <see cref="ListView"/> item.</param>
+		/// <param name="value">The <see cref="ListView"/> item</param>
 		public ListViewItemEventArgs (int item, object value)
 		{
 			Item = item;

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -17,12 +17,12 @@ using System.Reflection;
 namespace Terminal.Gui {
 
 	/// <summary>
-	/// A menu item has a title, an associated help text, and an action to execute on activation.
+	/// A <see cref="MenuItem"/> has a title, an associated help text, and an action to execute on activation.
 	/// </summary>
 	public class MenuItem {
 
 		/// <summary>
-		/// constructor
+		/// Initializes a new instance of <see cref="MenuItem"/>
 		/// </summary>
 		public MenuItem ()
 		{
@@ -31,7 +31,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.MenuItem"/>.
+		/// Initializes a new instance of <see cref="MenuItem"/>.
 		/// </summary>
 		/// <param name="title">Title for the menu item.</param>
 		/// <param name="help">Help text to display.</param>
@@ -58,7 +58,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.MenuItem"/>.
+		/// Initializes a new instance of <see cref="MenuItem"/>
 		/// </summary>
 		/// <param name="title">Title for the menu item.</param>
 		/// <param name="subMenu">The menu sub-menu.</param>
@@ -68,11 +68,8 @@ namespace Terminal.Gui {
 			IsFromSubMenu = true;
 		}
 
-		//
-		//
-
 		/// <summary>
-		/// The hotkey is used when the menu is active, the shortcut can be triggered when the menu is not active.
+		/// The HotKey is used when the menu is active, the shortcut can be triggered when the menu is not active.
 		/// For example HotKey would be "N" when the File Menu is open (assuming there is a "_New" entry
 		/// if the ShortCut is set to "Control-N", this would be a global hotkey that would trigger as well
 		/// </summary>
@@ -84,7 +81,7 @@ namespace Terminal.Gui {
 		public Key ShortCut;
 
 		/// <summary>
-		/// Gets or sets the title.
+		/// Gets or sets the title. 
 		/// </summary>
 		/// <value>The title.</value>
 		public ustring Title { get; set; }
@@ -118,7 +115,7 @@ namespace Terminal.Gui {
 		internal int Width => Title.Length + Help.Length + 1 + 2;
 
 		/// <summary>
-		/// Gets or sets the parent for this MenuBarItem
+		/// Gets or sets the parent for this <see cref="MenuItem"/>
 		/// </summary>
 		/// <value>The parent.</value>
 		internal MenuBarItem SubMenu { get; set; }
@@ -142,11 +139,11 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	/// A menu bar item contains other menu items.
+	/// A <see cref="MenuBarItem"/> contains <see cref="MenuBarItem"/>s or <see cref="MenuItem"/>s.
 	/// </summary>
 	public class MenuBarItem : MenuItem {
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.MenuBarItem"/> as a <see cref="T:Terminal.Gui.MenuItem"/>.
+		/// Initializes a new <see cref="MenuBarItem"/> as a <see cref="MenuItem"/>.
 		/// </summary>
 		/// <param name="title">Title for the menu item.</param>
 		/// <param name="help">Help text to display.</param>
@@ -159,7 +156,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.MenuBarItem"/>.
+		/// Initializes a new <see cref="MenuBarItem"/>.
 		/// </summary>
 		/// <param name="title">Title for the menu item.</param>
 		/// <param name="children">The items in the current menu.</param>
@@ -170,7 +167,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.MenuBarItem"/>.
+		/// Initializes a new <see cref="MenuBarItem"/>.
 		/// </summary>
 		/// <param name="children">The items in the current menu.</param>
 		public MenuBarItem (MenuItem [] children) : this (new string (' ', GetMaxTitleLength (children)), children)
@@ -217,7 +214,7 @@ namespace Terminal.Gui {
 		//public ustring Title { get; set; }
 
 		/// <summary>
-		/// Gets or sets the children for this MenuBarItem
+		/// Gets or sets an array of <see cref="MenuItem"/> objects that are the children of this <see cref="MenuBarItem"/>
 		/// </summary>
 		/// <value>The children.</value>
 		public MenuItem [] Children { get; set; }
@@ -524,11 +521,19 @@ namespace Terminal.Gui {
 
 
 	/// <summary>
-	/// A menu bar for your application.
+	/// The MenuBar provides a menu for Terminal.Gui applications. 
 	/// </summary>
+	/// <remarks>
+	///	<para>
+	///	The <see cref="MenuBar"/> appears on the first row of the terminal.
+	///	</para>
+	///	<para>
+	///	The <see cref="MenuBar"/> provides global hotkeys for the application.
+	///	</para>
+	/// </remarks>
 	public class MenuBar : View {
 		/// <summary>
-		/// The menus that were defined when the menubar was created.   This can be updated if the menu is not currently visible.
+		/// Gets or sets the array of <see cref="MenuBarItem"/>s for the menu. Only set this when the <see cref="MenuBar"/> is vislble.
 		/// </summary>
 		/// <value>The menu array.</value>
 		public MenuBarItem [] Menus { get; set; }
@@ -543,9 +548,9 @@ namespace Terminal.Gui {
 		public bool UseKeysUpDownAsKeysLeftRight { get; set; } = true;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.MenuBar"/> class with the specified set of toplevel menu items.
+		/// Initializes a new instance of the <see cref="MenuBar"/> class with the specified set of toplevel menu items.
 		/// </summary>
-		/// <param name="menus">Individual menu items, if one of those contains a null, then a separator is drawn.</param>
+		/// <param name="menus">Individual menu items; a null item will result in a separator being drawn.</param>
 		public MenuBar (MenuBarItem [] menus) : base ()
 		{
 			X = 0;

--- a/Terminal.Gui/Views/ProgressBar.cs
+++ b/Terminal.Gui/Views/ProgressBar.cs
@@ -2,17 +2,16 @@
 namespace Terminal.Gui {
 
 	/// <summary>
-	/// Progress bar can indicate progress of an activity visually.
+	/// A Progress Bar view that can indicate progress of an activity visually.
 	/// </summary>
 	/// <remarks>
 	///   <para>
-	///     The progressbar can operate in two modes, percentage mode, or
+	///     <see cref="ProgressBar"/> can operate in two modes, percentage mode, or
 	///     activity mode.  The progress bar starts in percentage mode and
 	///     setting the Fraction property will reflect on the UI the progress 
 	///     made so far.   Activity mode is used when the application has no 
-	///     way of knowing how much time is left, and is started when you invoke
-	///     the Pulse() method.    You should call the Pulse method repeatedly as
-	///     your application makes progress.
+	///     way of knowing how much time is left, and is started when the <see cref="Pulse"/> method is called.  
+	///     Call <see cref="Pulse"/> repeatedly as progress is made.
 	///   </para>
 	/// </remarks>
 	public class ProgressBar : View {
@@ -20,7 +19,7 @@ namespace Terminal.Gui {
 		int activityPos, delta;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.ProgressBar"/> class, starts in percentage mode with an absolute position and size.
+		/// Initializes a new instance of the <see cref="ProgressBar"/> class, starts in percentage mode with an absolute position and size.
 		/// </summary>
 		/// <param name="rect">Rect.</param>
 		public ProgressBar (Rect rect) : base (rect)
@@ -30,7 +29,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.ProgressBar"/> class, starts in percentage mode and uses relative layout.
+		/// Initializes a new instance of the <see cref="ProgressBar"/> class, starts in percentage mode and uses relative layout.
 		/// </summary>
 		public ProgressBar () : base ()
 		{
@@ -41,7 +40,7 @@ namespace Terminal.Gui {
 		float fraction;
 
 		/// <summary>
-		/// Gets or sets the progress indicator fraction to display, must be a value between 0 and 1.
+		/// Gets or sets the <see cref="ProgressBar"/> fraction to display, must be a value between 0 and 1.
 		/// </summary>
 		/// <value>The fraction representing the progress.</value>
 		public float Fraction {
@@ -54,10 +53,10 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Notifies the progress bar that some progress has taken place.
+		/// Notifies the <see cref="ProgressBar"/> that some progress has taken place.
 		/// </summary>
 		/// <remarks>
-		/// If the ProgressBar is is percentage mode, it switches to activity
+		/// If the <see cref="ProgressBar"/> is is percentage mode, it switches to activity
 		/// mode.   If is in activity mode, the marker is moved.
 		/// </remarks>
 		public void Pulse ()
@@ -80,6 +79,7 @@ namespace Terminal.Gui {
 			SetNeedsDisplay ();
 		}
 
+		///<inheritdoc cref="Redraw"/>
 		public override void Redraw(Rect region)
 		{
 			Driver.SetAttribute (ColorScheme.Normal);

--- a/Terminal.Gui/Views/RadioGroup.cs
+++ b/Terminal.Gui/Views/RadioGroup.cs
@@ -1,19 +1,19 @@
 ﻿using System;
 namespace Terminal.Gui {
 	/// <summary>
-	/// Radio group shows a group of labels, only one of those can be selected at a given time
+	/// <see cref="RadioGroup"/> shows a group of radio labels, only one of those can be selected at a given time
 	/// </summary>
 	public class RadioGroup : View {
 		int selected, cursor;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.RadioGroup"/> class
+		/// Initializes a new instance of the <see cref="RadioGroup"/> class
 		/// setting up the initial set of radio labels and the item that should be selected and uses
 		/// an absolute layout for the result.
 		/// </summary>
 		/// <param name="rect">Boundaries for the radio group.</param>
-		/// <param name="radioLabels">Radio labels, the strings can contain hotkeys using an undermine before the letter.</param>
-		/// <param name="selected">The item to be selected, the value is clamped to the number of items.</param>
+		/// <param name="radioLabels">The radio labels; an array of strings that can contain hotkeys using an underscore before the letter.</param>
+		/// <param name="selected">The index of item to be selected, the value is clamped to the number of items.</param>
 		public RadioGroup (Rect rect, string [] radioLabels, int selected = 0) : base (rect)
 		{
 			this.selected = selected;
@@ -22,7 +22,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// The location of the cursor in the radio group
+		/// The location of the cursor in the <see cref="RadioGroup"/>
 		/// </summary>
 		public int Cursor {
 			get => cursor;
@@ -35,11 +35,11 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.RadioGroup"/> class
+		/// Initializes a new instance of the <see cref="RadioGroup"/> class
 		/// setting up the initial set of radio labels and the item that should be selected.
 		/// </summary>
-		/// <param name="radioLabels">Radio labels, the strings can contain hotkeys using an undermine before the letter.</param>
-		/// <param name="selected">The item to be selected, the value is clamped to the number of items.</param>
+		/// <param name="radioLabels">The radio labels; an array of strings that can contain hotkeys using an underscore before the letter.</param>
+		/// <param name="selected">The index of the item to be selected, the value is clamped to the number of items.</param>
 		public RadioGroup (string [] radioLabels, int selected = 0) : base ()
 		{
 			SetWidthHeight(radioLabels);
@@ -64,14 +64,15 @@ namespace Terminal.Gui {
 				width = Math.Max (s.Length + 4, width);
 			return new Rect (x, y, width, radioLabels.Length);
 		}
+
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.RadioGroup"/> class
-		/// setting up the initial set of radio labels and the item that should be selected, 
-		/// the view frame is computed from the provided radioLabels.
+		/// Initializes a new instance of the <see cref="RadioGroup"/> class
+		/// setting up the initial set of radio labels and the item that should be selected.
+		/// The <see cref="View"/> frame is computed from the provided radio labels.
 		/// </summary>
 		/// <param name="x">The x coordinate.</param>
 		/// <param name="y">The y coordinate.</param>
-		/// <param name="radioLabels">Radio labels, the strings can contain hotkeys using an undermine before the letter.</param>
+		/// <param name="radioLabels">The radio labels; an array of strings that can contain hotkeys using an underscore before the letter.</param>
 		/// <param name="selected">The item to be selected, the value is clamped to the number of items.</param>		
 		public RadioGroup (int x, int y, string [] radioLabels, int selected = 0) : this (MakeRect (x, y, radioLabels), radioLabels, selected)
 		{
@@ -106,6 +107,7 @@ namespace Terminal.Gui {
 			}
 		}
 
+		///<inheritdoc cref="Redraw(Rect)"/>
 		public override void Redraw (Rect region)
 		{
 			base.Redraw (region);
@@ -117,11 +119,13 @@ namespace Terminal.Gui {
 			}
 		}
 
+		///<inheritdoc cref="PositionCursor"/>
 		public override void PositionCursor ()
 		{
 			Move (1, cursor);
 		}
 
+		///<inheritdoc cref="SelectionChanged"/>
 		public Action<int> SelectionChanged;
 
 		/// <summary>
@@ -137,6 +141,7 @@ namespace Terminal.Gui {
 			}
 		}
 
+		///<inheritdoc cref="ProcessColdKey"/>
 		public override bool ProcessColdKey (KeyEvent kb)
 		{
 			var key = kb.KeyValue;
@@ -165,6 +170,7 @@ namespace Terminal.Gui {
 			return false;
 		}
 
+		///<inheritdoc cref="ProcessKey(KeyEvent)"/>
 		public override bool ProcessKey (KeyEvent kb)
 		{
 			switch (kb.Key) {
@@ -189,6 +195,7 @@ namespace Terminal.Gui {
 			return base.ProcessKey (kb);
 		}
 
+		///<inheritdoc cref="MouseEvent(Gui.MouseEvent)"/>
 		public override bool MouseEvent (MouseEvent me)
 		{
 			if (!me.Flags.HasFlag (MouseFlags.Button1Clicked))

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -70,7 +70,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.Gui.ScrollBarView"/> class.
+		/// Initializes a new instance of the <see cref="Gui.ScrollBarView"/> class.
 		/// </summary>
 		/// <param name="rect">Frame for the scrollbar.</param>
 		/// <param name="size">The size that this scrollbar represents.</param>
@@ -518,6 +518,7 @@ namespace Terminal.Gui {
 			return false;
 		}
 
+		///<inheritdoc cref="MouseEvent(Gui.MouseEvent)"/>
 		public override bool MouseEvent (MouseEvent me)
 		{
 			if (me.Flags != MouseFlags.WheeledDown && me.Flags != MouseFlags.WheeledUp)

--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -11,18 +11,21 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	/// A statusbar item has a title, a shortcut aka hotkey, and an action to execute on activation.
-	/// Such an item is ment to be as part of the global hotkeys of the application, which are available in the current context of the screen.
-	/// The colour of the text will be changed after each ~. Having an statusbar item with a text of `~F1~ Help` will draw *F1* as shortcut and
-	/// *Help* as standard text.
+	/// <see cref="StatusItem"/> objects are contained by <see cref="StatusBar"/> <see cref="View"/>s. 
+	/// Each <see cref="StatusItem"/> has a title, a shortcut (hotkey), and an <see cref="Action"/> that will be invoked when the 
+	/// <see cref="StatusItem.Shortcut"/> is pressed.
+	/// The <see cref="StatusItem.Shortcut"/> will be a global hotkey for the application in the current context of the screen.
+	/// The colour of the <see cref="StatusItem.Title"/> will be changed after each ~. 
+	/// A <see cref="StatusItem.Title"/> set to `~F1~ Help` will render as *F1* using <see cref="ColorScheme.HotNormal"/> and
+	/// *Help* as <see cref="ColorScheme.HotNormal"/>.
 	/// </summary>
 	public class StatusItem {
 		/// <summary>
-		/// Initializes a new <see cref="T:Terminal.Gui.StatusItem"/>.
+		/// Initializes a new <see cref="StatusItem"/>.
 		/// </summary>
-		/// <param name="shortcut">Shortcut to activate the item.</param>
-		/// <param name="title">Title for the statusbar item.</param>
-		/// <param name="action">Action to invoke when the staturbar item is activated.</param>
+		/// <param name="shortcut">Shortcut to activate the <see cref="StatusItem"/>.</param>
+		/// <param name="title">Title for the <see cref="StatusItem"/>.</param>
+		/// <param name="action">Action to invoke when the <see cref="StatusItem"/> is activated.</param>
 		public StatusItem (Key shortcut, ustring title, Action action)
 		{
 			Title = title ?? "";
@@ -31,7 +34,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// This is the global setting that can be used as a global shortcut to invoke the action on the menu.
+		/// Gets the global shortcut to invoke the action on the menu.
 		/// </summary>
 		public Key Shortcut { get; }
 
@@ -39,25 +42,30 @@ namespace Terminal.Gui {
 		/// Gets or sets the title.
 		/// </summary>
 		/// <value>The title.</value>
+		/// <remarks>
+		/// The colour of the <see cref="StatusItem.Title"/> will be changed after each ~. 
+		/// A <see cref="StatusItem.Title"/> set to `~F1~ Help` will render as *F1* using <see cref="ColorScheme.HotNormal"/> and
+		/// *Help* as <see cref="ColorScheme.HotNormal"/>.
+		/// </remarks>
 		public ustring Title { get; }
 
 		/// <summary>
 		/// Gets or sets the action to be invoked when the statusbar item is triggered
 		/// </summary>
-		/// <value>Method to invoke.</value>
+		/// <value>Action to invoke.</value>
 		public Action Action { get; }
 	};
 
 	/// <summary>
-	/// A statusbar for your application.
-	/// The statusbar should be context sensitive. This means, if the main menu and an open text editor are visible, the items probably shown will
+	/// A status bar is a <see cref="View"/> that snaps to the bottom of a <see cref="Toplevel"/> displaying set of <see cref="StatusItem"/>s.
+	/// The <see cref="StatusBar"/> should be context sensitive. This means, if the main menu and an open text editor are visible, the items probably shown will
 	/// be ~F1~ Help ~F2~ Save ~F3~ Load. While a dialog to ask a file to load is executed, the remaining commands will probably be ~F1~ Help.
 	/// So for each context must be a new instance of a statusbar.
 	/// </summary>
 	public class StatusBar : View {
-// After attempting to implement this, I noticed that there are hard dependencies
-// on StatusBar and MenuBars within core. They will need to be refactored for having the
-// StatusBar work at the top
+		// After attempting to implement this, I noticed that there are hard dependencies
+		// on StatusBar and MenuBars within core. They will need to be refactored for having the
+		// StatusBar work at the top
 #if SNAP_TO_TOP
 		/// <summary>
 		/// The style supported by StatusBar
@@ -86,18 +94,18 @@ namespace Terminal.Gui {
 		public StatusBarStyle Style { get; set; } = StatusBarStyle.Default;
 #endif
 		/// <summary>
-		/// The parent view of the StatusBar.
+		/// The parent view of the <see cref="StatusBar"/>.
 		/// </summary>
 		public View Parent { get; set; }
 
 		/// <summary>
-		/// The items that compose the StatusBar
+		/// The items that compose the <see cref="StatusBar"/>
 		/// </summary>
 		public StatusItem [] Items { get; set; }
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="T:Terminal.Gui.StatusBar"/> class with the specified set of statusbar items.
-		/// It will be drawn in the lowest line of the terminal.
+		/// Initializes a new instance of the <see cref="StatusBar"/> class with the specified set of <see cref="StatusItem"/>s.
+		/// The <see cref="StatusBar"/> will be drawn on the lowest line of the terminal or <see cref="StatusBar.Parent"/> (if not null).
 		/// </summary>
 		/// <param name="items">A list of statusbar items.</param>
 		public StatusBar (StatusItem [] items) : base ()

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -12,11 +12,10 @@ using NStack;
 
 namespace Terminal.Gui {
 	/// <summary>
-	///   Text data entry widget
+	///   Single-line text entry <see cref="View"/>
 	/// </summary>
 	/// <remarks>
-	///   The Entry widget provides Emacs-like editing
-	///   functionality,  and mouse support.
+	///   The <see cref="TextField"/> <see cref="View"/> provides editing functionality and mouse support.
 	/// </remarks>
 	public class TextField : View {
 		List<Rune> text;
@@ -85,6 +84,7 @@ namespace Terminal.Gui {
 			WantMousePositionReports = true;
 		}
 
+		///<inheritdoc cref="OnLeave"/>
 		public override bool OnLeave ()
 		{
 			if (Application.mouseGrabView != null && Application.mouseGrabView == this)
@@ -95,6 +95,7 @@ namespace Terminal.Gui {
 			return base.OnLeave ();
 		}
 
+		///<inheritdoc cref="Frame"/>
 		public override Rect Frame {
 			get => base.Frame;
 			set {
@@ -110,7 +111,7 @@ namespace Terminal.Gui {
 		bool isFromHistory;
 
 		/// <summary>
-		///   Sets or gets the text in the entry.
+		///   Sets or gets the text held by the view.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -180,6 +181,7 @@ namespace Terminal.Gui {
 			Move (col, 0);
 		}
 
+		///<inheritdoc cref="Redraw(Rect)"/>
 		public override void Redraw (Rect region)
 		{
 			ColorScheme color = Colors.Menu;
@@ -193,7 +195,7 @@ namespace Terminal.Gui {
 			int width = Frame.Width;
 			var tcount = text.Count;
 			var roc = new Attribute (Color.DarkGray, Color.Gray);
-			for (int idx = 0; idx < tcount; idx++){
+			for (int idx = 0; idx < tcount; idx++) {
 				var rune = text [idx];
 				if (idx < p)
 					continue;
@@ -251,6 +253,7 @@ namespace Terminal.Gui {
 			SetText (newText.ToList ());
 		}
 
+		///<inheritdoc cref="CanFocus"/>
 		public override bool CanFocus {
 			get => true;
 			set { base.CanFocus = value; }
@@ -262,6 +265,24 @@ namespace Terminal.Gui {
 				Clipboard.Contents = ustring.Make (text.ToList ());
 		}
 
+		/// <summary>
+		/// Processes key presses for the <see cref="TextField"/>.
+		/// </summary>
+		/// <param name="kb"></param>
+		/// <returns></returns>
+		/// <remarks>
+		/// The <see cref="TextField"/> control responds to the following keys:
+		/// <list type="table">
+		///    <listheader>
+		///        <term>Keys</term>
+		///        <description>Function</description>
+		///    </listheader>
+		///    <item>
+		///        <term><see cref="Key.Delete"/>, <see cref="Key.Backspace"/></term>
+		///        <description>Deletes the character before cursor.</description>
+		///    </item>
+		/// </list>
+		/// </remarks>
 		public override bool ProcessKey (KeyEvent kb)
 		{
 			// remember current cursor position
@@ -532,10 +553,10 @@ namespace Terminal.Gui {
 				return -1;
 
 			int i = p;
-			if (Rune.IsPunctuation (text [p]) || Rune.IsWhiteSpace(text [p])) {
+			if (Rune.IsPunctuation (text [p]) || Rune.IsWhiteSpace (text [p])) {
 				for (; i < text.Count; i++) {
 					var r = text [i];
-					if (Rune.IsLetterOrDigit(r))
+					if (Rune.IsLetterOrDigit (r))
 						break;
 				}
 				for (; i < text.Count; i++) {
@@ -565,7 +586,7 @@ namespace Terminal.Gui {
 				return 0;
 
 			var ti = text [i];
-			if (Rune.IsPunctuation (ti) || Rune.IsSymbol(ti) || Rune.IsWhiteSpace(ti)) {
+			if (Rune.IsPunctuation (ti) || Rune.IsSymbol (ti) || Rune.IsWhiteSpace (ti)) {
 				for (; i >= 0; i--) {
 					if (Rune.IsLetterOrDigit (text [i]))
 						break;
@@ -606,6 +627,7 @@ namespace Terminal.Gui {
 		int start, length;
 		bool isButtonReleased = true;
 
+		///<inheritdoc cref="MouseEvent(Gui.MouseEvent)"/>
 		public override bool MouseEvent (MouseEvent ev)
 		{
 			if (!ev.Flags.HasFlag (MouseFlags.Button1Pressed) && !ev.Flags.HasFlag (MouseFlags.ReportMousePosition) &&

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -169,11 +169,11 @@ namespace Terminal.Gui {
 	}
 
 	/// <summary>
-	///   Multi-line text editing view
+	///   Multi-line text editing <see cref="View"/>
 	/// </summary>
 	/// <remarks>
 	///   <para>
-	///     The text view provides a multi-line text view.   Users interact
+	///     <see cref="TextView"/> provides a multi-line text editor. Users interact
 	///     with it with the standard Emacs commands for movement or the arrow
 	///     keys. 
 	///   </para> 
@@ -283,7 +283,7 @@ namespace Terminal.Gui {
 		//bool used;
 
 		/// <summary>
-		/// Raised when the Text of the TextView changes.
+		/// Raised when the <see cref="Text"/> of the <see cref="TextView"/> changes.
 		/// </summary>
 		public event EventHandler TextChanged;
 
@@ -298,7 +298,7 @@ namespace Terminal.Gui {
 		public event EventHandler Changed;
 #endif
 		/// <summary>
-		///   Public constructor, creates a view on the specified area, with absolute position and size.
+		///   Initalizes a <see cref="TextView"/> on the specified area, with absolute position and size.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -308,7 +308,8 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Public constructor, creates a view on the specified area, with dimensions controlled with the X, Y, Width and Height properties.
+		///   Initalizes a <see cref="TextView"/> on the specified area, 
+		///   with dimensions controlled with the X, Y, Width and Height properties.
 		/// </summary>
 		public TextView () : base ()
 		{
@@ -321,7 +322,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Sets or gets the text in the entry.
+		///   Sets or gets the text in the <see cref="TextView"/>.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -339,7 +340,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Loads the contents of the file into the TextView.
+		/// Loads the contents of the file into the  <see cref="TextView"/>.
 		/// </summary>
 		/// <returns><c>true</c>, if file was loaded, <c>false</c> otherwise.</returns>
 		/// <param name="path">Path to the file to load.</param>
@@ -354,7 +355,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Loads the contents of the stream into the TextView.
+		/// Loads the contents of the stream into the  <see cref="TextView"/>.
 		/// </summary>
 		/// <returns><c>true</c>, if stream was loaded, <c>false</c> otherwise.</returns>
 		/// <param name="stream">Stream to load the contents from.</param>
@@ -368,7 +369,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Closes the contents of the stream into the TextView.
+		/// Closes the contents of the stream into the  <see cref="TextView"/>.
 		/// </summary>
 		/// <returns><c>true</c>, if stream was closed, <c>false</c> otherwise.</returns>
 		public bool CloseFile()
@@ -380,7 +381,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///    The current cursor row.
+		///    Gets the current cursor row.
 		/// </summary>
 		public int CurrentRow => currentRow;
 
@@ -429,7 +430,7 @@ namespace Terminal.Gui {
 		bool isReadOnly = false;
 
 		/// <summary>
-		/// Indicates readonly attribute of TextView
+		/// Gets or sets whether the  <see cref="TextView"/> is in read-only mode or not
 		/// </summary>
 		/// <value>Boolean value(Default false)</value>
 		public bool ReadOnly {
@@ -523,10 +524,7 @@ namespace Terminal.Gui {
 			SetNeedsDisplay ();
 		}
 
-		/// <summary>
-		/// Redraw the text editor region 
-		/// </summary>
-		/// <param name="region">The region to redraw.</param>
+		///<inheritdoc cref="Redraw(Rect)"/>
 		public override void Redraw (Rect region)
 		{
 			ColorNormal ();
@@ -701,7 +699,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Will scroll the view to display the specified row at the top
+		/// Will scroll the <see cref="TextView"/> to display the specified row at the top
 		/// </summary>
 		/// <param name="row">Row that should be displayed at the top, if the value is negative it will be reset to zero</param>
 		public void ScrollTo (int row)

--- a/Terminal.Gui/Views/TimeField.cs
+++ b/Terminal.Gui/Views/TimeField.cs
@@ -1,23 +1,20 @@
-﻿	//
+﻿//
 // TimeField.cs: text entry for time
 //
 // Author: Jörg Preiß
 //
 // Licensed under the MIT license
-//
 using System;
 using System.Globalization;
-using System.Collections.Generic;
 using System.Linq;
 using NStack;
 
 namespace Terminal.Gui {
-
 	/// <summary>
-	///   Time edit widget
+	///   Time editing <see cref="View"/>
 	/// </summary>
 	/// <remarks>
-	///   This widget provides time editing functionality, and mouse support.
+	///   The <see cref="TimeField"/> <see cref="View"/> provides time editing functionality with mouse support.
 	/// </remarks>
 	public class TimeField : TextField {
 		bool isShort;
@@ -32,7 +29,7 @@ namespace Terminal.Gui {
 
 
 		/// <summary>
-		///    Public constructor that creates a time edit field at an absolute position and fixed size.
+		///    Initializes a new instance of <see cref="TimeField"/> at an absolute position and fixed size.
 		/// </summary>
 		/// <param name="x">The x coordinate.</param>
 		/// <param name="y">The y coordinate.</param>
@@ -57,7 +54,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		///   Gets or sets the time in the widget.
+		///   Gets or sets the time of the <see cref="TimeField"/>.
 		/// </summary>
 		/// <remarks>
 		/// </remarks>
@@ -119,7 +116,7 @@ namespace Terminal.Gui {
 			Text = time;
 
 			if (!DateTime.TryParseExact (text.ToString (), Format, CultureInfo.CurrentCulture, DateTimeStyles.None, out DateTime result) ||
-				!isValidTime) 
+				!isValidTime)
 				return false;
 			return true;
 		}
@@ -146,6 +143,7 @@ namespace Terminal.Gui {
 				CursorPosition++;
 		}
 
+		///<inheritdoc cref="ProcessKey(KeyEvent)"/>
 		public override bool ProcessKey (KeyEvent kb)
 		{
 			switch (kb.Key) {
@@ -192,6 +190,7 @@ namespace Terminal.Gui {
 			return true;
 		}
 
+		///<inheritdoc cref="MouseEvent(Gui.MouseEvent)"/>
 		public override bool MouseEvent (MouseEvent ev)
 		{
 			if (!ev.Flags.HasFlag (MouseFlags.Button1Clicked))


### PR DESCRIPTION
I noticed that a lot of the API documentation was either

1. Missing
2. Out dated
3. Had poor English or grammar
4. Had missing  or incorrect`<see cref=""/>` tags

I decided to fix all that. I figured it'd give me an opportunity to study the source code some too.

As a result this PR touches almost every file containing a public API for `Terminal.Gui`.

