### PR TITLE
Trying fixing #518. Almost functions work on both Windows and Unix with the NetDriver.

### DIFF
--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -17,9 +17,9 @@ namespace Terminal.Gui {
 	/// This is the Curses driver for the gui.cs/Terminal framework.
 	/// </summary>
 	internal class CursesDriver : ConsoleDriver {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 		public override int Cols => Curses.Cols;
 		public override int Rows => Curses.Lines;
+		public override int Top => 0;
 
 		// Current row, and current col, tracked by Move/AddRune only
 		int ccol, crow;
@@ -907,7 +907,5 @@ namespace Terminal.Gui {
 			killpg (0, signal);
 			return true;
 		}
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 	}
-
 }

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -15,15 +15,11 @@ namespace Terminal.Gui {
 	/// Implements a mock ConsoleDriver for unit testing
 	/// </summary>
 	public class FakeDriver : ConsoleDriver {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 		int cols, rows;
-		/// <summary>
-		/// 
-		/// </summary>
 		public override int Cols => cols;
-		/// <summary>
-		/// 
-		/// </summary>
 		public override int Rows => rows;
+		public override int Top => 0;
 
 		// The format is rows, columns and 3 values on the last column: Rune, Attribute and Dirty Flag
 		int [,,] contents;
@@ -49,9 +45,6 @@ namespace Terminal.Gui {
 
 		static bool sync = false;
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public FakeDriver ()
 		{
 			cols = FakeConsole.WindowWidth;
@@ -62,11 +55,6 @@ namespace Terminal.Gui {
 		bool needMove;
 		// Current row, and current col, tracked by Move/AddCh only
 		int ccol, crow;
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="col"></param>
-		/// <param name="row"></param>
 		public override void Move (int col, int row)
 		{
 			ccol = col;
@@ -84,10 +72,6 @@ namespace Terminal.Gui {
 
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="rune"></param>
 		public override void AddRune (Rune rune)
 		{
 			rune = MakePrintable (rune);
@@ -113,19 +97,12 @@ namespace Terminal.Gui {
 				UpdateScreen ();
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="str"></param>
 		public override void AddStr (ustring str)
 		{
 			foreach (var rune in str)
 				AddRune (rune);
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void End ()
 		{
 			FakeConsole.ResetColor ();
@@ -138,10 +115,6 @@ namespace Terminal.Gui {
 			return new Attribute () { value = ((((int)f) & 0xffff) << 16) | (((int)b) & 0xffff) };
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="terminalResized"></param>
 		public override void Init (Action terminalResized)
 		{
 			Colors.TopLevel = new ColorScheme ();
@@ -185,12 +158,6 @@ namespace Terminal.Gui {
 			//MockConsole.Clear ();
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="fore"></param>
-		/// <param name="back"></param>
-		/// <returns></returns>
 		public override Attribute MakeAttribute (Color fore, Color back)
 		{
 			return MakeColor ((ConsoleColor)fore, (ConsoleColor)back);
@@ -211,9 +178,6 @@ namespace Terminal.Gui {
 			}
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void UpdateScreen ()
 		{
 			int rows = Rows;
@@ -233,9 +197,6 @@ namespace Terminal.Gui {
 			}
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void Refresh ()
 		{
 			int rows = Rows;
@@ -267,40 +228,24 @@ namespace Terminal.Gui {
 			FakeConsole.CursorLeft = savedCol;
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void UpdateCursor ()
 		{
 			//
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void StartReportingMouseMoves ()
 		{
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void StopReportingMouseMoves ()
 		{
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void Suspend ()
 		{
 		}
 
 		int currentAttribute;
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="c"></param>
 		public override void SetAttribute (Attribute c)
 		{
 			currentAttribute = c.value;
@@ -417,18 +362,10 @@ namespace Terminal.Gui {
 			return keyMod != Key.Null ? keyMod | key : key;
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="mainLoop"></param>
-		/// <param name="keyHandler"></param>
-		/// <param name="keyDownHandler"></param>
-		/// <param name="keyUpHandler"></param>
-		/// <param name="mouseHandler"></param>
 		public override void PrepareToRun (MainLoop mainLoop, Action<KeyEvent> keyHandler, Action<KeyEvent> keyDownHandler, Action<KeyEvent> keyUpHandler, Action<MouseEvent> mouseHandler)
 		{
 			// Note: Net doesn't support keydown/up events and thus any passed keyDown/UpHandlers will never be called
-			(mainLoop.Driver as NetMainLoop).KeyPressed = delegate (ConsoleKeyInfo consoleKey) {
+			(mainLoop.Driver as FakeMainLoop).KeyPressed = delegate (ConsoleKeyInfo consoleKey) {
 				var map = MapKey (consoleKey);
 				if (map == (Key)0xffffffff)
 					return;
@@ -452,38 +389,23 @@ namespace Terminal.Gui {
 			};
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="foreground"></param>
-		/// <param name="background"></param>
 		public override void SetColors (ConsoleColor foreground, ConsoleColor background)
 		{
 			throw new NotImplementedException ();
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="foregroundColorId"></param>
-		/// <param name="backgroundColorId"></param>
 		public override void SetColors (short foregroundColorId, short backgroundColorId)
 		{
 			throw new NotImplementedException ();
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void CookMouse ()
 		{
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
 		public override void UncookMouse ()
 		{
 		}
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 	}
 }

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeMainLoop.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeMainLoop.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading;
+
+namespace Terminal.Gui {
+	/// <summary>
+	/// Mainloop intended to be used with the .NET System.Console API, and can
+	/// be used on Windows and Unix, it is cross platform but lacks things like
+	/// file descriptor monitoring.
+	/// </summary>
+	/// <remarks>
+	/// This implementation is used for FakeDriver.
+	/// </remarks>
+	public class FakeMainLoop : IMainLoopDriver {
+		AutoResetEvent keyReady = new AutoResetEvent (false);
+		AutoResetEvent waitForProbe = new AutoResetEvent (false);
+		ConsoleKeyInfo? keyResult = null;
+		MainLoop mainLoop;
+		Func<ConsoleKeyInfo> consoleKeyReaderFn = null;
+
+		/// <summary>
+		/// Invoked when a Key is pressed.
+		/// </summary>
+		public Action<ConsoleKeyInfo> KeyPressed;
+
+		/// <summary>
+		/// Initializes the class.
+		/// </summary>
+		/// <remarks>
+		///   Passing a consoleKeyReaderfn is provided to support unit test scenarios.
+		/// </remarks>
+		/// <param name="consoleKeyReaderFn">The method to be called to get a key from the console.</param>
+		public FakeMainLoop (Func<ConsoleKeyInfo> consoleKeyReaderFn = null)
+		{
+			if (consoleKeyReaderFn == null) {
+				throw new ArgumentNullException ("key reader function must be provided.");
+			}
+			this.consoleKeyReaderFn = consoleKeyReaderFn;
+		}
+
+		void WindowsKeyReader ()
+		{
+			while (true) {
+				waitForProbe.WaitOne ();
+				keyResult = consoleKeyReaderFn ();
+				keyReady.Set ();
+			}
+		}
+
+		void IMainLoopDriver.Setup (MainLoop mainLoop)
+		{
+			this.mainLoop = mainLoop;
+			Thread readThread = new Thread (WindowsKeyReader);
+			readThread.Start ();
+		}
+
+		void IMainLoopDriver.Wakeup ()
+		{
+		}
+
+		bool IMainLoopDriver.EventsPending (bool wait)
+		{
+			long now = DateTime.UtcNow.Ticks;
+
+			int waitTimeout;
+			if (mainLoop.timeouts.Count > 0) {
+				waitTimeout = (int)((mainLoop.timeouts.Keys [0] - now) / TimeSpan.TicksPerMillisecond);
+				if (waitTimeout < 0)
+					return true;
+			} else
+				waitTimeout = -1;
+
+			if (!wait)
+				waitTimeout = 0;
+
+			keyResult = null;
+			waitForProbe.Set ();
+			keyReady.WaitOne (waitTimeout);
+			return keyResult.HasValue;
+		}
+
+		void IMainLoopDriver.MainIteration ()
+		{
+			if (keyResult.HasValue) {
+				KeyPressed?.Invoke (keyResult.Value);
+				keyResult = null;
+			}
+		}
+	}
+}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -510,6 +510,7 @@ namespace Terminal.Gui {
 
 		public override int Cols => cols;
 		public override int Rows => rows;
+		public override int Top => 0;
 
 		public WindowsDriver ()
 		{

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -190,8 +190,8 @@ namespace Terminal.Gui {
 			if (Driver == null) {
 				var p = Environment.OSVersion.Platform;
 				if (UseSystemConsole) {
-					mainLoopDriver = new NetMainLoop (() => Console.ReadKey (true));
 					Driver = new NetDriver ();
+					mainLoopDriver = new NetMainLoop (Driver);
 				} else if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows) {
 					var windowsDriver = new WindowsDriver ();
 					mainLoopDriver = windowsDriver;

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -542,6 +542,11 @@ namespace Terminal.Gui {
 		/// </summary>
 		public abstract int Rows { get; }
 		/// <summary>
+		/// The current top in the terminal.
+		/// </summary>
+		public abstract int Top { get; }
+
+		/// <summary>
 		/// Initializes the driver
 		/// </summary>
 		/// <param name="terminalResized">Method to invoke when the terminal is resized.</param>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1912,7 +1912,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Used by <see cref="Text"/> to resize the view's <see cref="Bounds"/> with the <see cref="TextFormatter.Size"/>.
-		/// Setting <see cref="Auto"/> to true only work if the <see cref="Width"/> and <see cref="Height"/> are null or
+		/// Setting <see cref="AutoSize"/> to true only work if the <see cref="Width"/> and <see cref="Height"/> are null or
 		///   <see cref="LayoutStyle.Absolute"/> values and doesn't work with <see cref="LayoutStyle.Computed"/> layout,
 		///   to avoid breaking the <see cref="Pos"/> and <see cref="Dim"/> settings.
 		/// </summary>

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1095,6 +1095,10 @@ namespace Terminal.Gui {
 		/// <param name="row">Row.</param>
 		public void Move (int col, int row)
 		{
+			if (Driver.Rows == 0) {
+				return;
+			}
+
 			ViewToScreen (col, row, out var rcol, out var rrow);
 			Driver.Move (rcol, rrow);
 		}

--- a/UICatalog/Scenarios/Threading.cs
+++ b/UICatalog/Scenarios/Threading.cs
@@ -127,6 +127,7 @@ namespace UICatalog {
 			await Task.Delay (3000);
 			LogJob ("Returning from task method");
 			await _itemsList.SetSourceAsync (items);
+			_itemsList.SetNeedsDisplay ();
 		}
 
 		private CancellationTokenSource cancellationTokenSource;

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -28,7 +28,7 @@ namespace Terminal.Gui {
 			Assert.Null (Application.MainLoop);
 			Assert.Null (Application.Driver);
 
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			Assert.NotNull (Application.Current);
 			Assert.NotNull (Application.CurrentView);
 			Assert.NotNull (Application.Top);
@@ -66,7 +66,7 @@ namespace Terminal.Gui {
 
 		void Init ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey(true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			Assert.NotNull (Application.Driver);
 			Assert.NotNull (Application.MainLoop);
 		}

--- a/UnitTests/ConsoleDriverTests.cs
+++ b/UnitTests/ConsoleDriverTests.cs
@@ -11,7 +11,7 @@ namespace Terminal.Gui {
 		public void Init_Inits ()
 		{
 			var driver = new FakeDriver ();
-			Application.Init (driver, new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (driver, new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			driver.Init (() => { });
 
 			Assert.Equal (80, Console.BufferWidth);
@@ -27,7 +27,7 @@ namespace Terminal.Gui {
 		public void End_Cleans_Up ()
 		{
 			var driver = new FakeDriver ();
-			Application.Init (driver, new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (driver, new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			driver.Init (() => { });
 
 			FakeConsole.ForegroundColor = ConsoleColor.Red;
@@ -50,7 +50,7 @@ namespace Terminal.Gui {
 		public void SetColors_Changes_Colors ()
 		{
 			var driver = new FakeDriver ();
-			Application.Init (driver, new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (driver, new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			driver.Init (() => { });
 			Assert.Equal (ConsoleColor.Gray, Console.ForegroundColor);
 			Assert.Equal (ConsoleColor.Black, Console.BackgroundColor);

--- a/UnitTests/DimTests.cs
+++ b/UnitTests/DimTests.cs
@@ -247,7 +247,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Dim_Validation_Throws_If_NewValue_Is_DimAbsolute_And_OldValue_Is_Another_Type ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -279,7 +279,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Dim_Validation_Do_Not_Throws_If_NewValue_Is_DimAbsolute_And_OldValue_Is_Null ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -300,7 +300,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Dim_Validation_Do_Not_Throws_If_NewValue_Is_DimAbsolute_And_OldValue_Is_Another_Type_After_Sets_To_LayoutStyle_Absolute ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -333,7 +333,7 @@ namespace Terminal.Gui {
 		{
 			// Testing with the Button because it properly handles the Dim class.
 
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 

--- a/UnitTests/MainLoopTests.cs
+++ b/UnitTests/MainLoopTests.cs
@@ -18,7 +18,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Constructor_Setups_Driver ()
 		{
-			var ml = new MainLoop (new NetMainLoop(() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			Assert.NotNull (ml.Driver);
 		}
 
@@ -26,7 +26,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddIdle_Adds_And_Removes ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			Func<bool> fnTrue = () => { return true; };
 			Func<bool> fnFalse = () => { return false; };
@@ -60,7 +60,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddIdle_Function_GetsCalled_OnIteration ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn = () => {
@@ -76,7 +76,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void RemoveIdle_Function_NotCalled ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn = () => {
@@ -93,7 +93,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddThenRemoveIdle_Function_NotCalled ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn = () => {
@@ -111,7 +111,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTwice_Function_CalledTwice ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn = () => {
@@ -139,7 +139,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void False_Idle_Stops_It_Being_Called_Again ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn1 = () => {
@@ -172,7 +172,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddIdle_Twice_Returns_False_Called_Twice ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn1 = () => {
@@ -204,7 +204,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Run_Runs_Idle_Stop_Stops_Idle ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var functionCalled = 0;
 			Func<bool> fn = () => {
@@ -226,7 +226,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_Adds_Removes_NoFaults ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = 100;
 
 			var callbackCount = 0;
@@ -246,7 +246,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_Run_Called ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = 100;
 
 			var callbackCount = 0;
@@ -274,7 +274,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_Run_CalledAtApproximatelyRightTime ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = TimeSpan.FromMilliseconds (50);
 			var watch = new System.Diagnostics.Stopwatch ();
 
@@ -300,7 +300,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_Run_CalledTwiceApproximatelyRightTime ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = TimeSpan.FromMilliseconds (50);
 			var watch = new System.Diagnostics.Stopwatch ();
 
@@ -328,7 +328,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_Remove_NotCalled ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = TimeSpan.FromMilliseconds (50);
 
 			// Force stop if 10 iterations
@@ -357,7 +357,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void AddTimer_ReturnFalse_StopsBeingCalled ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			var ms = TimeSpan.FromMilliseconds (50);
 
 			// Force stop if 10 iterations
@@ -390,7 +390,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Invoke_Adds_Idle ()
 		{
-			var ml = new MainLoop (new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			var ml = new MainLoop (new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var actionCalled = 0;
 			ml.Invoke (() => { actionCalled++; });

--- a/UnitTests/PosTests.cs
+++ b/UnitTests/PosTests.cs
@@ -262,7 +262,7 @@ namespace Terminal.Gui {
 			// Setup Fake driver
 			(Window win, Button button) setup ()
 			{
-				Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 				Application.Iteration = () => {
 					Application.RequestStop ();
 				};
@@ -374,7 +374,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Pos_Validation_Throws_If_NewValue_Is_PosAbsolute_And_OldValue_Is_Another_Type ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -406,7 +406,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Pos_Validation_Do_Not_Throws_If_NewValue_Is_PosAbsolute_And_OldValue_Is_Null ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -428,7 +428,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Pos_Validation_Do_Not_Throws_If_NewValue_Is_PosAbsolute_And_OldValue_Is_Another_Type_After_Sets_To_LayoutStyle_Absolute ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 

--- a/UnitTests/ScenarioTests.cs
+++ b/UnitTests/ScenarioTests.cs
@@ -55,7 +55,7 @@ namespace Terminal.Gui {
 						Application.RequestStop ();
 					}
 				};
-				Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 				var ms = 1000;
 				var abortCount = 0;
@@ -107,7 +107,7 @@ namespace Terminal.Gui {
 					Application.RequestStop ();
 				}
 			};
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var ms = 1000;
 			var abortCount = 0;

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -544,7 +544,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Initialized_Event_Comparing_With_Added_Event ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = new Toplevel () { Id = "0", };
 
@@ -643,7 +643,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Initialized_Event_Will_Be_Invoked_When_Added_Dynamically ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = new Toplevel () { Id = "0", };
 
@@ -751,7 +751,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void CanFocus_Faced_With_Container_Before_Run ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -788,7 +788,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void CanFocus_Faced_With_Container_After_Run ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -831,7 +831,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void CanFocus_Container_ToFalse_Turns_All_Subviews_ToFalse_Too ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -866,7 +866,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void CanFocus_Container_Toggling_All_Subviews_To_Old_Value_When_Is_True ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 
@@ -910,7 +910,7 @@ namespace Terminal.Gui {
 		{
 			// Non-regression test for #882 (NullReferenceException during keyboard navigation when Focused is null)
 
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			Application.Top.Ready += () => {
 				Assert.Null (Application.Top.Focused);
@@ -928,7 +928,7 @@ namespace Terminal.Gui {
 		[Fact]
 		public void Multi_Thread_Toplevels ()
 		{
-			Application.Init (new FakeDriver (), new NetMainLoop (() => FakeConsole.ReadKey (true)));
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var t = Application.Top;
 			var w = new Window ();


### PR DESCRIPTION
- To run this PR is needed passing the -usc argument in the `UICatalog` project or uncomment the `Application.UseSystemConsole = true;` in the `Example `or `UICatalog `projects. On the `UICatalog `trying select "`Use System Console`" from the menu item "`Diagnostics`", which is bad spelled, won't work because a driver must be setted on startup and not after driver was being created. To open the menu press `F9` or `Alt+hotkey`.
- Interestingly, it runs faster on `WSL `than on `CMD`.
- Consumes more `CPU `stress than the `WindowsDriver `or `CursesDriver `may be due the workaround with the `WaitWinChange `loop method to capture window resizing.
- It could be a good alternative to use a common platform for both `OS `with the new `Net5.0` version fusion of the `Net Core` and `Net Framework` in only one tool. But we need to wait a long time yet :-)
- I think that the `CSI (Code Sequence Identifier)` could be a cross reference to achieve most of the common functions cross platform `OS `compatible.
- Control keys, like `Ctrl`, `Alt`, `Shift`, `Capslock `and `Numlock`, aren't detected alone without combinations with other keys.
- In `WSL` `Shift+End` prints "`1;2F`" on a `TextField `instead selecting the characters on the right.
- I think mouse interaction could be achieved with `CSI `code and developers with more knowledge with code sequences would be a very good help.
- I would prefer convert the buffer size with current window size but I couldn't achieve and that why I created the new abstract property `Top `to only display from the current windows top unto the window height. Unfortunately in the `WSL `the `Top `is always equal to `0` no matter where the position of the vertical scroll bar.
- The good news is that all events like timers, events actions methods, thread events, all work without any problems. Try run the `Threading `scenario and you will see that.
- On `WSL `the terminal does not hangs with the Net5.0 unlike using ncurses.
- The `UICatalog `"`Diagnostics`" menu was changed to use all the `Enum ConsoleDriver.DiagnosticFlags` and was removed the "`Use _System Console`" which has nothing to do with these diagnostics.