### PR TITLE
TextView MoveHome and MoveEnd methods.  #886

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -234,6 +234,18 @@ namespace Terminal.Gui {
 	///        </description>
 	///     </item>
 	///     <item>
+	///        <term>Control-Home</term>
+	///        <description>
+	///          Scrolls to the first line and moves the cursor there.
+	///        </description>
+	///     </item>
+	///     <item>
+	///        <term>Control-End</term>
+	///        <description>
+	///          Scrolls to the last line and moves the cursor there.
+	///        </description>
+	///     </item>
+	///     <item>
 	///        <term>Delete, Control-d</term>
 	///        <description>
 	///          Deletes the character in front of the cursor.
@@ -1004,15 +1016,11 @@ namespace Terminal.Gui {
 				break;
 
 			case Key.CtrlMask | Key.End:
-				currentRow = model.Count;
-				TrackColumn ();
-				PositionCursor ();
+				MoveEnd ();
 				break;
 
 			case Key.CtrlMask | Key.Home:
-				currentRow = 0;
-				TrackColumn ();
-				PositionCursor ();
+				MoveHome ();
 				break;
 
 			default:
@@ -1085,6 +1093,26 @@ namespace Terminal.Gui {
 		}
 
 		Rune RuneAt (int col, int row) => model.GetLine (row) [col];
+
+		/// <summary>
+		/// Will scroll the <see cref="TextView"/> to the last line and position the cursor there.
+		/// </summary>
+		public void MoveEnd ()
+		{
+			currentRow = model.Count - 1;
+			TrackColumn ();
+			PositionCursor ();
+		}
+
+		/// <summary>
+		/// Will scroll the <see cref="TextView"/> to the first line and position the cursor there.
+		/// </summary>
+		public void MoveHome ()
+		{
+			currentRow = 0;
+			TrackColumn ();
+			PositionCursor ();
+		}
 
 		bool MoveNext (ref int col, ref int row, out Rune rune)
 		{


### PR DESCRIPTION
These are the public `MoveHome` and `MoveEnd` methods to reposition cursor and scroll the `TextView` discussed in #886.

