### PR TITLE
Removes command line param from UICatalog project

### DIFF
--- a/UICatalog/Properties/launchSettings.json
+++ b/UICatalog/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "UICatalog": {
-      "commandName": "Project",
-      "commandLineArgs": "\"Unicode\""
+      "commandName": "Project"
     }
   }
 }


### PR DESCRIPTION
I accidentally left this in. There is no way to exclude changes to `launchSettings.json` on a per-dev basis, which is really annoying. 