### PR TITLE
Upgraded ScrollView + Charmap

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -335,12 +335,12 @@ static class Demo {
 			$"{mi.Title.ToString ()} selected. Is from submenu: {mi.GetMenuBarItem ()}", "Ok");
 	}
 
-	static void MenuKeysStyle_Toggled (object sender, EventArgs e)
+	static void MenuKeysStyle_Toggled (object sender, bool e)
 	{
 		menu.UseKeysUpDownAsKeysLeftRight = menuKeysStyle.Checked;
 	}
 
-	static void MenuAutoMouseNav_Toggled (object sender, EventArgs e)
+	static void MenuAutoMouseNav_Toggled (object sender, bool e)
 	{
 		menu.WantMousePositionReports = menuAutoMouseNav.Checked;
 	}

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -909,7 +909,32 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Focuses the specified sub-view.
+		/// Event invoked when the content area of the View is to be drawn.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Will be invoked before any subviews added with <see cref="Add(View)"/> have been drawn.
+		/// </para>
+		/// <para>
+		/// Rect provides the view-relative rectangle describing the currently visible viewport into the <see cref="View"/>.
+		/// </para>
+		/// </remarks>
+		public event EventHandler<Rect> DrawContent;
+
+		/// <summary>
+		/// Enables overrides to draw infinitely scrolled content and/or a background behind added controls. 
+		/// </summary>
+		/// <param name="viewport">The view-relative rectangle describing the currently visible viewport into the <see cref="View"/></param>
+		/// <remarks>
+		/// This method will be called before any subviews added with <see cref="Add(View)"/> have been drawn. 
+		/// </remarks>
+		public virtual void OnDrawContent (Rect viewport)
+		{
+			DrawContent?.Invoke (this, viewport);
+		}
+
+		/// <summary>
+		/// Causes the specified subview to have focus.
 		/// </summary>
 		/// <param name="view">View.</param>
 		public void SetFocus (View view)

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -78,6 +78,15 @@
       * More robust error handing in Pos/Dim. Fixes #355 stack overflow with Pos based on the size of windows at startup. Added a OnResized action to set the Pos after the terminal are resized. (Thanks @bdisp!)
       * Fixes #389 Window layouting breaks when resizing. (Thanks @bdisp!)
       * Fixes #557 MessageBox needs to take ustrings (BREAKING CHANGE). (Thanks @tig!)
+      * Fixes ScrollView in several key ways. (Thanks @tig!)
+      *   Now supports Computed layout and has constructors that don't require parameters.
+      *   ScrollBarViews are now positioned using Computed layout versus error prone absoulte
+      *   ScrollBarViews now correctly position themselves when one, either, or both are on/off.
+      *   IsVertical is now a public property that does the expected thing when changed
+      *   Mouse handling is better; there's still a bug where the mouse doesn't get grabbed by the ScrollView initially but I think this is a broader problem. I need @BDisp's help on this.
+      *   Supports "infinite scrolling" via the new OnDrawContent/DrawContent event on the View class.
+      *   The Scrolling Scenario was enhanced to demo dynamically adding/removing horizontal/vertical scrollbars (and to prove it was working right).
+      * The Checkbox.Toggled event is now an EventHandler event and passes previous state. (Thanks @tig!)
 
       0.81:
       * Fix ncurses engine for macOS/Linux, it works again

