### PR TITLE
Added ConsoleDriver.GetFont and Windows' impl.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -17,7 +17,6 @@ namespace Terminal.Gui {
 	/// This is the Curses driver for the gui.cs/Terminal framework.
 	/// </summary>
 	internal class CursesDriver : ConsoleDriver {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 		public override int Cols => Curses.Cols;
 		public override int Rows => Curses.Lines;
 
@@ -694,6 +693,11 @@ namespace Terminal.Gui {
 			//mouseGrabbed = false;
 			//Curses.mouseinterval (lastMouseInterval);
 		}
+
+		public override ConsoleFont GetFont ()
+		{
+			return null;
+		}
 	}
 
 	internal static class Platform {
@@ -755,7 +759,6 @@ namespace Terminal.Gui {
 			killpg (0, signal);
 			return true;
 		}
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 	}
 
 }

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -464,6 +464,15 @@ namespace Terminal.Gui {
 		{
 		}
 
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <returns></returns>
+		public override ConsoleFont GetFont ()
+		{
+			return null;
+		}
+
 		AutoResetEvent keyReady = new AutoResetEvent (false);
 		AutoResetEvent waitForProbe = new AutoResetEvent (false);
 		ConsoleKeyInfo? windowsKeyResult = null;

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -381,6 +381,11 @@ namespace Terminal.Gui {
 		{
 		}
 
+		public override ConsoleFont GetFont ()
+		{
+			return null;
+		}
+
 		//
 		// These are for the .NET driver, but running natively on Windows, wont run
 		// on the Mono emulation

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -8,6 +8,7 @@
 using NStack;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -889,6 +890,12 @@ namespace Terminal.Gui {
 		public abstract void CookMouse ();
 
 		/// <summary>
+		/// Gets the current font set for the console.
+		/// </summary>
+		/// <returns>The Font for the current console. <c>null</c> if the console driver does not support querying the font.</returns>
+		public abstract ConsoleFont GetFont ();
+
+		/// <summary>
 		/// Horizontal line character.
 		/// </summary>
 		public Rune HLine;
@@ -1025,5 +1032,25 @@ namespace Terminal.Gui {
 		/// <param name="back">Background.</param>
 		/// <returns></returns>
 		public abstract Attribute MakeAttribute (Color fore, Color back);
+
+		/// <summary>
+		/// Contains information for a console font.
+		/// </summary>
+		public class ConsoleFont {
+			/// <summary>
+			/// The name of the typeface (such as Courier or Arial).
+			/// </summary>
+			public string FaceName;
+
+			/// <summary>
+			/// The font weight. The weight can range from 100 to 1000, in multiples of 100. For example, the normal weight is 400, while 700 is bold.
+			/// </summary>
+			public int Weight;
+
+			/// <summary>
+			/// Contains the width and height of each character in the font, in logical units. The X member contains the width, while the Y member contains the height.
+			/// </summary>
+			public Size Size;
+		}
 	}
 }

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -890,6 +890,26 @@ namespace Terminal.Gui {
 		public abstract void CookMouse ();
 
 		/// <summary>
+		/// Contains information for a console font.
+		/// </summary>
+		public class ConsoleFont {
+			/// <summary>
+			/// The name of the typeface (such as Courier or Arial).
+			/// </summary>
+			public string FaceName;
+
+			/// <summary>
+			/// The font weight. The weight can range from 100 to 1000, in multiples of 100. For example, the normal weight is 400, while 700 is bold.
+			/// </summary>
+			public int Weight;
+
+			/// <summary>
+			/// Contains the width and height of each character in the font, in logical units. The X member contains the width, while the Y member contains the height.
+			/// </summary>
+			public Size Size;
+		}
+
+		/// <summary>
 		/// Gets the current font set for the console.
 		/// </summary>
 		/// <returns>The Font for the current console. <c>null</c> if the console driver does not support querying the font.</returns>
@@ -1032,25 +1052,5 @@ namespace Terminal.Gui {
 		/// <param name="back">Background.</param>
 		/// <returns></returns>
 		public abstract Attribute MakeAttribute (Color fore, Color back);
-
-		/// <summary>
-		/// Contains information for a console font.
-		/// </summary>
-		public class ConsoleFont {
-			/// <summary>
-			/// The name of the typeface (such as Courier or Arial).
-			/// </summary>
-			public string FaceName;
-
-			/// <summary>
-			/// The font weight. The weight can range from 100 to 1000, in multiples of 100. For example, the normal weight is 400, while 700 is bold.
-			/// </summary>
-			public int Weight;
-
-			/// <summary>
-			/// Contains the width and height of each character in the font, in logical units. The X member contains the width, while the Y member contains the height.
-			/// </summary>
-			public Size Size;
-		}
 	}
 }

--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -181,7 +181,11 @@ namespace Terminal.Gui {
 					}
 					Driver.AddRune (title [n]);
 				}
-				Driver.AddRune (' ');
+				if (i + 1 < Items.Length) {
+					Driver.AddRune (' ');
+					Driver.AddRune (Driver.VLine);
+					Driver.AddRune (' ');
+				}
 			}
 		}
 

