### PR TITLE
Just a little Unit Test for Focus #798

### DIFF
--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -718,5 +718,34 @@ namespace Terminal.Gui {
 			Assert.False (v1.CanFocus);
 			Assert.False (v2.CanFocus);
 		}
+
+		[Fact]
+		public void CanFocus_Faced_With_Container ()
+		{
+			var t = new Toplevel ();
+			var w = new Window ();
+			var f = new FrameView ();
+			var v = new View () { CanFocus = true };
+			f.Add (v);
+			w.Add (f);
+			t.Add (w);
+
+			Assert.True (t.CanFocus);
+			Assert.True (w.CanFocus);
+			Assert.True (f.CanFocus);
+			Assert.True (v.CanFocus);
+
+			f.CanFocus = false;
+			Assert.False (f.CanFocus);
+			Assert.True (v.CanFocus);
+
+			v.CanFocus = false;
+			Assert.False (f.CanFocus);
+			Assert.False (v.CanFocus);
+
+			v.CanFocus = true;
+			Assert.False (f.CanFocus);
+			Assert.True (v.CanFocus);
+		}
 	}
 }


### PR DESCRIPTION
- If a container CanFocus property is false it's needed to set all the subviews to false too, it's not magic.
- For the above behavior to work it's needed to change almost all the code that uses SetFocus method to check the CanFocus property before use it.