### PR TITLE
Removed redundant properties on MenuBar View

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -190,7 +190,7 @@ static class Demo {
 			new DateField (3, 22, DateTime.Now),
 			new DateField (23, 22, DateTime.Now, true),
 			progress,
-			new Label (3, 24, "Press F9 (on Unix, ESC+9 is an alias) to activate the menubar"),
+			new Label (3, 24, "Press F9 (on Unix, ESC+9 is an alias) or Ctrl+T to activate the menubar"),
 			menuKeysStyle,
 			menuAutoMouseNav
 
@@ -636,10 +636,23 @@ static class Demo {
 		};
 #endif
 
+		win.KeyPress += Win_KeyPress;
+
 
 		top.Add (win);
 		//top.Add (menu);
 		top.Add (menu, statusBar);
 		Application.Run ();
+	}
+
+	private static void Win_KeyPress (object sender, View.KeyEventEventArgs e)
+	{
+		if (e.KeyEvent.Key == Key.ControlT) {
+			if (menu.IsMenuOpen)
+				menu.CloseMenu ();
+			else
+				menu.OpenMenu ();
+			e.Handled = true;
+		}
 	}
 }

--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1087,6 +1087,11 @@ namespace Terminal.Gui {
 			/// The <see cref="KeyEvent"/> for the event.
 			/// </summary>
 			public KeyEvent KeyEvent { get; set; }
+			/// <summary>
+			/// Indicates if the current Key event has already been processed and the driver should stop notifying any other event subscriber.
+			/// Its important to set this value to true specially when updating any View's layout from inside the subscriber method.
+			/// </summary>
+			public bool Handled { get; set; } = false;
 		}
 
 		/// <summary>
@@ -1097,7 +1102,11 @@ namespace Terminal.Gui {
 		/// <inheritdoc cref="ProcessKey"/>
 		public override bool ProcessKey (KeyEvent keyEvent)
 		{
-			KeyPress?.Invoke (this, new KeyEventEventArgs(keyEvent));
+
+			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
+			KeyPress?.Invoke (this, args);
+			if (args.Handled)
+				return true;
 			if (Focused?.ProcessKey (keyEvent) == true)
 				return true;
 
@@ -1107,7 +1116,10 @@ namespace Terminal.Gui {
 		/// <inheritdoc cref="ProcessHotKey"/>
 		public override bool ProcessHotKey (KeyEvent keyEvent)
 		{
-			KeyPress?.Invoke (this, new KeyEventEventArgs (keyEvent));
+			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
+			KeyPress?.Invoke (this, args);
+			if (args.Handled)
+				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;
 			foreach (var view in subviews)
@@ -1119,7 +1131,10 @@ namespace Terminal.Gui {
 		/// <inheritdoc cref="ProcessColdKey"/>
 		public override bool ProcessColdKey (KeyEvent keyEvent)
 		{
-			KeyPress?.Invoke (this, new KeyEventEventArgs(keyEvent));
+			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
+			KeyPress?.Invoke (this, args);
+			if (args.Handled)
+				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;
 			foreach (var view in subviews)
@@ -1136,7 +1151,10 @@ namespace Terminal.Gui {
 		/// <param name="keyEvent">Contains the details about the key that produced the event.</param>
 		public override bool OnKeyDown (KeyEvent keyEvent)
 		{
-			KeyDown?.Invoke (this, new KeyEventEventArgs (keyEvent));
+			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
+			KeyDown?.Invoke (this, args);
+			if (args.Handled)
+				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;
 			foreach (var view in subviews)
@@ -1154,7 +1172,10 @@ namespace Terminal.Gui {
 		/// <param name="keyEvent">Contains the details about the key that produced the event.</param>
 		public override bool OnKeyUp (KeyEvent keyEvent)
 		{
-			KeyUp?.Invoke (this, new KeyEventEventArgs (keyEvent));
+			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
+			KeyUp?.Invoke (this, args);
+			if (args.Handled)
+				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;
 			foreach (var view in subviews)


### PR DESCRIPTION
*This commit is intended to make some refactoring on the MenuBar View, to make it more consistent and intuitive, and to remove redundant members in order to improve code maintenance and usability.*

Currently, the `MenuBar` view has two members for storing opposite states for the "Is Menu Open?" logical question. Those members are: `isMenuClosed` and `MenuOpen`. The second storing the negated value of the first, but without any automatic logic handling implemented. This means that in any point in time those two members could become desync and introduce bugs to the View, also code maintainability suffers by requiring to update two internal states with opposite logic values each time the Menu states changes.

Consider applying this commit to enhance the usability and code maintenance on the `MenuBar` view.

- Redundant members `isMenuClosed` and `MenuOpen` were replaced with a more consistent and intuitive single `IsMenuOpen` property.
- `CloseMenu` method is now Public.
- `StartMenu` has been renamed to `OpenMenu` and made Public.
+ Added missing XmlDoc to `OpenMenu` and `CloseMenu`, and fixed an small typo to `MenuOpen/IsMenuOpen`.

**Warning: This commit breaks compatibility with previous versions.**

**Changes required to host apps:**

`MenuBar.MenuOpen` property renamed to `IsMenuOpen`
`MenuBar.StartMenu` method renamed to `OpenMenu`, use it to open the Menu
Use `MenuBar.CloseMenu` to close the active menu.