### PR TITLE
Fixes #723 Views now are notified when they are added or removing.

### DIFF
--- a/Terminal.Gui/Core/Responder.cs
+++ b/Terminal.Gui/Core/Responder.cs
@@ -165,18 +165,6 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Method invoked when a view is added.
-		/// </summary>
-		/// <param name="view">The view added.</param>
-		public virtual void OnAddedView (View view) { }
-
-		/// <summary>
-		/// Method invoked when a view being removing.
-		/// </summary>
-		/// <param name="view">The view being removing.</param>
-		public virtual void OnRemovingView (View view) { }
-
-		/// <summary>
 		/// Method invoked when a view gets focus.
 		/// </summary>
 		/// <returns><c>true</c>, if the event was handled, <c>false</c> otherwise.</returns>

--- a/Terminal.Gui/Core/Responder.cs
+++ b/Terminal.Gui/Core/Responder.cs
@@ -165,6 +165,18 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
+		/// Method invoked when a view is added.
+		/// </summary>
+		/// <param name="view">The view added.</param>
+		public virtual void OnAddedView (View view) { }
+
+		/// <summary>
+		/// Method invoked when a view being removing.
+		/// </summary>
+		/// <param name="view">The view being removing.</param>
+		public virtual void OnRemovingView (View view) { }
+
+		/// <summary>
 		/// Method invoked when a view gets focus.
 		/// </summary>
 		/// <returns><c>true</c>, if the event was handled, <c>false</c> otherwise.</returns>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -125,14 +125,14 @@ namespace Terminal.Gui {
 		TextFormatter viewText;
 
 		/// <summary>
-		/// Event fired when the view is added.
+		/// Event fired when a subview is being added to this view.
 		/// </summary>
-		public Action<View> AddedView;
+		public Action<View> Adding;
 
 		/// <summary>
-		/// Event fired when the view is being removing.
+		/// Event fired when a subview is being removed from this view.
 		/// </summary>
-		public Action<View> RemovingView;
+		public Action<View> Removing;
 
 		/// <summary>
 		/// Event fired when the view gets focus.
