### PR TITLE
Removal NameFieldLabel. Change "Open" to "File"

### DIFF
--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -479,16 +479,15 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Initializes a new <see cref="FileDialog"/>.
 		/// </summary>
-		public FileDialog () : this (title: string.Empty, prompt: string.Empty, nameFieldLabel: string.Empty, message: string.Empty) { }
+		public FileDialog () : this (title: string.Empty, prompt: string.Empty, message: string.Empty) { }
 
 		/// <summary>
 		/// Initializes a new instance of <see cref="FileDialog"/>
 		/// </summary>
 		/// <param name="title">The title.</param>
 		/// <param name="prompt">The prompt.</param>
-		/// <param name="nameFieldLabel">The name field label.</param>
 		/// <param name="message">The message.</param>
-		public FileDialog (ustring title, ustring prompt, ustring nameFieldLabel, ustring message) : base (title)//, Driver.Cols - 20, Driver.Rows - 5, null)
+		public FileDialog (ustring title, ustring prompt, ustring message) : base (title)//, Driver.Cols - 20, Driver.Rows - 5, null)
 		{
 			this.message = new Label (message) { 
 				X = 1,
@@ -513,7 +512,7 @@ namespace Terminal.Gui {
 			};
 			Add (dirLabel, dirEntry);
 
-			this.nameFieldLabel = new Label ("Open: ") {
+			this.nameFieldLabel = new Label ("File:") {
 				X = 6,
 				Y = 3 + msgLines,
 			};
@@ -686,7 +685,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="title">The title.</param>
 		/// <param name="message">The message.</param>
-		public SaveDialog (ustring title, ustring message) : base (title, prompt: "Save", nameFieldLabel: "Save as:", message: message) { }
+		public SaveDialog (ustring title, ustring message) : base (title, prompt: "Save", message: message) { }
 
 		/// <summary>
 		/// Gets the name of the file the user selected for saving, or null
@@ -731,7 +730,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="title"></param>
 		/// <param name="message"></param>
-		public OpenDialog (ustring title, ustring message) : base (title, prompt: "Open", nameFieldLabel: "Open", message: message)
+		public OpenDialog (ustring title, ustring message) : base (title, prompt: "Open", message: message)
 		{
 		}
 


### PR DESCRIPTION
I noticed the SaveDialog used Open for the filename. 

The NameFieldLabel was hardcoded and ignoring the value passed by the OpenDialog and SaveDialog

![Save1](https://user-images.githubusercontent.com/1786698/99193546-be12da80-2747-11eb-9dfd-02936e59d5cd.png)

At first I changed it to use the passed fields but it doesn't really make since with Open and Save as the file name. The buttons at the bottom are Open and Save. 

![Save2](https://user-images.githubusercontent.com/1786698/99193585-fe725880-2747-11eb-8218-df111f362323.png)

The top field is the directory and the bottom is the filename it self. I think it would make sense to name it "File" or "Filename" like Directory. 
![File1](https://user-images.githubusercontent.com/1786698/99193598-12b65580-2748-11eb-96b8-a44bf711ce5e.png)
![File2](https://user-images.githubusercontent.com/1786698/99193601-15b14600-2748-11eb-9ae5-ae09fb8097d3.png)
![Word](https://user-images.githubusercontent.com/1786698/99193603-1813a000-2748-11eb-8faf-bb32abe43be9.PNG)

This matches normal FileDialogs as well. So if this would stay hard coded I just removed the the input fields from the Open and SaveDialogs all together. 