--- a/Terminal.Gui/Views/Checkbox.cs
+++ b/Terminal.Gui/Views/Checkbox.cs
@@ -23,9 +23,16 @@ namespace Terminal.Gui {
 		/// <remarks>
 		///   Client code can hook up to this event, it is
 		///   raised when the <see cref="CheckBox"/> is activated either with
-		///   the mouse or the keyboard.
+		///   the mouse or the keyboard. The passed <c>bool</c> contains the previous state. 
 		/// </remarks>
-		public event EventHandler Toggled;
+		public event EventHandler<bool> Toggled;
+
+		/// <summary>
+		/// Called when the <see cref="Checked"/> property changes. Invokes the <see cref="Toggled"/> event.
+		/// </summary>
+		public virtual void OnToggled (bool previousChecked) {
+			Toggled?.Invoke (this, previousChecked);
+		}
 
 		/// <summary>
 		/// Initializes a new instance of <see cref="CheckBox"/> based on the given text, uses Computed layout and sets the height and width.
@@ -122,11 +129,9 @@ namespace Terminal.Gui {
 		public override bool ProcessKey (KeyEvent kb)
 		{
 			if (kb.KeyValue == ' ') {
+				var previousChecked = Checked;
 				Checked = !Checked;
-
-				if (Toggled != null)
-					Toggled (this, EventArgs.Empty);
-
+				OnToggled (previousChecked);
 				SetNeedsDisplay ();
 				return true;
 			}
@@ -140,11 +145,11 @@ namespace Terminal.Gui {
 				return false;
 
 			SuperView.SetFocus (this);
+			var previousChecked = Checked;
 			Checked = !Checked;
+			OnToggled (previousChecked);
 			SetNeedsDisplay ();
 
-			if (Toggled != null)
-				Toggled (this, EventArgs.Empty);
 			return true;
 		}
 	}

--- a/UICatalog/Scenarios/Buttons.cs
+++ b/UICatalog/Scenarios/Buttons.cs
@@ -118,6 +118,16 @@ namespace UICatalog {
 			};
 			Win.Add (moveBtn);
 
+			// Demonstrates how changing the View.Frame property can SIZE Views (#583)
+			y += 2;
+			var sizeBtn = new Button (10, y, "Size This Button via Frame") {
+				ColorScheme = Colors.Error,
+			};
+			moveBtn.Clicked = () => {
+				sizeBtn.Frame = new Rect (sizeBtn.Frame.X, sizeBtn.Frame.Y, sizeBtn.Frame.Width + 5, sizeBtn.Frame.Height);
+			};
+			Win.Add (sizeBtn);
+
 			// Demo changing hotkey
 			ustring MoveHotkey (ustring txt)
 			{

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -1,0 +1,121 @@
+﻿using NStack;
+using System.Collections.Generic;
+using System.Text;
+using Terminal.Gui;
+
+namespace UICatalog {
+	/// <summary>
+	/// This Scenario demonstrates building a custom control (a class deriving from View) that:
+	///   - Provides a simple "Character Map" application (like Windows' charmap.exe).
+	///   - Helps test unicode character rendering in Terminal.Gui
+	///   - Illustrates how to use ScrollView to do infinite scrolling
+	/// </summary>
+	[ScenarioMetadata (Name: "Character Map", Description: "Illustrates a custom control and Unicode")]
+	[ScenarioCategory ("Text")]
+	[ScenarioCategory ("Controls")]
+	class CharacterMap : Scenario {
+		public override void Setup ()
+		{
+			var charMap = new CharMap () { X = 1, Y = 1, Width = Dim.Percent(75), Height = 16, Start = 0x2500 };
+
+			Win.Add (charMap);
+
+			var button = new Button ("Box Drawing & Geometric Shapes U+2500-25ff") { X = Pos.X (charMap), Y = Pos.Bottom (charMap) + 1,
+				Clicked = () => {
+					charMap.Start = 0x2500;
+				}
+			};
+			Win.Add (button);
+
+			button = new Button ("Dingbats U+2700-27ff") {
+				X = Pos.X (charMap),
+				Y = Pos.Bottom (button),
+				Clicked = () => {
+					charMap.Start = 0x2700;
+				}
+			};
+			Win.Add (button);
+
+			button = new Button ("Miscellaneous Symbols and Arrows U+2b00-2bff") {
+				X = Pos.X (charMap),
+				Y = Pos.Bottom (button),
+				Clicked = () => {
+					charMap.Start = 0x2b00;
+				}
+			};
+			Win.Add (button);
+
+			button = new Button ("Arrows U+2190-21ff") {
+				X = Pos.X (charMap),
+				Y = Pos.Bottom (button),
+				Clicked = () => {
+					charMap.Start = 0x2190;
+				}
+			};
+			Win.Add (button);
+		}
+	}
+
+	class CharMap : ScrollView {
+
+		/// <summary>
+		/// Specifies the starting offset for the character map. The default is 0x2500 
+		/// which is the Box Drawing characters.
+		/// </summary>
+		public int Start {
+			get => _start;
+			set {
+				_start = value;
+				ContentOffset = new Point (0, _start / 16);
+
+				SetNeedsDisplay ();
+			}
+		}
+		int _start = 0x2500;
+
+		// Row Header + space + (space + char + space)
+		public static int RowHeaderWidth => "U+000x".Length;
+		public static int RowWidth => RowHeaderWidth + 1 + (" c ".Length * 16);
+
+		public CharMap ()
+		{
+			ContentSize = new Size (CharMap.RowWidth, int.MaxValue / 16);
+			ShowVerticalScrollIndicator = true;
+			ShowHorizontalScrollIndicator = false;
+			LayoutComplete += (sender, args) => {
+				if (Bounds.Width <= RowWidth) {
+					ShowHorizontalScrollIndicator = true;
+				} else {
+					ShowHorizontalScrollIndicator = false;
+				}
+			};
+
+			DrawContent += CharMap_DrawContent;
+		}
+
+#if true
+		private void CharMap_DrawContent (object sender, Rect viewport)
+		{
+			for (int header = 0; header < 16; header++) {
+				Move (viewport.X + RowHeaderWidth + 1 + (header * 3), 0);
+				Driver.AddStr ($" {header:x} ");
+			}
+			for (int row = 0; row < viewport.Height - 1; row++) {
+				var rowLabel = $"U+{(((-viewport.Y + row) * 16)) / 16:x}x";
+				Move (0, row + 1);
+				Driver.AddStr (rowLabel);
+				for (int col = 0; col < 16; col++) {
+					Move (viewport.X + (RowHeaderWidth + 1 + (col * 3)), 0 + row + 1);
+					Driver.AddStr ($" {(char)(((-viewport.Y + row) * 16) + col)} ");
+				}
+			}
+		}
+#else
+		public override void OnDrawContent (Rect viewport)
+		{
+			CharMap_DrawContent(this, viewport);
+			base.OnDrawContent (viewport);
+		}
+#endif
+	}
+}

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -16,43 +16,40 @@ namespace UICatalog {
 	class CharacterMap : Scenario {
 		public override void Setup ()
 		{
-			var charMap = new CharMap () { X = 1, Y = 1, Width = Dim.Percent(75), Height = 16, Start = 0x2500 };
+			var charMap = new CharMap () { X = 0, Y = 0, Width = CharMap.RowWidth + 2, Height = Dim.Fill(), Start = 0x2500, 
+				ColorScheme = Colors.Dialog};
 
 			Win.Add (charMap);
 
-			var button = new Button ("Box Drawing & Geometric Shapes U+2500-25ff") { X = Pos.X (charMap), Y = Pos.Bottom (charMap) + 1,
-				Clicked = () => {
-					charMap.Start = 0x2500;
-				}
+			Button CreateBlock(Window win, ustring title, int start, int end, View align)
+			{
+				var button = new Button ($"{title} (U+{start:x5}-{end:x5})") {
+					X = Pos.X (align),
+					Y = Pos.Bottom (align),
+					Clicked = () => {
+						charMap.Start = start;
+					},
+				};
+				win.Add (button);
+				return button;
 			};
-			Win.Add (button);
 
-			button = new Button ("Dingbats U+2700-27ff") {
-				X = Pos.X (charMap),
-				Y = Pos.Bottom (button),
-				Clicked = () => {
-					charMap.Start = 0x2700;
-				}
-			};
-			Win.Add (button);
-
-			button = new Button ("Miscellaneous Symbols and Arrows U+2b00-2bff") {
-				X = Pos.X (charMap),
-				Y = Pos.Bottom (button),
-				Clicked = () => {
-					charMap.Start = 0x2b00;
-				}
-			};
-			Win.Add (button);
-
-			button = new Button ("Arrows U+2190-21ff") {
-				X = Pos.X (charMap),
-				Y = Pos.Bottom (button),
-				Clicked = () => {
-					charMap.Start = 0x2190;
-				}
-			};
-			Win.Add (button);
+			var label = new Label ("Unicode Blocks:") { X = Pos.Right (charMap) + 2, Y = Pos.Y (charMap) };
+			Win.Add (label);
+			var button = CreateBlock (Win, "Currency Symbols", 0x20A0, 0x20CF, label);
+			button = CreateBlock (Win, "Letterlike Symbols", 0x2100, 0x214F, button);
+			button = CreateBlock (Win, "Arrows", 0x2190, 0x21ff, button);
+			button = CreateBlock (Win, "Mathematical symbols", 0x2200, 0x22ff, button);
+			button = CreateBlock (Win, "Miscellaneous Technical", 0x2300, 0x23ff, button);
+			button = CreateBlock (Win, "Box Drawing & Geometric Shapes", 0x2500, 0x25ff, button);
+			button = CreateBlock (Win, "Miscellaneous Symbols", 0x2600, 0x26ff, button);
+			button = CreateBlock (Win, "Dingbats", 0x2700, 0x27ff, button);
+			button = CreateBlock (Win, "Braille", 0x2800, 0x28ff, button);
+			button = CreateBlock (Win, "Miscellaneous Symbols and Arrows", 0x2b00, 0x2bff, button);
+			button = CreateBlock (Win, "Alphabetic Presentation Forms", 0xFB00, 0xFb4f, button);
+			button = CreateBlock (Win, "Cuneiform Numbers and Punctuation[1", 0x12400, 0x1240f, button);
+			button = CreateBlock (Win, "Chess Symbols", 0x1FA00, 0x1FA0f, button);
+			button = CreateBlock (Win, "End", CharMap.MaxCodePointVal - 16, CharMap.MaxCodePointVal, button);
 		}
 	}
 
@@ -73,13 +70,15 @@ namespace UICatalog {
 		}
 		int _start = 0x2500;
 
+		public static int MaxCodePointVal => 0xE0FFF;
+
 		// Row Header + space + (space + char + space)
-		public static int RowHeaderWidth => "U+000x".Length;
+		public static int RowHeaderWidth => $"U+{MaxCodePointVal:x5}".Length;
 		public static int RowWidth => RowHeaderWidth + 1 + (" c ".Length * 16);
 
 		public CharMap ()
 		{
-			ContentSize = new Size (CharMap.RowWidth, int.MaxValue / 16);
+			ContentSize = new Size (CharMap.RowWidth, MaxCodePointVal / 16);
 			ShowVerticalScrollIndicator = true;
 			ShowHorizontalScrollIndicator = false;
 			LayoutComplete += (sender, args) => {
@@ -101,12 +100,15 @@ namespace UICatalog {
 				Driver.AddStr ($" {header:x} ");
 			}
 			for (int row = 0; row < viewport.Height - 1; row++) {
-				var rowLabel = $"U+{(((-viewport.Y + row) * 16)) / 16:x}x";
-				Move (0, row + 1);
-				Driver.AddStr (rowLabel);
-				for (int col = 0; col < 16; col++) {
-					Move (viewport.X + (RowHeaderWidth + 1 + (col * 3)), 0 + row + 1);
-					Driver.AddStr ($" {(char)(((-viewport.Y + row) * 16) + col)} ");
+				int val = (-viewport.Y + row) * 16;
+				if (val < MaxCodePointVal) {
+					var rowLabel = $"U+{val / 16:x4}x";
+					Move (0, row + 1);
+					Driver.AddStr (rowLabel);
+					for (int col = 0; col < 16; col++) {
+						Move (viewport.X + RowHeaderWidth + 1 + (col * 3), 0 + row + 1);
+						Driver.AddStr ($" {(char)((-viewport.Y + row) * 16 + col)} ");
+					}
 				}
 			}
 		}

--- a/UICatalog/Scenarios/Scrolling.cs
+++ b/UICatalog/Scenarios/Scrolling.cs
@@ -20,12 +20,13 @@ namespace UICatalog {
 			Win.Add (label);
 
 			// BUGBUG: ScrollView only supports Absolute Positioning (#72)
-			var scrollView = new ScrollView (new Rect (2, 2, 50, 20));
-			scrollView.ColorScheme = Colors.TopLevel;
-			scrollView.ContentSize = new Size (200, 100);
-			//ContentOffset = new Point (0, 0),
-			scrollView.ShowVerticalScrollIndicator = true;
-			scrollView.ShowHorizontalScrollIndicator = true;
+			var scrollView = new ScrollView (new Rect (2, 2, 50, 20)) {
+				ColorScheme = Colors.TopLevel,
+				ContentSize = new Size (200, 100),
+				//ContentOffset = new Point (0, 0),
+				ShowVerticalScrollIndicator = true,
+				ShowHorizontalScrollIndicator = true,
+			};
 
 			const string rule = "|123456789";
 			var horizontalRuler = new Label ("") {
@@ -101,7 +102,62 @@ namespace UICatalog {
 			};
 			scrollView.Add (anchorButton);
 
-			Win.Add (scrollView);
+			var hCheckBox = new CheckBox ("Horizontal Scrollbar", scrollView.ShowHorizontalScrollIndicator) {
+				X = Pos.X(scrollView),
+				Y = Pos.Bottom(scrollView) + 1,
+			};
+			hCheckBox.Toggled += (sender, previousChecked) => {
+				scrollView.ShowHorizontalScrollIndicator = ((CheckBox)sender).Checked;
+			};
+			Win.Add (hCheckBox);
+
+			var vCheckBox = new CheckBox ("Vertical Scrollbar", scrollView.ShowVerticalScrollIndicator) {
+				X = Pos.Right (hCheckBox) + 3,
+				Y = Pos.Bottom (scrollView) + 1,
+			};
+			vCheckBox.Toggled += (sender, previousChecked) => {
+				scrollView.ShowVerticalScrollIndicator = ((CheckBox)sender).Checked;
+			};
+			Win.Add (vCheckBox);
+
+			var scrollView2 = new ScrollView (new Rect (55, 2, 20, 8)) {
+				ContentSize = new Size (20, 50),
+				//ContentOffset = new Point (0, 0),
+				ShowVerticalScrollIndicator = true,
+				ShowHorizontalScrollIndicator = true
+			};
+			scrollView2.Add (new Filler (new Rect (0, 0, 60, 40)));
+
+			// This is just to debug the visuals of the scrollview when small
+			var scrollView3 = new ScrollView (new Rect (55, 15, 3, 3)) {
+				ContentSize = new Size (100, 100),
+				ShowVerticalScrollIndicator = true,
+				ShowHorizontalScrollIndicator = true
+			};
+			scrollView3.Add (new Box10x (0, 0));
+
+			int count = 0;
+			var mousePos = new Label ("Mouse: ");
+			mousePos.X = Pos.Center ();
+			mousePos.Y = Pos.AnchorEnd (1);
+			mousePos.Width = 50;
+			Application.RootMouseEvent += delegate (MouseEvent me) {
+				mousePos.TextColor = Colors.TopLevel.Normal;
+				mousePos.Text = $"Mouse: ({me.X},{me.Y}) - {me.Flags} {count++}";
+			};
+
+			var progress = new ProgressBar ();
+			progress.X = 5;
+			progress.Y = Pos.AnchorEnd (2);
+			progress.Width = 50;
+			bool timer (MainLoop caller)
+			{
+				progress.Pulse ();
+				return true;
+			}
+			Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (300), timer);
+
+			Win.Add (scrollView, scrollView2, scrollView3, mousePos, progress);
 		}
 	}
 }

--- a/UICatalog/Scenarios/TextAlignments.cs
+++ b/UICatalog/Scenarios/TextAlignments.cs
@@ -6,7 +6,7 @@ using Terminal.Gui;
 namespace UICatalog {
 	[ScenarioMetadata (Name: "Text Alignment", Description: "Demonstrates text alignment")]
 	[ScenarioCategory ("Text")]
-	class TextAlignment : Scenario {
+	class TextAlignments : Scenario {
 		public override void Setup ()
 		{
 			int i = 1;

--- a/UICatalog/Scenarios/Unicode.cs
+++ b/UICatalog/Scenarios/Unicode.cs
@@ -27,14 +27,9 @@ namespace UICatalog {
 			});
 			Top.Add (menu);
 
-			var label = new Label ("Button:") { X = margin, Y = margin };
+			var label = new Label ("Button:") { X = 0, Y = 1 };
 			Win.Add (label);
-			var button = new Button (" ~  s  gui.cs   master ↑10") { X = 15, Y = Pos.Y (label) };
-			Win.Add (button);
-
-			label = new Label ("Button:") { X = Pos.X (label), Y = Pos.Bottom (label) + 1 };
-			Win.Add (label);
-			var button2 = new Button ("Со_хранить") { X = 15, Y = Pos.Y (label), Width = Dim.Percent (50) };
+			var button2 = new Button ("Со_хранить") { X = 15, Y = Pos.Y (label), Width = Dim.Percent (50), };
 			Win.Add (button2);
 
 			label = new Label ("CheckBox:") { X = Pos.X (label), Y = Pos.Bottom (label) + 1 };


### PR DESCRIPTION
Note this PR should not be merged until after #600 is in. 

I went on a rampage tonight. It all started with wanting to use more/better characters for frame and other UI elements like the round corners:

![image](https://user-images.githubusercontent.com/585482/83601742-659ba800-a52e-11ea-9ee9-c888a7db5444.png)

I decided I needed a character map app that would let me test which fonts had which Unicode sets in them.

As a result we have this PR

- Fixes `ScrollView` in several key ways:
   - It now supports Computed layout and has constructors that don't require parameters.
   - `ScrollBarViews` are now positioned using Computed layout versus error prone absoulte
   - `ScrollBarViews` now correctly position themselves when one, either, or both are on/off.
   - `IsVertical` is now a public property that does the expected thing when changed
   - Mouse handling is better; there's still a bug where the mouse doesn't get grabbed by the `ScrollView` initially but I think this is a broader problem. I need @BDisp's help on this.

- The `Scrolling` Scenario was enhanced to demo dynamically adding/removing horizontal/vertical scrollbars (and to prove it was working right).

- I Enabled easy "infinite scroll capability" - CharMap literally lets you scroll over `int.MaxValue / 16` rows of data. Filling a `ContentView` with all of this and panning it around won't work. So I needed a way of having `Redraw` give me virtual coordinates. I did this by defining `OnDrawContent(Rect viewport)` and it's associated `event`:

```csharp
/// <summary>
/// Event invoked when the content area of the View is to be drawn.
/// </summary>
/// <remarks>
/// <para>
/// Will be invoked before any subviews added with <see cref="Add(View)"/> have been drawn.
/// </para>
/// <para>
/// Rect provides the view-relative rectangle describing the currently visible viewport into the <see cref="View"/>.
/// </para>
/// </remarks>
public event EventHandler<Rect> DrawContent;

/// <summary>
/// Enables overrides to draw infinitely scrolled content and/or a background behind added controls. 
/// </summary>
/// <param name="viewport">The view-relative rectangle describing the currently visible viewport into the <see cref="View"/></param>
/// <remarks>
/// This method will be called before any subviews added with <see cref="Add(View)"/> have been drawn. 
/// </remarks>
public virtual void OnDrawContent (Rect viewport)
{
	DrawContent?.Invoke (this, viewport);
}

```

I originally just implemented this pattern in `ScrollView`. Then I realized I wanted the same thing out of ALL `Views`. Namely: the ability to do drawing on an event, particularly to be able to paint something in the background. So I added it to `View`.

Note, that these changes mean we are about 3 small steps away from moving the scollbars from `ScrollView` into ALL views. Which makes a lot of sense to me because I don't think we want to implement duplicative logic in, say `ListView` and `TextView` as well. Why not just do it once?

Along the way I fixed some other things:

- The `Checkbox.Toggled` event now passes state. 

Here's some gifs. 
![](https://i.imgur.com/o5nP5Lo.gif)

Note:

- Scrollbars appear dynamically.
- Fast scrolling of huge data (using no memory).
- Static header
- Dynamic scrollbars on/off
- Note the bottom/right corner now draw correctly in all situations