@@ -562,7 +562,7 @@ namespace Terminal.Gui {
 				subviews = new List<View> ();
 			subviews.Add (view);
 			view.container = this;
-			OnAddedView (view);
+			OnAdding (view);
 			if (view.CanFocus)
 				CanFocus = true;
 			SetNeedsLayout ();
@@ -607,7 +607,7 @@ namespace Terminal.Gui {
 			if (view == null || subviews == null)
 				return;
 
-			OnRemovingView (view);
+			OnRemoving (view);
 			SetNeedsLayout ();
 			SetNeedsDisplay ();
 			var touched = view.Frame;
@@ -945,16 +945,22 @@ namespace Terminal.Gui {
 			public bool Handled { get; set; }
 		}
 
-		/// <inheritdoc/>
-		public override void OnAddedView (View view)
+		/// <summary>
+		/// Method invoked  when a subview is being added to this view.
+		/// </summary>
+		/// <param name="view">The subview being added.</param>
+		public virtual void OnAdding (View view)
 		{
-			AddedView?.Invoke (view);
+			Adding?.Invoke (view);
 		}
 
-		/// <inheritdoc/>
-		public override void OnRemovingView (View view)
+		/// <summary>
+		/// Method invoked when a subview is being removed from this view.
+		/// </summary>
+		/// <param name="view">The subview being removed.</param>
+		public virtual void OnRemoving (View view)
 		{
-			RemovingView?.Invoke (view);
+			Removing?.Invoke (view);
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -949,14 +949,12 @@ namespace Terminal.Gui {
 		public override void OnAddedView (View view)
 		{
 			AddedView?.Invoke (view);
-			base.OnAddedView (view);
 		}
 
 		/// <inheritdoc/>
 		public override void OnRemovingView (View view)
 		{
 			RemovingView?.Invoke (view);
-			base.OnRemovingView (view);
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -951,7 +951,7 @@ namespace Terminal.Gui {
 		/// <param name="view">The subview being added.</param>
 		public virtual void OnAdding (View view)
 		{
-			Adding?.Invoke (view);
+			view.Adding?.Invoke (this);
 		}
 
 		/// <summary>
@@ -960,7 +960,7 @@ namespace Terminal.Gui {
 		/// <param name="view">The subview being removed.</param>
 		public virtual void OnRemoving (View view)
 		{
-			Removing?.Invoke (view);
+			view.Removing?.Invoke (this);
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -125,6 +125,16 @@ namespace Terminal.Gui {
 		TextFormatter viewText;
 
 		/// <summary>
+		/// Event fired when the view is added.
+		/// </summary>
+		public Action<View> AddedView;
+
+		/// <summary>
+		/// Event fired when the view is being removing.
+		/// </summary>
+		public Action<View> RemovingView;
+
+		/// <summary>
 		/// Event fired when the view gets focus.
 		/// </summary>
 		public Action<FocusEventArgs> Enter;
@@ -552,6 +562,7 @@ namespace Terminal.Gui {
 				subviews = new List<View> ();
 			subviews.Add (view);
 			view.container = this;
+			OnAddedView (view);
 			if (view.CanFocus)
 				CanFocus = true;
 			SetNeedsLayout ();
@@ -596,6 +607,7 @@ namespace Terminal.Gui {
 			if (view == null || subviews == null)
 				return;
 
+			OnRemovingView (view);
 			SetNeedsLayout ();
 			SetNeedsDisplay ();
 			var touched = view.Frame;
@@ -931,6 +943,20 @@ namespace Terminal.Gui {
 			/// Its important to set this value to true specially when updating any View's layout from inside the subscriber method.
 			/// </summary>
 			public bool Handled { get; set; }
+		}
+
+		/// <inheritdoc/>
+		public override void OnAddedView (View view)
+		{
+			AddedView?.Invoke (view);
+			base.OnAddedView (view);
+		}
+
+		/// <inheritdoc/>
+		public override void OnRemovingView (View view)
+		{
+			RemovingView?.Invoke (view);
+			base.OnRemovingView (view);
 		}
 
 		/// <inheritdoc/>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -127,7 +127,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Event fired when a subview is being added to this view.
 		/// </summary>
-		public Action<View> Adding;
+		public Action<View> Added;
 
 		/// <summary>
 		/// Event fired when a subview is being removed from this view.
@@ -562,7 +562,7 @@ namespace Terminal.Gui {
 				subviews = new List<View> ();
 			subviews.Add (view);
 			view.container = this;
-			OnAdding (view);
+			OnAdded (view);
 			if (view.CanFocus)
 				CanFocus = true;
 			SetNeedsLayout ();
@@ -949,9 +949,9 @@ namespace Terminal.Gui {
 		/// Method invoked  when a subview is being added to this view.
 		/// </summary>
 		/// <param name="view">The subview being added.</param>
-		public virtual void OnAdding (View view)
+		public virtual void OnAdded (View view)
 		{
-			view.Adding?.Invoke (this);
+			view.Added?.Invoke (this);
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -132,7 +132,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Event fired when a subview is being removed from this view.
 		/// </summary>
-		public Action<View> Removing;
+		public Action<View> Removed;
 
 		/// <summary>
 		/// Event fired when the view gets focus.
@@ -607,12 +607,12 @@ namespace Terminal.Gui {
 			if (view == null || subviews == null)
 				return;
 
-			OnRemoving (view);
 			SetNeedsLayout ();
 			SetNeedsDisplay ();
 			var touched = view.Frame;
 			subviews.Remove (view);
 			view.container = null;
+			OnRemoved (view);
 
 			if (subviews.Count < 1)
 				this.CanFocus = false;
@@ -958,9 +958,9 @@ namespace Terminal.Gui {
 		/// Method invoked when a subview is being removed from this view.
 		/// </summary>
 		/// <param name="view">The subview being removed.</param>
-		public virtual void OnRemoving (View view)
+		public virtual void OnRemoved (View view)
 		{
-			view.Removing?.Invoke (this);
+			view.Removed?.Invoke (this);
 		}
 
 		/// <inheritdoc/>

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -146,8 +146,8 @@ namespace Terminal.Gui {
 				Assert.True (v.SuperView == e);
 			};
 
-			v.Removing += (View e) => {
-				Assert.True (v.SuperView == e);
+			v.Removed += (View e) => {
+				Assert.True (v.SuperView == null);
 			};
 
 			t.Add (v);

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -135,5 +135,26 @@ namespace Terminal.Gui {
 			sub2.Width = Dim.Width (sub2);
 			Assert.Throws<InvalidOperationException> (() => root.LayoutSubviews ());
 		}
+
+		[Fact]
+		public void Added_Removing ()
+		{
+			var v = new View (new Rect (0, 0, 10, 24));
+			var t = new View ();
+
+			v.Added += (View e) => {
+				Assert.True (v.SuperView == e);
+			};
+
+			v.Removing += (View e) => {
+				Assert.True (v.SuperView == e);
+			};
+
+			t.Add (v);
+			Assert.True (t.Subviews.Count == 1);
+
+			t.Remove (v);
+			Assert.True (t.Subviews.Count == 0);
+		}
 	}
 }


### PR DESCRIPTION
If a view have several views the events will get called for each one and in the event parameter will have the view being added or being removing. If there is no need to execute more than once it only need to add a flag to the event that was already executed.