### PR TITLE
Fixes #844. Now selects the correct Directory.

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -305,7 +305,7 @@ static class Demo {
 		Application.Run (d);
 
 		if (!d.Canceled)
-			MessageBox.Query (50, 7, "Selected File", string.Join (", ", d.FilePaths), "Ok");
+			MessageBox.Query (50, 7, "Selected File", d.FilePaths.Count > 0 ? string.Join (", ", d.FilePaths) : d.FilePath, "Ok");
 	}
 
 	public static void ShowHex (Toplevel top)

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -347,13 +347,15 @@ namespace Terminal.Gui {
 			}
 		}
 
-		internal bool ExecuteSelection ()
+		internal bool ExecuteSelection (bool isPrompt = false)
 		{
 			var isDir = infos [selected].Item2;
 
 			if (isDir) {
-				Directory = Path.GetFullPath (Path.Combine (Path.GetFullPath (Directory.ToString ()), infos [selected].Item1));
-				DirectoryChanged?.Invoke (Directory);
+				if (!isPrompt) {
+					Directory = Path.GetFullPath (Path.Combine (Path.GetFullPath (Directory.ToString ()), infos [selected].Item1));
+					DirectoryChanged?.Invoke (Directory);
+				}
 			} else {
 				FileChanged?.Invoke (infos [selected].Item1);
 				if (canChooseFiles) {
@@ -467,8 +469,8 @@ namespace Terminal.Gui {
 			};
 			Add (dirLabel, dirEntry);
 
-			this.nameFieldLabel = new Label ("Open: ") {
-				X = 6,
+			this.nameFieldLabel = new Label ("File(s): ") {
+				X = 3,
 				Y = 3 + msgLines,
 			};
 			nameEntry = new TextField ("") {
@@ -500,7 +502,7 @@ namespace Terminal.Gui {
 				IsDefault = true,
 			};
 			this.prompt.Clicked += () => {
-				dirListView.ExecuteSelection ();
+				dirListView.ExecuteSelection (true);
 				canceled = false;
 				Application.RequestStop ();
 			};

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -57,8 +57,18 @@ namespace Terminal.Gui {
 				top = 0;
 				selected = 0;
 				valid = true;
-			} catch (Exception) {
-				valid = false;
+			} catch (Exception ex) {
+				switch (ex) {
+				case DirectoryNotFoundException _:
+				case ArgumentException _:
+					dirInfo = null;
+					infos.Clear ();
+					valid = true;
+					break;
+				default:
+					valid = false;
+					break;
+				}
 			} finally {
 				if (valid) {
 					SetNeedsDisplay ();

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -349,6 +349,9 @@ namespace Terminal.Gui {
 
 		internal bool ExecuteSelection (bool isPrompt = false)
 		{
+			if (infos.Count == 0) {
+				return false;
+			}
 			var isDir = infos [selected].Item2;
 
 			if (isDir) {


### PR DESCRIPTION
- I recommend to navigate through keyboard or mouse for the File text because there are no control about the input. Only the directory is controlled to allow changing the drive.

- I changed the label name from Open to File(s) to avoid confusing about directiories and files, because it's only files can be used here and can be multi-selection.

- To select only a directory there must needed to enter to it too.