--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -181,11 +181,7 @@ namespace Terminal.Gui {
 					}
 					Driver.AddRune (title [n]);
 				}
-				if (i + 1 < Items.Length) {
-					Driver.AddRune (' ');
-					Driver.AddRune (Driver.VLine);
-					Driver.AddRune (' ');
-				}
+				Driver.AddRune (' ');
 			}
 		}
 

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -266,6 +266,11 @@ namespace UICatalog {
 			_numlock = new StatusItem (Key.CharMask, "Numlock", null);
 			_scrolllock = new StatusItem (Key.CharMask, "Scrolllock", null);
 
+			ConsoleDriver.ConsoleFont consoleFont = Application.Driver.GetFont ();
+			StatusItem font = new StatusItem (Key.Unknown, $"Console driver does not support querying font.", null); ;
+			if (consoleFont != null) {
+				font = new StatusItem (Key.Unknown, $"Console Font: {consoleFont.FaceName}, {consoleFont.Weight}, {consoleFont.Size.Width}x{consoleFont.Size.Height}", null);
+			}
 			_statusBar = new StatusBar (new StatusItem [] {
 				new StatusItem(Key.ControlQ, "~CTRL-Q~ Quit", () => {
 					if (_runningScenario is null){
@@ -278,7 +283,8 @@ namespace UICatalog {
 				}),
 				_capslock,
 				_numlock,
-				_scrolllock
+				_scrolllock,
+				font
 			});
 
 			SetColorScheme ();


### PR DESCRIPTION
This PR adds a new API to `ConsoleDriver`:

```csharp
/// <summary>
/// Contains information for a console font.
/// </summary>
public class ConsoleFont {
	/// <summary>
	/// The name of the typeface (such as Courier or Arial).
	/// </summary>
	public string FaceName;

	/// <summary>
	/// The font weight. The weight can range from 100 to 1000, in multiples of 100. For example, the normal weight is 400, while 700 is bold.
	/// </summary>
	public int Weight;

	/// <summary>
	/// Contains the width and height of each character in the font, in logical units. The X member contains the width, while the Y member contains the height.
	/// </summary>
	public Size Size;
}

/// <summary>
/// Gets the current font set for the console.
/// </summary>
/// <returns>The Font for the current console. <c>null</c> if the console driver does not support querying the font.</returns>
public abstract ConsoleFont GetFont ();
```

And it implements this for `WindowsDriver`. 

`UI Catalog` is updated to show the current font on the `StatusBar`:

![](https://i.imgur.com/EOCoMFv.png)

I've added this API in preparation for a feature I want to add to `ConsoleDriver` that will allow it to be intelligent about using Unicode glyphs beyond the boring, standard, least-common-denominator set currently defined. If, for example, the driver knows that `Cascadia Code` is being used, it knows it can use glyphs available in that font, like some of these:

![image](https://user-images.githubusercontent.com/585482/84220169-6d5bcf00-aa8f-11ea-97af-e5a0ade1c7ef.png)

I designed the API to be implementable across platforms. I don't know if there's an easy way to get Linux or Mac to directly provide the current terminal font, but I'm confident there's a WAY. If Windows didn't provide the `GetCurrentConsoleFontEx` API, I was prepared to go look in the registry or wherever...

Thoughts?