### PR TITLE
Fix InputRecord marshalling when built with .NET Native toolchain

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -364,7 +364,7 @@ namespace Terminal.Gui {
 		[DllImport ("kernel32.dll", EntryPoint = "ReadConsoleInputW", CharSet = CharSet.Unicode)]
 		public static extern bool ReadConsoleInput (
 			IntPtr hConsoleInput,
-			[Out] InputRecord [] lpBuffer,
+			IntPtr lpBuffer,
 			uint nLength,
 			out uint lpNumberOfEventsRead);
 
@@ -418,6 +418,24 @@ namespace Terminal.Gui {
 				uint v;
 				GetNumberOfConsoleInputEvents (InputHandle, out v);
 				return v;
+			}
+		}
+		
+		public InputRecord [] ReadConsoleInput ()
+		{
+			const int bufferSize = 1;
+			var pRecord = Marshal.AllocHGlobal (Marshal.SizeOf<InputRecord> () * bufferSize);
+			try {
+				ReadConsoleInput (InputHandle, pRecord, bufferSize,
+					out var numberEventsRead);
+
+				return numberEventsRead == 0
+					? null
+					: new [] {Marshal.PtrToStructure<InputRecord> (pRecord)};
+			} catch (Exception) {
+				return null;
+			} finally {
+				Marshal.FreeHGlobal (pRecord);
 			}
 		}
 
@@ -577,13 +595,7 @@ namespace Terminal.Gui {
 				waitForProbe.Wait ();
 				waitForProbe.Reset ();
 
-				uint numberEventsRead = 0;
-
-				WindowsConsole.ReadConsoleInput (winConsole.InputHandle, records, 1, out numberEventsRead);
-				if (numberEventsRead == 0)
-					result = null;
-				else
-					result = records;
+				result = winConsole.ReadConsoleInput ();
 
 				eventReady.Set ();
 			}


### PR DESCRIPTION
This is a subset of #707 that fixes the input issue with UWP apps (#700). Properly detecting UWP environment and switching the bindings to pass Windows Store checks seems to be a more sophisticated thing and better be tracked separately.