### PR TITLE
Delete using WindowsRuntime from unit test

### DIFF
--- a/UnitTests/PosTests.cs
+++ b/UnitTests/PosTests.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Data;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Terminal.Gui;
 using Xunit;
 


### PR DESCRIPTION
When building the UnitTests profile with .net5.0 (RC2), it gives the following error:

```sh
$ cd gui.cs/UnitTests
# bulk update TargetFramework netcoreapp3.1 -> net5.0 (macOS' sed compatible)
$ git ls-files :/*.csproj | xargs -I{} sed -i '' 's/netcoreapp3.1/net5.0/g' {}
# my dotnet 5.0.100-rc.2.20466.16 installation lives in non-standard location
$ ~/.dotnet5/dotnet test -f net5.0

/Users/am11/projects/gui.cs/UnitTests/PosTests.cs(7,38): error CS0234: The type or namespace name 'WindowsRuntime' does not exist in the namespace 'System.Runtime.InteropServices' (are you missing an assembly reference?) [/Users/am11/projects/gui.cs/UnitTests/UnitTests.csproj] 
```

Looks like it was removed in https://github.com/dotnet/runtime/pull/36715 and it is unused in the UnitTests project.