### PR TITLE
Closes #683 Resizing issue and Unix change colors.

### DIFF
--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -87,6 +87,8 @@ namespace UICatalog {
 				scenario.Run ();
 				scenario = GetScenarioToRun ();
 			}
+			if (!_top.Running)
+				Application.Shutdown (true);
 		}
 
 		/// <summary>
@@ -118,8 +120,8 @@ namespace UICatalog {
 				}
 			};
 
-			Application.Run (_top, true);
-			Application.Shutdown ();
+			Application.Run (_top, false);
+			Application.Shutdown (false);
 			return _runningScenario;
 		}
 


### PR DESCRIPTION
- This had already been fixed in #551 but came back.
- It also corrects the color change in Unix.
- The driver can only be closed when closing the application. In Unix this caused the OS to reset the color to its default.