### PR TITLE
ListView.cs fixes

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // ListView.cs: ListView control
 //
 // Authors:
@@ -448,8 +448,20 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public virtual bool MoveDown ()
 		{
-			if (selected + 1 < source.Count) {
+			if (source.Count == 0){
+				// Do we set lastSelectedItem to zero here?
+                return false; //Nothing for us to move to
+            }
+			if (selected >= source.Count) { 
+				// If for some reason we are currently outside of the
+				// valid values range, we should select the bottommost valid value.
+				// This can occur if the backing data source changes.
+                selected = source.Count - 1;
+				OnSelectedChanged ();
+				SetNeedsDisplay ();
+            } else if (selected + 1 < source.Count) { //can move by down by one.
 				selected++;
+
 				if (selected >= top + Frame.Height)
 					top++;
 				OnSelectedChanged ();
@@ -468,8 +480,22 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public virtual bool MoveUp ()
 		{
-			if (selected > 0) {
+			if (source.Count == 0){
+				// Do we set lastSelectedItem to zero here?
+                return false; //Nothing for us to move to
+            }
+			if (selected >= source.Count) { 
+				// If for some reason we are currently outside of the
+				// valid values range, we should select the bottommost valid value.
+				// This can occur if the backing data source changes.
+                selected = source.Count - 1;
+				OnSelectedChanged ();
+				SetNeedsDisplay ();
+            } else if (selected > 0) {
 				selected--;
+				if (selected > Source.Count) {
+                    selected = Source.Count - 1;
+                }
 				if (selected < top)
 					top = selected;
 				OnSelectedChanged ();

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -450,17 +450,18 @@ namespace Terminal.Gui {
 		{
 			if (source.Count == 0){
 				// Do we set lastSelectedItem to zero here?
-				return false; //Nothing for us to move to
-			}
+                return false; //Nothing for us to move to
+            }
 			if (selected >= source.Count) { 
 				// If for some reason we are currently outside of the
 				// valid values range, we should select the bottommost valid value.
 				// This can occur if the backing data source changes.
-		                selected = source.Count - 1;
+                selected = source.Count - 1;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
-			} else if (selected + 1 < source.Count) { //can move by down by one.
+            } else if (selected + 1 < source.Count) { //can move by down by one.
 				selected++;
+
 				if (selected >= top + Frame.Height)
 					top++;
 				OnSelectedChanged ();
@@ -481,26 +482,25 @@ namespace Terminal.Gui {
 		{
 			if (source.Count == 0){
 				// Do we set lastSelectedItem to zero here?
-				return false; //Nothing for us to move to
-			}
+                return false; //Nothing for us to move to
+            }
 			if (selected >= source.Count) { 
 				// If for some reason we are currently outside of the
 				// valid values range, we should select the bottommost valid value.
 				// This can occur if the backing data source changes.
-				selected = source.Count - 1;
+                selected = source.Count - 1;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
-			} else if (selected > 0) {
-				selected--; 
+            } else if (selected > 0) {
+				selected--;
 				if (selected > Source.Count) {
-					selected = Source.Count - 1;
-				}
-				if (selected < top) 
+                    selected = Source.Count - 1;
+                }
+				if (selected < top)
 					top = selected;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
 			}
-
 			return true;
 		}
 
@@ -560,7 +560,8 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public virtual bool OnOpenSelectedItem ()
 		{
-			var value = source.ToList () [selected];
+			if (source.Count <= selected ||selected < 0) return false;
+            var value = source.ToList () [selected];
 			OpenSelectedItem?.Invoke (new ListViewItemEventArgs (selected, value));
 
 			return true;

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -450,18 +450,17 @@ namespace Terminal.Gui {
 		{
 			if (source.Count == 0){
 				// Do we set lastSelectedItem to zero here?
-                return false; //Nothing for us to move to
-            }
+				return false; //Nothing for us to move to
+			}
 			if (selected >= source.Count) { 
 				// If for some reason we are currently outside of the
 				// valid values range, we should select the bottommost valid value.
 				// This can occur if the backing data source changes.
-                selected = source.Count - 1;
+		                selected = source.Count - 1;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
-            } else if (selected + 1 < source.Count) { //can move by down by one.
+			} else if (selected + 1 < source.Count) { //can move by down by one.
 				selected++;
-
 				if (selected >= top + Frame.Height)
 					top++;
 				OnSelectedChanged ();
@@ -482,21 +481,21 @@ namespace Terminal.Gui {
 		{
 			if (source.Count == 0){
 				// Do we set lastSelectedItem to zero here?
-                return false; //Nothing for us to move to
-            }
+				return false; //Nothing for us to move to
+			}
 			if (selected >= source.Count) { 
 				// If for some reason we are currently outside of the
 				// valid values range, we should select the bottommost valid value.
 				// This can occur if the backing data source changes.
-                selected = source.Count - 1;
+				selected = source.Count - 1;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
-            } else if (selected > 0) {
-				selected--;
+			} else if (selected > 0) {
+				selected--; 
 				if (selected > Source.Count) {
-                    selected = Source.Count - 1;
-                }
-				if (selected < top)
+					selected = Source.Count - 1;
+				}
+				if (selected < top) 
 					top = selected;
 				OnSelectedChanged ();
 				SetNeedsDisplay ();


### PR DESCRIPTION
When calling MoveUp and MoveDown, the 'selected' variable is not checked. If I am using a backing data source that can change, this selected value +/- 1 may still not lie in the valid range of values. This PR checks and changes the following:

1) If moving up, and the CURRENT selected value is >= backing data length, the last item is selected
2) If moving down, and the CURRENT selected value is >= backing data length, the last item is selected
3) If the items list has no items, the methods return false as there is nothing to move to. I'm not sure if we should set lastSelectedItem to -1 in this instance.

Sorry if formatting is weird. I wrote this in visual studio code on linux and haven't figured out where the formatter is... 