### PR TITLE
Removing SauceControl.InheritDoc nuget from the build

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -181,10 +181,4 @@
   <ItemGroup>
     <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="SauceControl.InheritDoc" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
In #608 I added this tool to make generating "inherited docs" (`/// <inhertidoc/>') work with docfx.

It works wonderfully, but is annoying to have as part of the standard build process. When you have an error it's very difficult to figure it out.

So I'm going to make it part of the process for regenerating the API docs which will eventually be a github action on a PR merge.

