### PR TITLE
[Breaking] Use C# Events Instead of Just Actions

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -141,7 +141,7 @@ static class Demo {
 #else
 		var filler = new Filler (new Rect (0, 0, 40, 40));
 		scrollView.Add (filler);
-		scrollView.DrawContent = (r) => {
+		scrollView.DrawContent += (r) => {
 			scrollView.ContentSize = filler.GetContentSize ();
 		};
 #endif

--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -225,10 +225,11 @@ static class Demo {
 
 	static void NewFile ()
 	{
-		var d = new Dialog (
-			"New File", 50, 20,
-			new Button ("Ok", is_default: true) { Clicked = () => { Application.RequestStop (); } },
-			new Button ("Cancel") { Clicked = () => { Application.RequestStop (); } });
+		var ok = new Button ("Ok", is_default: true);
+		ok.Clicked += () => { Application.RequestStop (); };
+		var cancel = new Button ("Cancel");
+		cancel.Clicked += () => { Application.RequestStop (); };
+		var d = new Dialog ("New File", 50, 20, ok, cancel);
 		ml2 = new Label (1, 1, "Mouse Debug Line");
 		d.Add (ml2);
 		Application.Run (d);
@@ -423,9 +424,11 @@ static class Demo {
 
 	static void ListSelectionDemo (bool multiple)
 	{
-		var d = new Dialog ("Selection Demo", 60, 20,
-			new Button ("Ok", is_default: true) { Clicked = () => { Application.RequestStop (); } },
-			new Button ("Cancel") { Clicked = () => { Application.RequestStop (); } });
+		var ok = new Button ("Ok", is_default: true);
+		ok.Clicked += () => { Application.RequestStop (); };
+		var cancel = new Button ("Cancel");
+		cancel.Clicked += () => { Application.RequestStop (); };
+		var d = new Dialog ("Selection Demo", 60, 20, ok, cancel);
 
 		var animals = new List<string> () { "Alpaca", "Llama", "Lion", "Shark", "Goat" };
 		var msg = new Label ("Use space bar or control-t to toggle selection") {
@@ -483,9 +486,9 @@ static class Demo {
 	#region KeyDown / KeyPress / KeyUp Demo
 	private static void OnKeyDownPressUpDemo ()
 	{
-		var container = new Dialog (
-			"KeyDown & KeyPress & KeyUp demo", 80, 20,
-			new Button ("Close") { Clicked = () => { Application.RequestStop (); } }) {
+		var close = new Button ("Close");
+		close.Clicked += () => { Application.RequestStop (); };
+		var container = new Dialog ("KeyDown & KeyPress & KeyUp demo", 80, 20, close) {
 			Width = Dim.Fill (),
 			Height = Dim.Fill (),
 		};

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -53,7 +53,7 @@ namespace Terminal.Gui {
 		/// Subscribe to this event to perform tasks when the <see cref="Toplevel"/> has been laid out and focus has been set.
 		/// changes. A Ready event handler is a good place to finalize initialization after calling `<see cref="Application.Run()"/>(topLevel)`. 
 		/// </summary>
-		public Action Ready;
+		public event Action Ready;
 
 		/// <summary>
 		/// Called from <see cref="Application.RunLoop"/> after the <see cref="Toplevel"/> has entered it's first iteration of the loop. 

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -128,37 +128,37 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Event fired when a subview is being added to this view.
 		/// </summary>
-		public Action<View> Added;
+		public event Action<View> Added;
 
 		/// <summary>
 		/// Event fired when a subview is being removed from this view.
 		/// </summary>
-		public Action<View> Removed;
+		public event Action<View> Removed;
 
 		/// <summary>
 		/// Event fired when the view gets focus.
 		/// </summary>
-		public Action<FocusEventArgs> Enter;
+		public event Action<FocusEventArgs> Enter;
 
 		/// <summary>
 		/// Event fired when the view looses focus.
 		/// </summary>
-		public Action<FocusEventArgs> Leave;
+		public event Action<FocusEventArgs> Leave;
 
 		/// <summary>
 		/// Event fired when the view receives the mouse event for the first time.
 		/// </summary>
-		public Action<MouseEventArgs> MouseEnter;
+		public event Action<MouseEventArgs> MouseEnter;
 
 		/// <summary>
 		/// Event fired when the view receives a mouse event for the last time.
 		/// </summary>
-		public Action<MouseEventArgs> MouseLeave;
+		public event Action<MouseEventArgs> MouseLeave;
 
 		/// <summary>
 		/// Event fired when a mouse event is generated.
 		/// </summary>
-		public Action<MouseEventArgs> MouseClick;
+		public event Action<MouseEventArgs> MouseClick;
 
 		/// <summary>
 		/// Gets or sets the HotKey defined for this view. A user pressing HotKey on the keyboard while this view has focus will cause the Clicked event to fire.
@@ -1269,7 +1269,7 @@ namespace Terminal.Gui {
 		/// Rect provides the view-relative rectangle describing the currently visible viewport into the <see cref="View"/>.
 		/// </para>
 		/// </remarks>
-		public Action<Rect> DrawContent;
+		public event Action<Rect> DrawContent;
 
 		/// <summary>
 		/// Enables overrides to draw infinitely scrolled content and/or a background behind added controls. 
@@ -1352,7 +1352,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invoked when a character key is pressed and occurs after the key up event.
 		/// </summary>
-		public Action<KeyEventEventArgs> KeyPress;
+		public event Action<KeyEventEventArgs> KeyPress;
 
 		/// <inheritdoc/>
 		public override bool ProcessKey (KeyEvent keyEvent)
@@ -1400,7 +1400,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invoked when a key is pressed
 		/// </summary>
-		public Action<KeyEventEventArgs> KeyDown;
+		public event Action<KeyEventEventArgs> KeyDown;
 
 		/// <param name="keyEvent">Contains the details about the key that produced the event.</param>
 		public override bool OnKeyDown (KeyEvent keyEvent)
@@ -1420,7 +1420,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invoked when a key is released
 		/// </summary>
-		public Action<KeyEventEventArgs> KeyUp;
+		public event Action<KeyEventEventArgs> KeyUp;
 
 		/// <param name="keyEvent">Contains the details about the key that produced the event.</param>
 		public override bool OnKeyUp (KeyEvent keyEvent)
@@ -1701,7 +1701,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		/// Subscribe to this event to perform tasks when the <see cref="View"/> has been resized or the layout has otherwise changed.
 		/// </remarks>
-		public Action<LayoutEventArgs> LayoutStarted;
+		public event Action<LayoutEventArgs> LayoutStarted;
 
 		/// <summary>
 		/// Raises the <see cref="LayoutStarted"/> event. Called from  <see cref="LayoutSubviews"/> before any subviews have been laid out.
@@ -1717,7 +1717,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		/// Subscribe to this event to perform tasks when the <see cref="View"/> has been resized or the layout has otherwise changed.
 		/// </remarks>
-		public Action<LayoutEventArgs> LayoutComplete;
+		public event Action<LayoutEventArgs> LayoutComplete;
 
 		/// <summary>
 		/// Event called only once when the <see cref="View"/> is being initialized for the first time.
@@ -1914,7 +1914,7 @@ namespace Terminal.Gui {
 			}
 
 			MouseEventArgs args = new MouseEventArgs (mouseEvent);
-			MouseClick?.Invoke (args);
+			OnMouseClick (args);
 			if (args.Handled)
 				return true;
 			if (MouseEvent (mouseEvent))
@@ -1931,6 +1931,11 @@ namespace Terminal.Gui {
 			}
 			return false;
 		}
+
+		/// <summary>
+		/// Invokes the MouseClick event.
+		/// </summary>
+		protected void OnMouseClick (MouseEventArgs args) => MouseClick?.Invoke (args);
 
 		/// <inheritdoc/>
 		protected override void Dispose (bool disposing)

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -201,7 +201,7 @@ namespace Terminal.Gui {
 		///   raised when the button is activated either with
 		///   the mouse or the keyboard.
 		/// </remarks>
-		public Action Clicked;
+		public event Action Clicked;
 
 		///<inheritdoc/>
 		public override bool MouseEvent (MouseEvent me)

--- a/Terminal.Gui/Views/Checkbox.cs
+++ b/Terminal.Gui/Views/Checkbox.cs
@@ -25,7 +25,7 @@ namespace Terminal.Gui {
 		///   raised when the <see cref="CheckBox"/> is activated either with
 		///   the mouse or the keyboard. The passed <c>bool</c> contains the previous state. 
 		/// </remarks>
-		public Action<bool> Toggled;
+		public event Action<bool> Toggled;
 
 		/// <summary>
 		/// Called when the <see cref="Checked"/> property changes. Invokes the <see cref="Toggled"/> event.

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -57,12 +57,12 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// This event is raised when the selected item in the <see cref="ComboBox"/> has changed.
 		/// </summary>
-		public Action<ListViewItemEventArgs> SelectedItemChanged;
+		public event Action<ListViewItemEventArgs> SelectedItemChanged;
 
 		/// <summary>
 		/// This event is raised when the user Double Clicks on an item or presses ENTER to open the selected item.
 		/// </summary>
-		public Action<ListViewItemEventArgs> OpenSelectedItem;
+		public event Action<ListViewItemEventArgs> OpenSelectedItem;
 
 		IList searchset;
 		ustring text = "";

--- a/Terminal.Gui/Views/DateField.cs
+++ b/Terminal.Gui/Views/DateField.cs
@@ -38,7 +38,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		///   The passed event arguments containing the old value, new value, and format string.
 		/// </remarks>
-		public Action<DateTimeEventArgs<DateTime>> DateChanged;
+		public event Action<DateTimeEventArgs<DateTime>> DateChanged;
 
 		/// <summary>
 		///    Initializes a new instance of <see cref="DateField"/> using <see cref="LayoutStyle.Absolute"/> layout.

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -78,7 +78,7 @@ namespace Terminal.Gui {
 		public override bool OnMouseEvent (MouseEvent mouseEvent)
 		{
 			MouseEventArgs args = new MouseEventArgs (mouseEvent);
-			MouseClick?.Invoke (args);
+			OnMouseClick (args);
 			if (args.Handled)
 				return true;
 			if (MouseEvent (mouseEvent))

--- a/Terminal.Gui/Views/Label.cs
+++ b/Terminal.Gui/Views/Label.cs
@@ -53,7 +53,7 @@ namespace Terminal.Gui {
 		///   raised when the button is activated either with
 		///   the mouse or the keyboard.
 		/// </remarks>
-		public Action Clicked;
+		public event Action Clicked;
 
 		///// <inheritdoc/>
 		//public new ustring Text {

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -318,12 +318,12 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// This event is raised when the selected item in the <see cref="ListView"/> has changed.
 		/// </summary>
-		public Action<ListViewItemEventArgs> SelectedItemChanged;
+		public event Action<ListViewItemEventArgs> SelectedItemChanged;
 
 		/// <summary>
 		/// This event is raised when the user Double Clicks on an item or presses ENTER to open the selected item.
 		/// </summary>
-		public Action<ListViewItemEventArgs> OpenSelectedItem;
+		public event Action<ListViewItemEventArgs> OpenSelectedItem;
 
 		///<inheritdoc/>
 		public override bool ProcessKey (KeyEvent kb)

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -871,12 +871,12 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Raised as a menu is opening.
 		/// </summary>
-		public Action MenuOpening;
+		public event Action MenuOpening;
 
 		/// <summary>
 		/// Raised when a menu is closing.
 		/// </summary>
-		public Action MenuClosing;
+		public event Action MenuClosing;
 
 		internal Menu openMenu;
 		internal Menu openCurrentMenu;

--- a/Terminal.Gui/Views/RadioGroup.cs
+++ b/Terminal.Gui/Views/RadioGroup.cs
@@ -244,7 +244,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invoked when the selected radio label has changed.
 		/// </summary>
-		public Action<SelectedItemChangedArgs> SelectedItemChanged;
+		public event Action<SelectedItemChangedArgs> SelectedItemChanged;
 
 		/// <summary>
 		/// The currently selected item from the list of radio labels

--- a/Terminal.Gui/Views/ScrollView.cs
+++ b/Terminal.Gui/Views/ScrollView.cs
@@ -60,7 +60,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// This event is raised when the position on the scrollbar has changed.
 		/// </summary>
-		public Action ChangedPosition;
+		public event Action ChangedPosition;
 
 		/// <summary>
 		/// The position, relative to <see cref="Size"/>, to set the scrollbar at.

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -41,7 +41,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		///   The passed <see cref="EventArgs"/> is a <see cref="ustring"/> containing the old value. 
 		/// </remarks>
-		public Action<ustring> TextChanged;
+		public event Action<ustring> TextChanged;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TextField"/> class using <see cref="LayoutStyle.Computed"/> positioning.

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -300,7 +300,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Raised when the <see cref="Text"/> of the <see cref="TextView"/> changes.
 		/// </summary>
-		public Action TextChanged;
+		public event Action TextChanged;
 
 #if false
 		/// <summary>

--- a/Terminal.Gui/Views/TimeField.cs
+++ b/Terminal.Gui/Views/TimeField.cs
@@ -38,7 +38,7 @@ namespace Terminal.Gui {
 		/// <remarks>
 		///   The passed <see cref="EventArgs"/> is a <see cref="DateTimeEventArgs{T}"/> containing the old value, new value, and format string.
 		/// </remarks>
-		public Action<DateTimeEventArgs<TimeSpan>> TimeChanged;
+		public event Action<DateTimeEventArgs<TimeSpan>> TimeChanged;
 
 		/// <summary>
 		///    Initializes a new instance of <see cref="TimeField"/> using <see cref="LayoutStyle.Absolute"/> positioning.

--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -506,10 +506,10 @@ namespace Terminal.Gui {
 				X = Pos.Right (dirLabel),
 				Y = 1 + msgLines,
 				Width = Dim.Fill () - 1,
-				TextChanged = (e) => {
-					DirectoryPath = dirEntry.Text;
-					nameEntry.Text = ustring.Empty;
-				}
+			};
+			dirEntry.TextChanged += (e) => {
+				DirectoryPath = dirEntry.Text;
+				nameEntry.Text = ustring.Empty;
 			};
 			Add (dirLabel, dirEntry);
 

--- a/UICatalog/Scenarios/AllViewsTester.cs
+++ b/UICatalog/Scenarios/AllViewsTester.cs
@@ -133,8 +133,8 @@ namespace UICatalog {
 			_xRadioGroup = new RadioGroup (radioItems) {
 				X = 0,
 				Y = Pos.Bottom (label),
-				SelectedItemChanged = (selected) => DimPosChanged (_curView),
 			};
+			_xRadioGroup.SelectedItemChanged += (selected) => DimPosChanged (_curView);
 			_xText = new TextField ($"{_xVal}") { X = Pos.Right (label) + 1, Y = 0, Width = 4 };
 			_xText.TextChanged += (args) => {
 				try {
@@ -164,8 +164,8 @@ namespace UICatalog {
 			_yRadioGroup = new RadioGroup (radioItems) {
 				X = Pos.X (label),
 				Y = Pos.Bottom (label),
-				SelectedItemChanged = (selected) => DimPosChanged (_curView),
 			};
+			_yRadioGroup.SelectedItemChanged += (selected) => DimPosChanged (_curView);
 			_locationFrame.Add (_yRadioGroup);
 
 			_sizeFrame = new FrameView ("Size (Dim)") {
@@ -181,8 +181,8 @@ namespace UICatalog {
 			_wRadioGroup = new RadioGroup (radioItems) {
 				X = 0,
 				Y = Pos.Bottom (label),
-				SelectedItemChanged = (selected) => DimPosChanged (_curView)
 			};
+			_wRadioGroup.SelectedItemChanged += (selected) => DimPosChanged (_curView);
 			_wText = new TextField ($"{_wVal}") { X = Pos.Right (label) + 1, Y = 0, Width = 4 };
 			_wText.TextChanged += (args) => {
 				try {
@@ -212,8 +212,8 @@ namespace UICatalog {
 			_hRadioGroup = new RadioGroup (radioItems) {
 				X = Pos.X (label),
 				Y = Pos.Bottom (label),
-				SelectedItemChanged = (selected) => DimPosChanged (_curView),
 			};
+			_hRadioGroup.SelectedItemChanged += (selected) => DimPosChanged (_curView);
 			_sizeFrame.Add (_hRadioGroup);
 
 			_settingsPane.Add (_sizeFrame);

--- a/UICatalog/Scenarios/Buttons.cs
+++ b/UICatalog/Scenarios/Buttons.cs
@@ -29,12 +29,12 @@ namespace UICatalog {
 				//TODO: Change to use Pos.AnchorEnd()
 				Y = Pos.Bottom (Win) - 3,
 				IsDefault = true,
-				Clicked = () => Application.RequestStop (),
 			};
+			defaultButton.Clicked += () => Application.RequestStop ();
 			Win.Add (defaultButton);
 
 			var swapButton = new Button (50, 0, "Swap Default (Absolute Layout)");
-			swapButton.Clicked = () => {
+			swapButton.Clicked += () => {
 				defaultButton.IsDefault = !defaultButton.IsDefault;
 				swapButton.IsDefault = !swapButton.IsDefault;
 			};
@@ -42,7 +42,7 @@ namespace UICatalog {
 
 			static void DoMessage (Button button, ustring txt)
 			{
-				button.Clicked = () => {
+				button.Clicked += () => {
 					var btnText = button.Text.ToString ();
 					MessageBox.Query ("Message", $"Did you click {txt}?", "Yes", "No");
 				};
@@ -82,15 +82,15 @@ namespace UICatalog {
 			Win.Add (button = new Button ("a Newline\nin the button") {
 				X = 2,
 				Y = Pos.Bottom (button) + 1,
-				Clicked = () => MessageBox.Query ("Message", "Question?", "Yes", "No")
 			});
+			button.Clicked += () => MessageBox.Query ("Message", "Question?", "Yes", "No");
 
 			var textChanger = new Button ("Te_xt Changer") {
 				X = 2,
 				Y = Pos.Bottom (button) + 1,
 			};
 			Win.Add (textChanger);
-			textChanger.Clicked = () => textChanger.Text += "!";
+			textChanger.Clicked += () => textChanger.Text += "!";
 
 			Win.Add (button = new Button ("Lets see if this will move as \"Text Changer\" grows") {
 				X = Pos.Right (textChanger) + 2,
@@ -104,7 +104,7 @@ namespace UICatalog {
 			};
 			Win.Add (removeButton);
 			// This in intresting test case because `moveBtn` and below are laid out relative to this one!
-			removeButton.Clicked = () => Win.Remove (removeButton);
+			removeButton.Clicked += () => Win.Remove (removeButton);
 
 			var computedFrame = new FrameView ("Computed Layout") {
 				X = 0,
@@ -121,7 +121,7 @@ namespace UICatalog {
 				Width = 30,
 				ColorScheme = Colors.Error,
 			};
-			moveBtn.Clicked = () => {
+			moveBtn.Clicked += () => {
 				moveBtn.X = moveBtn.Frame.X + 5;
 				// This is already fixed with the call to SetNeedDisplay() in the Pos Dim.
 				//computedFrame.LayoutSubviews (); // BUGBUG: This call should not be needed. View.X is not causing relayout correctly
@@ -135,7 +135,7 @@ namespace UICatalog {
 				Width = 30,
 				ColorScheme = Colors.Error,
 			};
-			sizeBtn.Clicked = () => {
+			sizeBtn.Clicked += () => {
 				sizeBtn.Width = sizeBtn.Frame.Width + 5;
 				//computedFrame.LayoutSubviews (); // FIXED: This call should not be needed. View.X is not causing relayout correctly
 			};
@@ -153,7 +153,7 @@ namespace UICatalog {
 			var moveBtnA = new Button (0, 0, "Move This Button via Frame") {
 				ColorScheme = Colors.Error,
 			};
-			moveBtnA.Clicked = () => {
+			moveBtnA.Clicked += () => {
 				moveBtnA.Frame = new Rect (moveBtnA.Frame.X + 5, moveBtnA.Frame.Y, moveBtnA.Frame.Width, moveBtnA.Frame.Height);
 			};
 			absoluteFrame.Add (moveBtnA);
@@ -162,7 +162,7 @@ namespace UICatalog {
 			var sizeBtnA = new Button (0, 2, " ~  s  gui.cs   master ↑10 = Со_хранить") {
 				ColorScheme = Colors.Error,
 			};
-			sizeBtnA.Clicked = () => {
+			sizeBtnA.Clicked += () => {
 				sizeBtnA.Frame = new Rect (sizeBtnA.Frame.X, sizeBtnA.Frame.Y, sizeBtnA.Frame.Width + 5, sizeBtnA.Frame.Height);
 			};
 			absoluteFrame.Add (sizeBtnA);
@@ -213,7 +213,7 @@ namespace UICatalog {
 				Width = Dim.Width (computedFrame) - 2,
 				ColorScheme = Colors.TopLevel,
 			};
-			moveHotKeyBtn.Clicked = () => {
+			moveHotKeyBtn.Clicked += () => {
 				moveHotKeyBtn.Text = MoveHotkey (moveHotKeyBtn.Text);
 			};
 			Win.Add (moveHotKeyBtn);
@@ -225,7 +225,7 @@ namespace UICatalog {
 				Width = Dim.Width (absoluteFrame) - 2, // BUGBUG: Not always the width isn't calculated correctly.
 				ColorScheme = Colors.TopLevel,
 			};
-			moveUnicodeHotKeyBtn.Clicked = () => {
+			moveUnicodeHotKeyBtn.Clicked += () => {
 				moveUnicodeHotKeyBtn.Text = MoveHotkey (moveUnicodeHotKeyBtn.Text);
 			};
 			Win.Add (moveUnicodeHotKeyBtn);

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -62,7 +62,7 @@ namespace UICatalog {
 			jumpList.X = Pos.X (label);
 			jumpList.Y = Pos.Bottom (label);
 			jumpList.Width = Dim.Fill ();
-			jumpList.SelectedItemChanged = (args) => {
+			jumpList.SelectedItemChanged += (args) => {
 				_charMap.Start = radioItems[args.SelectedItem].start;
 			};
 

--- a/UICatalog/Scenarios/Clipping.cs
+++ b/UICatalog/Scenarios/Clipping.cs
@@ -69,11 +69,12 @@ namespace UICatalog {
 				Height = Dim.Fill (3),
 				ColorScheme = Colors.TopLevel
 			};
-			embedded3.Add (new Button (2, 2, "click me") {
-				Clicked = () => {
-					MessageBox.Query (10, 5, "Test", "test message", "Ok");
-				}
-			});
+
+			var testButton = new Button (2, 2, "click me");
+			testButton.Clicked += () => {
+				MessageBox.Query (10, 5, "Test", "test message", "Ok");
+			};
+			embedded3.Add (testButton);
 			embedded2.Add (embedded3);
 
 			scrollView.Add (embedded1);

--- a/UICatalog/Scenarios/ComputedLayout.cs
+++ b/UICatalog/Scenarios/ComputedLayout.cs
@@ -125,7 +125,7 @@ namespace UICatalog {
 			};
 			// TODO: Use Pos.Width instead of (Right-Left) when implemented (#502)
 			anchorButton.X = Pos.AnchorEnd () - (Pos.Right (anchorButton) - Pos.Left (anchorButton));
-			anchorButton.Clicked = () => {
+			anchorButton.Clicked += () => {
 				// Ths demonstrates how to have a dynamically sized button
 				// Each time the button is clicked the button's text gets longer
 				// The call to Win.LayoutSubviews causes the Computed layout to
@@ -152,7 +152,7 @@ namespace UICatalog {
 			var leftButton = new Button ("Left") {
 				Y = Pos.Bottom (Win) - 3
 			};
-			leftButton.Clicked = () => {
+			leftButton.Clicked += () => {
 				// Ths demonstrates how to have a dynamically sized button
 				// Each time the button is clicked the button's text gets longer
 				// The call to Win.LayoutSubviews causes the Computed layout to
@@ -167,7 +167,7 @@ namespace UICatalog {
 				X = Pos.Center (),
 				Y = Pos.AnchorEnd () - 1
 			};
-			centerButton.Clicked = () => {
+			centerButton.Clicked += () => {
 				// Ths demonstrates how to have a dynamically sized button
 				// Each time the button is clicked the button's text gets longer
 				// The call to Win.LayoutSubviews causes the Computed layout to
@@ -180,7 +180,7 @@ namespace UICatalog {
 			var rightButton = new Button ("Right") {
 				Y = Pos.Y (centerButton)
 			};
-			rightButton.Clicked = () => {
+			rightButton.Clicked += () => {
 				// Ths demonstrates how to have a dynamically sized button
 				// Each time the button is clicked the button's text gets longer
 				// The call to Win.LayoutSubviews causes the Computed layout to

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -116,52 +116,54 @@ namespace UICatalog {
 				X = Pos.Center(),
 				Y = Pos.Bottom (frame) + 2			,
 				IsDefault = true,
-				Clicked = () => {
-					try {
-						int width = int.Parse (widthEdit.Text.ToString ());
-						int height = int.Parse (heightEdit.Text.ToString ());
-						int numButtons = int.Parse (numButtonsEdit.Text.ToString ());
+			};
+			showDialogButton.Clicked += () => {
+				try {
+					int width = int.Parse (widthEdit.Text.ToString ());
+					int height = int.Parse (heightEdit.Text.ToString ());
+					int numButtons = int.Parse (numButtonsEdit.Text.ToString ());
 
-						var buttons = new List<Button> ();
-						var clicked = -1;
-						for (int i = 0; i < numButtons; i++) {
-							var buttonId = i;
-							var button = new Button (btnText [buttonId % 10], is_default: buttonId == 0) {
-								Clicked = () => {
-									clicked = buttonId;
-									Application.RequestStop ();
-								},
-							};
-							buttons.Add(button);
-						}
-
-						// This tests dynamically adding buttons; ensuring the dialog resizes if needed and 
-						// the buttons are laid out correctly
-						var dialog = new Dialog (titleEdit.Text, width, height, buttons.ToArray ());
-						var add = new Button ("Add a button") {
-							X = Pos.Center (),
-							Y = Pos.Center (),
-							Clicked = () => {
-								var buttonId = buttons.Count;
-								var button = new Button (btnText [buttonId % 10], is_default: buttonId == 0) {
-									Clicked = () => {
-										clicked = buttonId;
-										Application.RequestStop ();
-									},
-								};
-								buttons.Add (button);
-								dialog.AddButton (button);
-							},
+					var buttons = new List<Button> ();
+					var clicked = -1;
+					for (int i = 0; i < numButtons; i++) {
+						var buttonId = i;
+						var button = new Button (btnText [buttonId % 10],
+							is_default: buttonId == 0);
+						button.Clicked += () => {
+							clicked = buttonId;
+							Application.RequestStop ();
 						};
-						dialog.Add (add);
-
-						Application.Run (dialog);
-						buttonPressedLabel.Text = $"{clicked}";
-
-					} catch (FormatException) {
-						buttonPressedLabel.Text = "Invalid Options";
+						buttons.Add (button);
 					}
-				},
+
+					// This tests dynamically adding buttons; ensuring the dialog resizes if needed and 
+					// the buttons are laid out correctly
+					var dialog = new Dialog (titleEdit.Text, width, height,
+						buttons.ToArray ());
+					var add = new Button ("Add a button") {
+						X = Pos.Center (),
+						Y = Pos.Center (),
+
+					};
+					add.Clicked += () => {
+						var buttonId = buttons.Count;
+						var button = new Button (btnText [buttonId % 10],
+							is_default: buttonId == 0);
+						button.Clicked += () => {
+							clicked = buttonId;
+							Application.RequestStop ();
+						};
+						buttons.Add (button);
+						dialog.AddButton (button);
+					};
+					dialog.Add (add);
+
+					Application.Run (dialog);
+					buttonPressedLabel.Text = $"{clicked}";
+
+				} catch (FormatException) {
+					buttonPressedLabel.Text = "Invalid Options";
+				}
 			};
 			Win.Add (showDialogButton);
 

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -477,7 +477,7 @@ namespace UICatalog {
 				EditMenuBarItem (null);
 			};
 
-			_lblMenuBar.Enter = (e) => {
+			_lblMenuBar.Enter += (e) => {
 				if (_menuBar?.Menus != null) {
 					_currentMenuBarItem = _menuBar.Menus [_currentSelectedMenuBar];
 					EditMenuBarItem (_menuBar.Menus [_currentSelectedMenuBar]);

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -498,12 +498,12 @@ namespace UICatalog {
 				SelectCurrentMenuBarItem ();
 			};
 
-			_lstMenus.SelectedItemChanged = (e) => {
+			_lstMenus.SelectedItemChanged += (e) => {
 				var menuBarItem = DataContext.Menus.Count > 0 ? DataContext.Menus [e.Item].MenuItem : null;
 				EditMenuBarItem (menuBarItem);
 			};
 
-			_lstMenus.OpenSelectedItem = (e) => {
+			_lstMenus.OpenSelectedItem += (e) => {
 				_currentMenuBarItem = DataContext.Menus [e.Item].MenuItem;
 				DataContext.Parent = _currentMenuBarItem.Title;
 				DataContext.Menus = new List<DynamicMenuItemList> ();

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -270,13 +270,19 @@ namespace UICatalog {
 			var _btnOk = new Button ("Ok") {
 				X = Pos.Left (_lblTitle) + 20,
 				Y = Pos.Bottom (_rbChkStyle) + 1,
-				Clicked = () => {
-					if (ustring.IsNullOrEmpty (_txtTitle.Text) && _currentEditMenuBarItem != null) {
-						MessageBox.ErrorQuery ("Invalid title", "Must enter a valid title!.", "Ok");
-					} else if (_currentEditMenuBarItem != null) {
-						var menuItem = new DynamicMenuItem (_txtTitle.Text, _txtHelp.Text, _txtAction.Text, _ckbIsTopLevel != null ? _ckbIsTopLevel.Checked : false, _ckbSubMenu != null ? _ckbSubMenu.Checked : false, _rbChkStyle.SelectedItem == 0 ? MenuItemCheckStyle.NoCheck : _rbChkStyle.SelectedItem == 1 ? MenuItemCheckStyle.Checked : MenuItemCheckStyle.Radio);
-						UpdateMenuItem (_currentEditMenuBarItem, menuItem, _lstMenus.SelectedItem);
-					}
+			};
+			_btnOk.Clicked += () => {
+				if (ustring.IsNullOrEmpty (_txtTitle.Text) && _currentEditMenuBarItem != null) {
+					MessageBox.ErrorQuery ("Invalid title", "Must enter a valid title!.", "Ok");
+				} else if (_currentEditMenuBarItem != null) {
+					var menuItem = new DynamicMenuItem (_txtTitle.Text, _txtHelp.Text,
+						_txtAction.Text,
+						_ckbIsTopLevel != null ? _ckbIsTopLevel.Checked : false,
+						_ckbSubMenu != null ? _ckbSubMenu.Checked : false,
+						_rbChkStyle.SelectedItem == 0 ? MenuItemCheckStyle.NoCheck :
+						_rbChkStyle.SelectedItem == 1 ? MenuItemCheckStyle.Checked :
+						MenuItemCheckStyle.Radio);
+					UpdateMenuItem (_currentEditMenuBarItem, menuItem, _lstMenus.SelectedItem);
 				}
 			};
 			_frmMenuDetails.Add (_btnOk);
@@ -284,15 +290,15 @@ namespace UICatalog {
 			var _btnCancel = new Button ("Cancel") {
 				X = Pos.Right (_btnOk) + 3,
 				Y = Pos.Top (_btnOk),
-				Clicked = () => {
-					_txtTitle.Text = ustring.Empty;
-				}
+			};
+			_btnCancel.Clicked += () => {
+				_txtTitle.Text = ustring.Empty;
 			};
 			_frmMenuDetails.Add (_btnCancel);
 
 			Add (_frmMenuDetails);
 
-			_btnAdd.Clicked = () => {
+			_btnAdd.Clicked += () => {
 				if (MenuBar == null) {
 					MessageBox.ErrorQuery ("Menu Bar Error", "Must add a MenuBar first!", "Ok");
 					_btnAddMenuBar.SetFocus ();
@@ -328,7 +334,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnRemove.Clicked = () => {
+			_btnRemove.Clicked += () => {
 				var menuItem = DataContext.Menus.Count > 0 ? DataContext.Menus [_lstMenus.SelectedItem].MenuItem : null;
 				if (menuItem != null) {
 					var childrens = ((MenuBarItem)_currentMenuBarItem).Children;
@@ -355,7 +361,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnMenuBarUp.Clicked = () => {
+			_btnMenuBarUp.Clicked += () => {
 				var i = _currentSelectedMenuBar;
 				var menuItem = _menuBar != null && _menuBar.Menus.Length > 0 ? _menuBar.Menus [i] : null;
 				if (menuItem != null) {
@@ -369,7 +375,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnMenuBarDown.Clicked = () => {
+			_btnMenuBarDown.Clicked += () => {
 				var i = _currentSelectedMenuBar;
 				var menuItem = _menuBar != null && _menuBar.Menus.Length > 0 ? _menuBar.Menus [i] : null;
 				if (menuItem != null) {
@@ -383,7 +389,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnUp.Clicked = () => {
+			_btnUp.Clicked += () => {
 				var i = _lstMenus.SelectedItem;
 				var menuItem = DataContext.Menus.Count > 0 ? DataContext.Menus [i].MenuItem : null;
 				if (menuItem != null) {
@@ -398,7 +404,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnDown.Clicked = () => {
+			_btnDown.Clicked += () => {
 				var i = _lstMenus.SelectedItem;
 				var menuItem = DataContext.Menus.Count > 0 ? DataContext.Menus [i].MenuItem : null;
 				if (menuItem != null) {
@@ -413,7 +419,7 @@ namespace UICatalog {
 				}
 			};
 
-			_btnAddMenuBar.Clicked = () => {
+			_btnAddMenuBar.Clicked += () => {
 				var item = EnterMenuItem (null);
 				if (ustring.IsNullOrEmpty (item.title)) {
 					return;
@@ -439,7 +445,7 @@ namespace UICatalog {
 				_menuBar.SetNeedsDisplay ();
 			};
 
-			_btnRemoveMenuBar.Clicked = () => {
+			_btnRemoveMenuBar.Clicked += () => {
 				if (_menuBar != null && _menuBar.Menus.Length > 0) {
 					_menuBar.Menus [_currentSelectedMenuBar] = null;
 					int i = 0;
@@ -478,14 +484,14 @@ namespace UICatalog {
 				}
 			};
 
-			_btnPrevious.Clicked = () => {
+			_btnPrevious.Clicked += () => {
 				if (_currentSelectedMenuBar - 1 > -1) {
 					_currentSelectedMenuBar--;
 				}
 				SelectCurrentMenuBarItem ();
 			};
 
-			_btnNext.Clicked = () => {
+			_btnNext.Clicked += () => {
 				if (_menuBar != null && _currentSelectedMenuBar + 1 < _menuBar.Menus.Length) {
 					_currentSelectedMenuBar++;
 				}
@@ -506,7 +512,7 @@ namespace UICatalog {
 				EditMenuBarItem (menuBarItem);
 			};
 
-			_btnPreviowsParent.Clicked = () => {
+			_btnPreviowsParent.Clicked += () => {
 				if (_currentMenuBarItem != null && _currentMenuBarItem.Parent != null) {
 					var mi = _currentMenuBarItem;
 					_currentMenuBarItem = _currentMenuBarItem.Parent as MenuBarItem;
@@ -770,19 +776,18 @@ namespace UICatalog {
 				};
 				var _btnOk = new Button ("Ok") {
 					IsDefault = true,
-					Clicked = () => {
-						if (ustring.IsNullOrEmpty (_txtTitle.Text)) {
-							MessageBox.ErrorQuery ("Invalid title", "Must enter a valid title!.", "Ok");
-						} else {
-							Application.RequestStop ();
-						}
-					}
 				};
-				var _btnCancel = new Button ("Cancel") {
-					Clicked = () => {
-						_txtTitle.Text = ustring.Empty;
+				_btnOk.Clicked += () => {
+					if (ustring.IsNullOrEmpty (_txtTitle.Text)) {
+						MessageBox.ErrorQuery ("Invalid title", "Must enter a valid title!.", "Ok");
+					} else {
 						Application.RequestStop ();
 					}
+				};
+				var _btnCancel = new Button ("Cancel");
+				_btnCancel.Clicked += () => {
+					_txtTitle.Text = ustring.Empty;
+					Application.RequestStop ();
 				};
 				var _dialog = new Dialog ("Please enter the menu details.", _btnOk, _btnCancel);
 				_dialog.Add (_lblTitle, _txtTitle, _lblHelp, _txtHelp, _lblAction, _txtAction, _ckbIsTopLevel, _ckbSubMenu, _rbChkStyle);

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -236,7 +236,7 @@ namespace UICatalog {
 				Y = Pos.Bottom (_ckbIsTopLevel)
 			};
 			_frmMenuDetails.Add (_ckbSubMenu);
-			_ckbIsTopLevel.Toggled = (e) => {
+			_ckbIsTopLevel.Toggled += (e) => {
 				if (_ckbIsTopLevel.Checked && _currentEditMenuBarItem.Parent != null) {
 					MessageBox.ErrorQuery ("Invalid IsTopLevel", "Only menu bar can have top level menu item!", "Ok");
 					_ckbIsTopLevel.Checked = false;
@@ -250,7 +250,7 @@ namespace UICatalog {
 					_txtAction.ReadOnly = true;
 				}
 			};
-			_ckbSubMenu.Toggled = (e) => {
+			_ckbSubMenu.Toggled += (e) => {
 				if (_ckbSubMenu.Checked) {
 					_ckbIsTopLevel.Checked = false;
 					_ckbIsTopLevel.SetNeedsDisplay ();
@@ -746,7 +746,7 @@ namespace UICatalog {
 					Y = Pos.Bottom (_ckbIsTopLevel),
 					Checked = menuItem == null
 				};
-				_ckbIsTopLevel.Toggled = (e) => {
+				_ckbIsTopLevel.Toggled += (e) => {
 					if (_ckbIsTopLevel.Checked && menuItem != null) {
 						MessageBox.ErrorQuery ("Invalid IsTopLevel", "Only menu bar can have top level menu item!", "Ok");
 						_ckbIsTopLevel.Checked = false;
@@ -760,7 +760,7 @@ namespace UICatalog {
 						_txtAction.ReadOnly = true;
 					}
 				};
-				_ckbSubMenu.Toggled = (e) => {
+				_ckbSubMenu.Toggled += (e) => {
 					if (_ckbSubMenu.Checked) {
 						_ckbIsTopLevel.Checked = false;
 						_ckbIsTopLevel.SetNeedsDisplay ();

--- a/UICatalog/Scenarios/Generic.cs
+++ b/UICatalog/Scenarios/Generic.cs
@@ -7,11 +7,12 @@ namespace UICatalog {
 		public override void Setup ()
 		{
 			// Put your scenario code here, e.g.
-			Win.Add (new Button ("Press me!") {
+			var button = new Button ("Press me!") {
 				X = Pos.Center (),
 				Y = Pos.Center (),
-				Clicked = () => MessageBox.Query (20, 7, "Hi", "Neat?", "Yes", "No")
-			});
+			};
+			button.Clicked += () => MessageBox.Query (20, 7, "Hi", "Neat?", "Yes", "No");
+			Win.Add (button);
 		}
 	}
 }

--- a/UICatalog/Scenarios/LabelsAsButtons.cs
+++ b/UICatalog/Scenarios/LabelsAsButtons.cs
@@ -29,17 +29,17 @@ namespace UICatalog {
 				//TODO: Change to use Pos.AnchorEnd()
 				Y = Pos.Bottom (Win) - 3,
 				//IsDefault = true,
-				Clicked = () => Application.RequestStop (),
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
+			defaultLabel.Clicked += () => Application.RequestStop ();
 			Win.Add (defaultLabel);
 
 			var swapLabel = new Label (50, 0, "S_wap Default (Absolute Layout)") {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			swapLabel.Clicked = () => {
+			swapLabel.Clicked += () => {
 				//defaultLabel.IsDefault = !defaultLabel.IsDefault;
 				//swapLabel.IsDefault = !swapLabel.IsDefault;
 			};
@@ -47,7 +47,7 @@ namespace UICatalog {
 
 			static void DoMessage (Label Label, ustring txt)
 			{
-				Label.Clicked = () => {
+				Label.Clicked += () => {
 					var btnText = Label.Text.ToString ();
 					MessageBox.Query ("Message", $"Did you click {txt}?", "Yes", "No");
 				};
@@ -88,10 +88,10 @@ namespace UICatalog {
 			Win.Add (Label = new Label ("a Newline\nin the Label") {
 				X = 2,
 				Y = Pos.Bottom (Label) + 1,
-				Clicked = () => MessageBox.Query ("Message", "Question?", "Yes", "No"),
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			});
+			Label.Clicked += () => MessageBox.Query ("Message", "Question?", "Yes", "No");
 
 			var textChanger = new Label ("Te_xt Changer") {
 				X = 2,
@@ -100,7 +100,7 @@ namespace UICatalog {
 				CanFocus = true,
 			};
 			Win.Add (textChanger);
-			textChanger.Clicked = () => textChanger.Text += "!";
+			textChanger.Clicked += () => textChanger.Text += "!";
 
 			Win.Add (Label = new Label ("Lets see if this will move as \"Text Changer\" grows") {
 				X = Pos.Right (textChanger) + 2,
@@ -118,7 +118,7 @@ namespace UICatalog {
 			};
 			Win.Add (removeLabel);
 			// This in intresting test case because `moveBtn` and below are laid out relative to this one!
-			removeLabel.Clicked = () => Win.Remove (removeLabel);
+			removeLabel.Clicked += () => Win.Remove (removeLabel);
 
 			var computedFrame = new FrameView ("Computed Layout") {
 				X = 0,
@@ -137,7 +137,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			moveBtn.Clicked = () => {
+			moveBtn.Clicked += () => {
 				moveBtn.X = moveBtn.Frame.X + 5;
 				// This is already fixed with the call to SetNeedDisplay() in the Pos Dim.
 				//computedFrame.LayoutSubviews (); // BUGBUG: This call should not be needed. View.X is not causing relayout correctly
@@ -154,7 +154,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			sizeBtn.Clicked = () => {
+			sizeBtn.Clicked += () => {
 				sizeBtn.Width = sizeBtn.Frame.Width + 5;
 				//computedFrame.LayoutSubviews (); // FIXED: This call should not be needed. View.X is not causing relayout correctly
 			};
@@ -174,7 +174,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			moveBtnA.Clicked = () => {
+			moveBtnA.Clicked += () => {
 				moveBtnA.Frame = new Rect (moveBtnA.Frame.X + 5, moveBtnA.Frame.Y, moveBtnA.Frame.Width, moveBtnA.Frame.Height);
 			};
 			absoluteFrame.Add (moveBtnA);
@@ -185,7 +185,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			sizeBtnA.Clicked = () => {
+			sizeBtnA.Clicked += () => {
 				sizeBtnA.Frame = new Rect (sizeBtnA.Frame.X, sizeBtnA.Frame.Y, sizeBtnA.Frame.Width + 5, sizeBtnA.Frame.Height);
 			};
 			absoluteFrame.Add (sizeBtnA);
@@ -240,7 +240,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			moveHotKeyBtn.Clicked = () => {
+			moveHotKeyBtn.Clicked += () => {
 				moveHotKeyBtn.Text = MoveHotkey (moveHotKeyBtn.Text);
 			};
 			Win.Add (moveHotKeyBtn);
@@ -254,7 +254,7 @@ namespace UICatalog {
 				HotKeySpecifier = (System.Rune)'_',
 				CanFocus = true,
 			};
-			moveUnicodeHotKeyBtn.Clicked = () => {
+			moveUnicodeHotKeyBtn.Clicked += () => {
 				moveUnicodeHotKeyBtn.Text = MoveHotkey (moveUnicodeHotKeyBtn.Text);
 			};
 			Win.Add (moveUnicodeHotKeyBtn);

--- a/UICatalog/Scenarios/MessageBoxes.cs
+++ b/UICatalog/Scenarios/MessageBoxes.cs
@@ -148,25 +148,25 @@ namespace UICatalog {
 				X = Pos.Center(),
 				Y = Pos.Bottom (frame) + 2			,
 				IsDefault = true,
-				Clicked = () => {
-					try {
-						int width = int.Parse (widthEdit.Text.ToString ());
-						int height = int.Parse (heightEdit.Text.ToString ());
-						int numButtons = int.Parse (numButtonsEdit.Text.ToString ());
+			};
+			showMessageBoxButton.Clicked += () => {
+				try {
+					int width = int.Parse (widthEdit.Text.ToString ());
+					int height = int.Parse (heightEdit.Text.ToString ());
+					int numButtons = int.Parse (numButtonsEdit.Text.ToString ());
 
-						var btns = new List<ustring> ();
-						for (int i = 0; i < numButtons; i++) {
-							btns.Add(btnText[i % 10]);
-						}
-						if (styleRadioGroup.SelectedItem == 0) {
-							buttonPressedLabel.Text = $"{MessageBox.Query (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), btns.ToArray ())}";
-						} else {
-							buttonPressedLabel.Text = $"{MessageBox.ErrorQuery (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), btns.ToArray ())}";
-						}
-					} catch (FormatException) {
-						buttonPressedLabel.Text = "Invalid Options";
+					var btns = new List<ustring> ();
+					for (int i = 0; i < numButtons; i++) {
+						btns.Add(btnText[i % 10]);
 					}
-				},
+					if (styleRadioGroup.SelectedItem == 0) {
+						buttonPressedLabel.Text = $"{MessageBox.Query (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), btns.ToArray ())}";
+					} else {
+						buttonPressedLabel.Text = $"{MessageBox.ErrorQuery (width, height, titleEdit.Text.ToString (), messageEdit.Text.ToString (), btns.ToArray ())}";
+					}
+				} catch (FormatException) {
+					buttonPressedLabel.Text = "Invalid Options";
+				}
 			};
 			Win.Add (showMessageBoxButton);
 

--- a/UICatalog/Scenarios/Progress.cs
+++ b/UICatalog/Scenarios/Progress.cs
@@ -58,18 +58,18 @@ namespace UICatalog {
 				var startButton = new Button ("Start Timer") {
 					X = Pos.Right (LeftFrame) + 1,
 					Y = 0,
-					Clicked = () => Start()
 				};
+				startButton.Clicked += () => Start ();
 				var pulseButton = new Button ("Pulse") {
 					X = Pos.Right (startButton) + 2,
 					Y = Pos.Y (startButton),
-					Clicked = () => Pulse()
 				};
+				pulseButton.Clicked += () => Pulse ();
 				var stopbutton = new Button ("Stop Timer") {
 					X = Pos.Right (pulseButton) + 2,
 					Y = Pos.Top (pulseButton),
-					Clicked = () => Stop()
 				};
+				stopbutton.Clicked += () => Stop ();
 
 				Add (startButton);
 				Add (pulseButton);
@@ -225,7 +225,7 @@ namespace UICatalog {
 				X = Pos.Center (),
 				Y = Pos.Bottom(mainLoopTimeoutDemo) + 1,
 			};
-			startBoth.Clicked = () => {
+			startBoth.Clicked += () => {
 				systemTimerDemo.Start ();
 				mainLoopTimeoutDemo.Start ();
 			};

--- a/UICatalog/Scenarios/Scrolling.cs
+++ b/UICatalog/Scenarios/Scrolling.cs
@@ -149,18 +149,20 @@ namespace UICatalog {
 				verticalRuler.Text = vrule.Repeat ((int)Math.Ceiling ((double)(verticalRuler.Bounds.Height * 2) / (double)rule.Length)) [0..(verticalRuler.Bounds.Height * 2)];
 			};
 
-			scrollView.Add (new Button ("Press me!") {
+			var pressMeButton = new Button ("Press me!") {
 				X = 3,
 				Y = 3,
-				Clicked = () => MessageBox.Query (20, 7, "MessageBox", "Neat?", "Yes", "No")
-			});
+			};
+			pressMeButton.Clicked += () => MessageBox.Query (20, 7, "MessageBox", "Neat?", "Yes", "No");
+			scrollView.Add (pressMeButton);
 
-			scrollView.Add (new Button ("A very long button. Should be wide enough to demo clipping!") {
+			var aLongButton = new Button ("A very long button. Should be wide enough to demo clipping!") {
 				X = 3,
 				Y = 4,
 				Width = Dim.Fill (6),
-				Clicked = () => MessageBox.Query (20, 7, "MessageBox", "Neat?", "Yes", "No")
-			});
+			};
+			aLongButton.Clicked += () => MessageBox.Query (20, 7, "MessageBox", "Neat?", "Yes", "No");
+			scrollView.Add (aLongButton);
 
 			scrollView.Add (new TextField ("This is a test of...") {
 				X = 3,
@@ -189,7 +191,7 @@ namespace UICatalog {
 			};
 			// TODO: Use Pos.Width instead of (Right-Left) when implemented (#502)
 			anchorButton.X = Pos.AnchorEnd () - (Pos.Right (anchorButton) - Pos.Left (anchorButton));
-			anchorButton.Clicked = () => {
+			anchorButton.Clicked += () => {
 				// Ths demonstrates how to have a dynamically sized button
 				// Each time the button is clicked the button's text gets longer
 				// The call to Win.LayoutSubviews causes the Computed layout to

--- a/UICatalog/Scenarios/Scrolling.cs
+++ b/UICatalog/Scenarios/Scrolling.cs
@@ -257,7 +257,7 @@ namespace UICatalog {
 			};
 			var filler = new Filler (new Rect (0, 0, 60, 40));
 			scrollView2.Add (filler);
-			scrollView2.DrawContent = (r) => {
+			scrollView2.DrawContent += (r) => {
 				scrollView2.ContentSize = filler.GetContentSize ();
 			};
 

--- a/UICatalog/Scenarios/SystemConsole.cs
+++ b/UICatalog/Scenarios/SystemConsole.cs
@@ -24,11 +24,12 @@ namespace UICatalog {
 
 		public override void Setup ()
 		{
-		       Win.Add (new Button ("Press me!") {
-			       X = Pos.Center (),
-			       Y = Pos.Center (),
-			       Clicked = () => MessageBox.Query (20, 7, "Hi", "Neat?", "Yes", "No")
-		       });
+			var pressMe = new Button ("Press me!") {
+				X = Pos.Center (),
+				Y = Pos.Center (),
+			};
+			pressMe.Clicked += () => MessageBox.Query (20, 7, "Hi", "Neat?", "Yes", "No");
+			Win.Add (pressMe);
 		}
 	}
 }

--- a/UICatalog/Scenarios/TextAlignments.cs
+++ b/UICatalog/Scenarios/TextAlignments.cs
@@ -40,7 +40,7 @@ namespace UICatalog {
 				ColorScheme = Colors.TopLevel,
 				Text = txt,
 			};
-			edit.TextChanged = () => {
+			edit.TextChanged += () => {
 				foreach (var alignment in alignments) {
 					singleLines [(int)alignment].Text = edit.Text;
 					multipleLines [(int)alignment].Text = edit.Text;

--- a/UICatalog/Scenarios/TextAlignments.cs
+++ b/UICatalog/Scenarios/TextAlignments.cs
@@ -51,20 +51,21 @@ namespace UICatalog {
 			var unicodeSample = new Button ("Unicode Sample") {
 				X = Pos.Right (edit) + 1,
 				Y = 0,
-				Clicked = () => {
-					edit.Text = unicodeSampleText;
-				}
+			};
+			unicodeSample.Clicked += () => {
+				edit.Text = unicodeSampleText;
 			};
 			Win.Add (unicodeSample);
 
 			var update = new Button ("_Update") {
 				X = Pos.Right (edit) + 1,
 				Y = Pos.Bottom (edit) - 1,
-				Clicked = () => {
-					foreach (var alignment in alignments) {
-						singleLines [(int)alignment].Text = edit.Text;
-						multipleLines [(int)alignment].Text = edit.Text;
-					}
+				
+			};
+			update.Clicked += () => {
+				foreach (var alignment in alignments) {
+					singleLines [(int) alignment].Text = edit.Text;
+					multipleLines [(int) alignment].Text = edit.Text;
 				}
 			};
 			Win.Add (update);

--- a/UICatalog/Scenarios/TimeAndDate.cs
+++ b/UICatalog/Scenarios/TimeAndDate.cs
@@ -99,23 +99,24 @@ namespace UICatalog {
 			};
 			Win.Add (lblDateFmt);
 
-			Win.Add (new Button ("Swap Long/Short & Read/Read Only") {
+			var swapButton = new Button ("Swap Long/Short & Read/Read Only") {
 				X = Pos.Center (),
 				Y = Pos.Bottom (Win) - 5,
-				Clicked = () => {
-					longTime.ReadOnly = !longTime.ReadOnly;
-					shortTime.ReadOnly = !shortTime.ReadOnly;
+			};
+			swapButton.Clicked += () => {
+				longTime.ReadOnly = !longTime.ReadOnly;
+				shortTime.ReadOnly = !shortTime.ReadOnly;
 
-					longTime.IsShortFormat = !longTime.IsShortFormat;
-					shortTime.IsShortFormat = !shortTime.IsShortFormat;
+				longTime.IsShortFormat = !longTime.IsShortFormat;
+				shortTime.IsShortFormat = !shortTime.IsShortFormat;
 
-					longDate.ReadOnly = !longDate.ReadOnly;
-					shortDate.ReadOnly = !shortDate.ReadOnly;
+				longDate.ReadOnly = !longDate.ReadOnly;
+				shortDate.ReadOnly = !shortDate.ReadOnly;
 
-					longDate.IsShortFormat = !longDate.IsShortFormat;
-					shortDate.IsShortFormat = !shortDate.IsShortFormat;
-				}
-			});
+				longDate.IsShortFormat = !longDate.IsShortFormat;
+				shortDate.IsShortFormat = !shortDate.IsShortFormat;
+			};
+			Win.Add (swapButton);
 		}
 
 		private void TimeChanged (DateTimeEventArgs<TimeSpan> e)

--- a/UICatalog/Scenarios/WindowsAndFrameViews.cs
+++ b/UICatalog/Scenarios/WindowsAndFrameViews.cs
@@ -60,12 +60,13 @@ namespace UICatalog {
 				Height = Dim.Percent (15)
 			};
 			Win.ColorScheme = Colors.Dialog;
-			Win.Add (new Button ($"Padding of container is {padding}") {
+			var paddingButton = new Button ($"Padding of container is {padding}") {
 				X = Pos.Center (),
 				Y = 0,
 				ColorScheme = Colors.Error,
-				Clicked = () => About ()
-			});
+			};
+			paddingButton.Clicked += () => About ();
+			Win.Add (paddingButton);
 			Win.Add (new Button ("Press ME! (Y = Pos.AnchorEnd(1))") {
 				X = Pos.Center (),
 				Y = Pos.AnchorEnd (1),
@@ -83,12 +84,14 @@ namespace UICatalog {
 					Height = contentHeight + (i * 2) + 2,
 				};
 				win.ColorScheme = Colors.Dialog;
-				win.Add (new Button ("Press me! (Y = 0)") {
+				var pressMeButton = new Button ("Press me! (Y = 0)") {
 					X = Pos.Center (),
 					Y = 0,
 					ColorScheme = Colors.Error,
-					Clicked = () => MessageBox.ErrorQuery (win.Title.ToString (), "Neat?", "Yes", "No")
-				});
+				};
+				pressMeButton.Clicked += () =>
+					MessageBox.ErrorQuery (win.Title.ToString (), "Neat?", "Yes", "No");
+				win.Add (pressMeButton);
 				var subWin = new Window ("Sub Window") {
 					X = Pos.Percent (0),
 					Y = 1,

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -96,10 +96,14 @@ namespace UICatalog {
 				scenario.Init (Application.Top, _baseColorScheme);
 				scenario.Setup ();
 				scenario.Run ();
-				_top.Ready += () => {
+
+				static void ReadyHandler ()
+				{
 					_rightPane.SetFocus ();
-					_top.Ready = null;
-				};
+					_top.Ready -= ReadyHandler;
+				}
+				
+				_top.Ready += ReadyHandler;
 
 #if DEBUG_IDISPOSABLE
 				// After the scenario runs, validate all Responder-based instances

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -966,17 +966,12 @@ namespace Terminal.Gui {
 				return true;
 			});
 
-			t.Ready = () => {
-				FirstDialogToplevel ();
-			};
+			t.Ready += FirstDialogToplevel;
 
 			void FirstDialogToplevel ()
 			{
-				var od = new OpenDialog {
-					Ready = () => {
-						SecoundDialogToplevel ();
-					}
-				};
+				var od = new OpenDialog();
+				od.Ready += SecoundDialogToplevel;
 
 				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
 					count1++;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR introduces a massive breaking change, it converts every `public Action<TEventArgs> EventName;` into a C# event `public event Action<TEventArgs> EventName;` Following the [discussion](https://twitter.com/worldbeaterdev/status/1308485191942451206) with @migueldeicaza on Twitter, there are a couple of reasons for doing this.

The first reason is, that an IDE like Microsoft Visual Studio or JetBrains Rider **highlights** `Action`s declared with the `event` keyword with ⚡, making the events easier to discover among the suggested methods, fields, and properties. All events in Xamarin Forms, WPF, Windows Forms, and [Avalonia](https://github.com/AvaloniaUI/Avalonia/blob/75c3707d5d9ba56a356ac3924426dcf478549052/src/Avalonia.Input/IInputElement.cs#L16) are declared with the `event` keyword, and this makes the process of interacting with them a tiny bit easier. Having events highlighted with ⚡ in the IDE is cool stuff.

![ezgif-7-7ac02673d0dd](https://user-images.githubusercontent.com/6759207/93945438-91da6f00-fd3f-11ea-9dd5-cb275fa352b4.gif)

Another reason is, that tools like [Pharmacist](https://github.com/reactiveui/pharmacist) that do code generation are processing **only** those `Action`s that are defined as `event`s. [Pharmacist](https://github.com/reactiveui/pharmacist) is a tool that turns all events in a given assembly into `IObservable` wrappers, and this improves the dev experience for those developers, who decide to use `Terminal.Gui` with [reactive extensions](https://github.com/dotnet/reactive), and with the [ReactiveUI](https://github.com/reactiveui/reactiveui) MVVM framework. In short, Pharmacist allows us to write the following code:

```cs
// Reactive way of processing streams of events.
var item = new CheckBox();
var subscription =
    item.Events()
        .Toggled
        .Where(toggled => toggled)
        .Subscribe(_ => Console.WriteLine("Toggled!"))
        .DisposeWith(cleanup);

// Unsubscribe from the notifications.
subscription.Dispose();
```

Instead of the following code:

```cs
// Traidional way of implementing the pattern shown above.
var item = new CheckBox();

void OnToggled(bool toggled) {
    if (toggled) {
        Console.WriteLine("Toggled!");
    }
}

item.Toggled += OnToggled;

// Unsubscribe from the notifications.
item.Toggled -= OnToggled;
```

It may seem like a matter of taste, but reactive extensions are [really powerful](https://youtu.be/DYEbUF4xs1Q), and there are a lot of tasty extension methods. There is also a [demo view](https://github.com/worldbeater/ReactiveMvvm/blob/main/src/ReactiveMvvm.Terminal/Views/FeedbackView.cs) that shows how to combine MVVM, ReactiveUI, and `Terminal.Gui`. 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, most events are defined as follows:

```cs
public Action<SelectedItemChangedArgs> SelectedItemChanged;
```

**What is the new behavior?**
<!-- If this is a feature change -->

Now, most events are defined as follows:

```cs
public event Action<SelectedItemChangedArgs> SelectedItemChanged;
```

**What might this PR break?**

If folks are using the following syntax:

```cs
scrollView.DrawContent = args => {
    // Do stuff
};
```

Then they'll definitely break. The solution would be to change the code block above to:

```cs
scrollView.DrawContent += args => {
    // Do stuff
};
```

Thanks in advance for reviewing this.