### PR TITLE
workaround for lifecycle bug introduced in 685

### DIFF
--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -96,7 +96,7 @@ namespace Terminal.Gui {
 				if (SuperView == null || SuperView == Application.Top) {
 					Y = Driver.Rows - 1;
 				} else {
-					Y = Pos.Bottom (SuperView);
+					//Y = Pos.Bottom (SuperView);
 				}
 			};
 		}


### PR DESCRIPTION
See #686 

Note: This breaks any app that wants to use StatusBar as a subview of anything other than `Application.Top`. 