### PR TITLE
Fixes #750. Ensure the correct focus order after call SetFocus.

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -253,12 +253,7 @@ static class Demo {
 		});
 		ntop.Add (menu);
 
-		string fname = null;
-		foreach (var s in new [] { "/etc/passwd", "c:\\windows\\win.ini" })
-			if (System.IO.File.Exists (s)) {
-				fname = s;
-				break;
-			}
+		string fname = GetFileName ();
 
 		var win = new Window (fname ?? "Untitled") {
 			X = 0,
@@ -275,6 +270,18 @@ static class Demo {
 		win.Add (text);
 
 		Application.Run (ntop);
+	}
+
+	private static string GetFileName ()
+	{
+		string fname = null;
+		foreach (var s in new [] { "/etc/passwd", "c:\\windows\\win.ini" })
+			if (System.IO.File.Exists (s)) {
+				fname = s;
+				break;
+			}
+
+		return fname;
 	}
 
 	static bool Quit ()
@@ -312,7 +319,8 @@ static class Demo {
 		});
 		ntop.Add (menu);
 
-		var win = new Window ("/etc/passwd") {
+		string fname = GetFileName ();
+		var win = new Window (fname) {
 			X = 0,
 			Y = 1,
 			Width = Dim.Fill (),
@@ -320,7 +328,7 @@ static class Demo {
 		};
 		ntop.Add (win);
 
-		var source = System.IO.File.OpenRead ("/etc/passwd");
+		var source = System.IO.File.OpenRead (fname);
 		var hex = new HexView (source) {
 			X = 0,
 			Y = 0,
@@ -647,7 +655,7 @@ static class Demo {
 		win.Add (test);
 		win.Add (ml);
 
-		var drag = new Label ("Drag: ") { X = 70, Y = 24 };
+		var drag = new Label ("Drag: ") { X = 70, Y = 22 };
 		var dragText = new TextField ("") {
 			X = Pos.Right (drag),
 			Y = Pos.Top (drag),

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1049,13 +1049,13 @@ namespace Terminal.Gui {
 		{
 			if (hasFocus != value) {
 				hasFocus = value;
+				if (value) {
+					OnEnter (view);
+				} else {
+					OnLeave (view);
+				}
+				SetNeedsDisplay ();
 			}
-			if (value) {
-				OnEnter (view);
-			} else {
-				OnLeave (view);
-			}
-			SetNeedsDisplay ();
 
 			// Remove focus down the chain of subviews if focus is removed
 			if (!value && focused != null) {
@@ -1274,7 +1274,8 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Causes the specified subview to have focus.
+		/// Causes the specified subview to have focus. 
+		/// This does not ensures that the entire parent hierarchy can really get focus and thus not updating the focus order.
 		/// </summary>
 		/// <param name="view">View.</param>
 		public void SetFocus (View view)
@@ -1284,7 +1285,7 @@ namespace Terminal.Gui {
 			//Console.WriteLine ($"Request to focus {view}");
 			if (!view.CanFocus)
 				return;
-			if (focused == view)
+			if (focused?.hasFocus == true && focused == view)
 				return;
 
 			// Make sure that this view is a subview
@@ -1304,6 +1305,14 @@ namespace Terminal.Gui {
 			focused.EnsureFocus ();
 
 			// Send focus upwards
+			SuperView?.SetFocus (this);
+		}
+
+		/// <summary>
+		/// Causes the specified view and the entire parent hierarchy to have focus.
+		/// </summary>
+		public void SetFocus ()
+		{
 			SuperView?.SetFocus (this);
 		}
 
@@ -1420,11 +1429,13 @@ namespace Terminal.Gui {
 		/// </summary>
 		public void EnsureFocus ()
 		{
-			if (focused == null)
-				if (FocusDirection == Direction.Forward)
+			if (focused == null && subviews?.Count > 0) {
+				if (FocusDirection == Direction.Forward) {
 					FocusFirst ();
-				else
+				} else {
 					FocusLast ();
+				}
+			}
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1274,11 +1274,10 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Causes the specified subview to have focus. 
-		/// This does not ensures that the entire parent hierarchy can really get focus and thus not updating the focus order.
+		/// Causes the specified subview to have focus.
 		/// </summary>
 		/// <param name="view">View.</param>
-		public void SetFocus (View view)
+		void SetFocus (View view)
 		{
 			if (view == null)
 				return;
@@ -1309,7 +1308,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Causes the specified view and the entire parent hierarchy to have focus.
+		/// Causes the specified view and the entire parent hierarchy to have the focused order updated.
 		/// </summary>
 		public void SetFocus ()
 		{

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -154,7 +154,7 @@ namespace Terminal.Gui {
 		bool CheckKey (KeyEvent key)
 		{
 			if (key.Key == (Key.AltMask | HotKey)) {
-				this.SuperView.SetFocus (this);
+				SetFocus ();
 				Clicked?.Invoke ();
 				return true;
 			}
@@ -210,7 +210,7 @@ namespace Terminal.Gui {
 				me.Flags == MouseFlags.Button1TripleClicked) {
 				if (CanFocus) {
 					if (!HasFocus) {
-						SuperView?.SetFocus (this);
+						SetFocus ();
 						SetNeedsDisplay ();
 					}
 					Clicked?.Invoke ();

--- a/Terminal.Gui/Views/Checkbox.cs
+++ b/Terminal.Gui/Views/Checkbox.cs
@@ -150,7 +150,7 @@ namespace Terminal.Gui {
 			if (!me.Flags.HasFlag (MouseFlags.Button1Clicked) || !CanFocus)
 				return false;
 
-			SuperView.SetFocus (this);
+			SetFocus ();
 			var previousChecked = Checked;
 			Checked = !Checked;
 			OnToggled (previousChecked);

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -196,7 +196,7 @@ namespace Terminal.Gui {
 				return true;
 			} else if (me.Flags == MouseFlags.Button1Pressed) {
 				if (!search.HasFocus) {
-					SetFocus (search);
+					search.SetFocus ();
 				}
 
 				return true;
@@ -210,7 +210,7 @@ namespace Terminal.Gui {
 			listview.SelectedItem = SelectedItem > -1 ? SelectedItem : 0;
 			if (SelectedItem > -1) {
 				listview.TabStop = true;
-				this.SetFocus (listview);
+				listview.SetFocus ();
 			}
 		}
 
@@ -218,7 +218,7 @@ namespace Terminal.Gui {
 		public override bool OnEnter (View view)
 		{
 			if (!search.HasFocus && !listview.HasFocus) {
-				SetFocus (search);
+				search.SetFocus ();
 			}
 
 			search.CursorPosition = search.Text.RuneCount;
@@ -301,7 +301,7 @@ namespace Terminal.Gui {
 			if (e.Key == Key.CursorDown && search.HasFocus) { // jump to list
 				if (searchset.Count > 0) {
 					listview.TabStop = true;
-					this.SetFocus (listview);
+					listview.SetFocus ();
 					SetValue (searchset [listview.SelectedItem]);
 					return true;
 				} else {
@@ -317,7 +317,7 @@ namespace Terminal.Gui {
 			if (e.Key == Key.CursorUp && listview.HasFocus && listview.SelectedItem == 0 && searchset.Count > 0) // jump back to search
 			{
 				search.CursorPosition = search.Text.RuneCount;
-				this.SetFocus (search);
+				search.SetFocus ();
 				return true;
 			}
 
@@ -350,7 +350,7 @@ namespace Terminal.Gui {
 			}
 
 			if (e.Key == Key.Esc) {
-				this.SetFocus (search);
+				search.SetFocus ();
 				search.Text = text = "";
 				OnSelectedChanged ();
 				return true;
@@ -431,7 +431,7 @@ namespace Terminal.Gui {
 			listview.Height = CalculatetHeight ();
 
 			if (Subviews.Count > 0) {
-				SetFocus (search);
+				search.SetFocus ();
 			}
 		}
 

--- a/Terminal.Gui/Views/DateField.cs
+++ b/Terminal.Gui/Views/DateField.cs
@@ -357,7 +357,7 @@ namespace Terminal.Gui {
 			if (!ev.Flags.HasFlag (MouseFlags.Button1Clicked))
 				return false;
 			if (!HasFocus)
-				SuperView.SetFocus (this);
+				SetFocus ();
 
 			var point = ev.X;
 			if (point > FieldLen)

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -87,7 +87,7 @@ namespace Terminal.Gui {
 
 			if (mouseEvent.Flags == MouseFlags.Button1Clicked) {
 				if (!HasFocus && SuperView != null) {
-					SuperView.SetFocus (this);
+					SetFocus ();
 					SetNeedsDisplay ();
 				}
 

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -577,7 +577,7 @@ namespace Terminal.Gui {
 				return false;
 
 			if (!HasFocus)
-				SuperView.SetFocus (this);
+				SetFocus ();
 
 			if (source == null)
 				return false;

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -720,7 +720,7 @@ namespace Terminal.Gui {
 					selected = 0;
 					CanFocus = true;
 					lastFocused = SuperView.MostFocused;
-					SuperView.SetFocus (this);
+					SetFocus ();
 					SetNeedsDisplay ();
 					Application.GrabMouse (this);
 				} else if (!openedByHotKey) {
@@ -747,7 +747,7 @@ namespace Terminal.Gui {
 			selected = -1;
 			CanFocus = false;
 			if (lastFocused != null) {
-				lastFocused.SuperView?.SetFocus (lastFocused);
+				lastFocused.SetFocus ();
 			}
 			SetNeedsDisplay ();
 			Application.UngrabMouse ();
@@ -880,7 +880,7 @@ namespace Terminal.Gui {
 				openCurrentMenu.previousSubFocused = openMenu;
 
 				SuperView.Add (openMenu);
-				SuperView.SetFocus (openMenu);
+				openMenu.SetFocus ();
 				break;
 			default:
 				if (openSubMenu == null)
@@ -896,7 +896,7 @@ namespace Terminal.Gui {
 				}
 				selectedSub = openSubMenu.Count - 1;
 				if (selectedSub > -1 && SelectEnabledItem (openCurrentMenu.barItems.Children, openCurrentMenu.current, out openCurrentMenu.current)) {
-					SuperView?.SetFocus (openCurrentMenu);
+					openCurrentMenu.SetFocus ();
 				}
 				break;
 			}
@@ -1007,7 +1007,7 @@ namespace Terminal.Gui {
 				}
 				SetNeedsDisplay ();
 				if (previousFocused != null && previousFocused is Menu && openMenu != null && previousFocused.ToString () != openCurrentMenu.ToString ())
-					previousFocused?.SuperView?.SetFocus (previousFocused);
+					previousFocused.SetFocus ();
 				openMenu?.Dispose ();
 				openMenu = null;
 				if (lastFocused is Menu || lastFocused is MenuBar) {
@@ -1020,10 +1020,10 @@ namespace Terminal.Gui {
 					if (!reopen) {
 						selected = -1;
 					}
-					LastFocused.SuperView?.SetFocus (LastFocused);
+					LastFocused.SetFocus ();
 				} else {
 					CanFocus = true;
-					SuperView.SetFocus (this);
+					SetFocus ();
 					PositionCursor ();
 				}
 				IsMenuOpen = false;
@@ -1033,7 +1033,7 @@ namespace Terminal.Gui {
 				selectedSub = -1;
 				SetNeedsDisplay ();
 				RemoveAllOpensSubMenus ();
-				openCurrentMenu.previousSubFocused?.SuperView?.SetFocus (openCurrentMenu.previousSubFocused);
+				openCurrentMenu.previousSubFocused.SetFocus ();
 				openSubMenu = null;
 				IsMenuOpen = true;
 				break;
@@ -1049,9 +1049,9 @@ namespace Terminal.Gui {
 			for (int i = openSubMenu.Count - 1; i > index; i--) {
 				isMenuClosing = true;
 				if (openSubMenu.Count - 1 > 0)
-					SuperView.SetFocus (openSubMenu [i - 1]);
+					openSubMenu [i - 1].SetFocus ();
 				else
-					SuperView.SetFocus (openMenu);
+					openMenu.SetFocus ();
 				if (openSubMenu != null) {
 					var menu = openSubMenu [i];
 					SuperView.Remove (menu);
@@ -1272,7 +1272,7 @@ namespace Terminal.Gui {
 				CloseMenu ();
 				if (openedByAltKey) {
 					openedByAltKey = false;
-					LastFocused.SuperView?.SetFocus (LastFocused);
+					LastFocused.SetFocus ();
 				}
 				break;
 

--- a/Terminal.Gui/Views/RadioGroup.cs
+++ b/Terminal.Gui/Views/RadioGroup.cs
@@ -224,7 +224,7 @@ namespace Terminal.Gui {
 								SelectedItem = i;
 								cursor = i;
 								if (!HasFocus)
-									SuperView.SetFocus (this);
+									SetFocus ();
 								return true;
 							}
 							nextIsHot = false;
@@ -267,7 +267,7 @@ namespace Terminal.Gui {
 			if (!me.Flags.HasFlag (MouseFlags.Button1Clicked))
 				return false;
 
-			SuperView.SetFocus (this);
+			SetFocus ();
 
 			if (me.Y < radioLabels.Count) {
 				cursor = SelectedItem = me.Y;

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -651,7 +651,7 @@ namespace Terminal.Gui {
 					return true;
 				}
 				if (!HasFocus) {
-					SuperView.SetFocus (this);
+					SetFocus ();
 				}
 				PositionCursor (ev);
 				if (isButtonReleased) {

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1204,7 +1204,7 @@ namespace Terminal.Gui {
 			}
 
 			if (!HasFocus) {
-				SuperView.SetFocus (this);
+				SetFocus ();
 			}
 
 			if (ev.Flags == MouseFlags.Button1Clicked) {

--- a/Terminal.Gui/Views/TimeField.cs
+++ b/Terminal.Gui/Views/TimeField.cs
@@ -275,7 +275,7 @@ namespace Terminal.Gui {
 			if (!ev.Flags.HasFlag (MouseFlags.Button1Clicked))
 				return false;
 			if (!HasFocus)
-				SuperView.SetFocus (this);
+				SetFocus ();
 
 			var point = ev.X;
 			if (point > FieldLen)

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -88,7 +88,7 @@ namespace Terminal.Gui {
 				return false;
 
 			if (!HasFocus)
-				SuperView.SetFocus (this);
+				SetFocus ();
 
 			if (infos == null)
 				return false;

--- a/UICatalog/Scenarios/AllViewsTester.cs
+++ b/UICatalog/Scenarios/AllViewsTester.cs
@@ -94,7 +94,7 @@ namespace UICatalog {
 				ColorScheme = Colors.TopLevel,
 			};
 			_classListView.OpenSelectedItem += (a) => {
-				Top.SetFocus (_settingsPane);
+				_settingsPane.SetFocus ();
 			};
 			_classListView.SelectedItemChanged += (args) => {
 				ClearClass (_curView);

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -97,7 +97,7 @@ namespace UICatalog {
 				scenario.Setup ();
 				scenario.Run ();
 				_top.Ready += () => {
-					_top.SetFocus (_rightPane);
+					_rightPane.SetFocus ();
 					_top.Ready = null;
 				};
 
@@ -176,7 +176,7 @@ namespace UICatalog {
 				CanFocus = true,
 			};
 			_categoryListView.OpenSelectedItem += (a) => {
-				_top.SetFocus (_rightPane);
+				_rightPane.SetFocus ();
 			};
 			_categoryListView.SelectedItemChanged += CategoryListView_SelectedChanged;
 			_leftPane.Add (_categoryListView);


### PR DESCRIPTION
- For this to work it's needed to call `SetFocus` with one of the two methods:
`view.SuperView.SetFocus (view)`
or
`view.SetFocus ()`
This is a new method more simple and avoid focus order issues.

- Call like `SuperView.SetFocus (view)` does not ensures that the entire parent hierarchy can really get focus and thus not updating the focus order.