### PR TITLE
New Control 'TableView' for viewing tabular data

### DIFF
--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -6,6 +6,9 @@ using System.Linq;
 
 namespace Terminal.Gui.Views {
 
+	/// <summary>
+	/// Describes how to render a given column in  a <see cref="TableView"/> including <see cref="Alignment"/> and textual representation of cells (e.g. date formats)
+	/// </summary>
 	public class ColumnStyle {
 		
 		/// <summary>
@@ -448,7 +451,7 @@ namespace Terminal.Gui.Views {
 		}
 
 		/// <summary>
-		/// Truncates or pads <paramref name="representation"/> so that it occupies a exactly <paramref name="availableHorizontalSpace"/> using the alignment specified in <paramref name="style"/> (or left if no style is defined)
+		/// Truncates or pads <paramref name="representation"/> so that it occupies a exactly <paramref name="availableHorizontalSpace"/> using the alignment specified in <paramref name="colStyle"/> (or left if no style is defined)
 		/// </summary>
 		/// <param name="originalCellValue">The object in this cell of the <see cref="Table"/></param>
 		/// <param name="representation">The string representation of <paramref name="originalCellValue"/></param>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -172,8 +172,15 @@ namespace Terminal.Gui {
 		public int SelectedColumn {
 			get => selectedColumn;
 
-			//try to prevent this being set to an out of bounds column
-			set => selectedColumn = Table == null ? 0 :  Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+			set {
+				var oldValue = selectedColumn;
+
+				//try to prevent this being set to an out of bounds column
+				selectedColumn = Table == null ? 0 :  Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+
+				if(oldValue != selectedColumn)
+					OnSelectedCellChanged();
+			} 
 		}
 
 		/// <summary>
@@ -181,7 +188,15 @@ namespace Terminal.Gui {
 		/// </summary>
 		public int SelectedRow {
 			get => selectedRow;
-			set => selectedRow =  Table == null ? 0 : Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+			set {
+
+				var oldValue = selectedColumn;
+
+				selectedRow =  Table == null ? 0 : Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+
+				if(oldValue != selectedRow)
+					OnSelectedCellChanged();
+			}
 		}
 
 		/// <summary>
@@ -198,6 +213,11 @@ namespace Terminal.Gui {
 		/// The symbol to add after each cell value and header value to visually seperate values (if not using vertical gridlines)
 		/// </summary>
 		public char SeparatorSymbol { get; set; } = ' ';
+
+		/// <summary>
+		/// This event is raised when the selected cell in the table changes.
+		/// </summary>
+		public event Action<EventArgs> SelectedCellChanged;
 
 		/// <summary>
 		/// Initialzies a <see cref="TableView"/> class using <see cref="LayoutStyle.Computed"/> layout. 
@@ -690,6 +710,14 @@ namespace Terminal.Gui {
 			if (SelectedRow < RowOffset) {
 				RowOffset = SelectedRow;
 			}
+		}
+
+		/// <summary>
+		/// Invokes the <see cref="SelectedCellChanged"/> event
+		/// </summary>
+		protected virtual void OnSelectedCellChanged()
+		{
+			SelectedCellChanged?.Invoke(new EventArgs());
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -27,6 +27,11 @@ namespace Terminal.Gui.Views {
 		public Func<object,string> RepresentationGetter;
 
 		/// <summary>
+		/// Defines the format for values e.g. "yyyy-MM-dd" for dates
+		/// </summary>
+		public string Format{get;set;}
+
+		/// <summary>
 		/// Set the maximum width of the column in characters.  This value will be ignored if more than the tables <see cref="TableView.MaxCellWidth"/>.  Defaults to <see cref="TableView.DefaultMaxCellWidth"/>
 		/// </summary>
 		public int MaxWidth {get;set;} = TableView.DefaultMaxCellWidth;
@@ -56,6 +61,13 @@ namespace Terminal.Gui.Views {
 		/// <returns></returns>
 		public string GetRepresentation (object value)
 		{
+			if(!string.IsNullOrWhiteSpace(Format)) {
+
+				if(value is IFormattable f)
+					return f.ToString(Format,null);
+			}
+				
+
 			if(RepresentationGetter != null)
 				return RepresentationGetter(value);
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -331,6 +331,15 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
+		/// Returns the amount of vertical space currently occupied by the header or 0 if it is not visible.
+		/// </summary>
+		/// <returns></returns>
+		private int GetHeaderHeightIfAny()
+		{
+			return ShouldRenderHeaders()? GetHeaderHeight():0;
+		}
+
+		/// <summary>
 		/// Returns the amount of vertical space required to display the header
 		/// </summary>
 		/// <returns></returns>
@@ -589,12 +598,12 @@ namespace Terminal.Gui {
 				break;
 			case Key.PageUp:
 			case Key.PageUp | Key.ShiftMask:
-				ChangeSelectionByOffset(0,-Frame.Height,keyEvent.Key.HasFlag(Key.ShiftMask));
+				ChangeSelectionByOffset(0,-(Bounds.Height - GetHeaderHeightIfAny()),keyEvent.Key.HasFlag(Key.ShiftMask));
 				Update ();
 				break;
 			case Key.PageDown:
 			case Key.PageDown | Key.ShiftMask:
-				ChangeSelectionByOffset(0,Frame.Height,keyEvent.Key.HasFlag(Key.ShiftMask));
+				ChangeSelectionByOffset(0,Bounds.Height - GetHeaderHeightIfAny(),keyEvent.Key.HasFlag(Key.ShiftMask));
 				Update ();
 				break;
 			case Key.Home | Key.CtrlMask:
@@ -778,8 +787,8 @@ namespace Terminal.Gui {
 				
 				var hit = ScreenToCell(me.OfX,me.OfY);
 				if(hit != null) {
-					// TODO : if shift is held down extend selection
-					SetSelection(hit.Value.X,hit.Value.Y,false );
+					
+					SetSelection(hit.Value.X,hit.Value.Y,me.Flags.HasFlag(MouseFlags.ButtonShift));
 					Update();
 				}
 			}
@@ -808,7 +817,7 @@ namespace Terminal.Gui {
 
 			var viewPort = CalculateViewport(Bounds);
 				
-			var headerHeight = ShouldRenderHeaders()? GetHeaderHeight():0;
+			var headerHeight = GetHeaderHeightIfAny();
 
 			var col = viewPort.LastOrDefault(c=>c.X <= clientX);
 				
@@ -839,7 +848,7 @@ namespace Terminal.Gui {
 
 			var viewPort = CalculateViewport(Bounds);
 				
-			var headerHeight = ShouldRenderHeaders()? GetHeaderHeight():0;
+			var headerHeight = GetHeaderHeightIfAny();
 
 			var colHit = viewPort.FirstOrDefault(c=>c.Column.Ordinal == tableColumn);
 
@@ -916,7 +925,7 @@ namespace Terminal.Gui {
 			}
 
 			var columnsToRender = CalculateViewport (Bounds).ToArray();
-			var headerHeight = ShouldRenderHeaders()? GetHeaderHeight() : 0;
+			var headerHeight = GetHeaderHeightIfAny();
 
 			//if we have scrolled too far to the left 
 			if (SelectedColumn < columnsToRender.Min (r => r.Column.Ordinal)) {

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -854,7 +854,7 @@ namespace Terminal.Gui {
 
 			if(me.Flags.HasFlag(MouseFlags.Button1Clicked)) {
 				
-				var hit = ScreenToCell(me.OfX,me.OfY);
+				var hit = ScreenToCell(me.X,me.Y);
 				if(hit != null) {
 					
 					SetSelection(hit.Value.X,hit.Value.Y,me.Flags.HasFlag(MouseFlags.ButtonShift));
@@ -864,7 +864,7 @@ namespace Terminal.Gui {
 
 			// Double clicking a cell activates
 			if(me.Flags == MouseFlags.Button1DoubleClicked) {
-				var hit = ScreenToCell(me.OfX,me.OfY);
+				var hit = ScreenToCell(me.X,me.Y);
 				if(hit!= null) {
 					OnCellActivated(new CellActivatedEventArgs(Table,hit.Value.X,hit.Value.Y));
 				}

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Terminal.Gui.Views {
 
@@ -22,10 +20,21 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int ColumnOffset {
-			get => columnOffset; 
+			get {
+				return columnOffset; 
+			}
 
 			//try to prevent this being set to an out of bounds column
-			set => columnOffset = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+			set {
+				//the value before we changed it
+				var origValue = columnOffset;
+
+				columnOffset = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+				
+				//if value actually changed we must update UI
+				if(columnOffset != origValue)
+					SetNeedsDisplay();
+			}
 		}
 
 
@@ -34,9 +43,20 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int RowOffset { 
-			get => rowOffset; 
-			set => rowOffset = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+			get {
+				return rowOffset; 
 			}
+			set {
+				//the value before we changed it
+				var origValue = rowOffset;
+
+				rowOffset = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+
+				//if value actually changed we must update UI
+				if(rowOffset != origValue)
+					SetNeedsDisplay();
+			}
+		}
 
 		/// <summary>
 		/// The maximum number of characters to render in any given column.  This prevents one long column from pushing out all the others
@@ -47,6 +67,11 @@ namespace Terminal.Gui.Views {
 		/// The text representation that should be rendered for cells with the value <see cref="DBNull.Value"/>
 		/// </summary>
 		public string NullSymbol {get;set;} = "-";
+
+		/// <summary>
+		/// The symbol to add after each cell value and header value to visually seperate values
+		/// </summary>
+		public char SeparatorSymbol {get;set; } = ' ';
 
 		/// <summary>
 		/// Initialzies a <see cref="TableView"/> class using <see cref="LayoutStyle.Computed"/> layout. 
@@ -74,41 +99,35 @@ namespace Terminal.Gui.Views {
 
 			Driver.SetAttribute (ColorScheme.HotNormal);
 
+			//invalidate current row (prevents scrolling around leaving old characters in the frame
+			Driver.AddStr(new string (' ',bounds.Width));
+
 			// Render the headers
 			foreach(var kvp in columnsToRender) {
 				
 				Move (kvp.Value,0);
-				Driver.AddStr(kvp.Key.ColumnName);
+				Driver.AddStr(kvp.Key.ColumnName+ SeparatorSymbol);
 			}
 
 			//render the cells
 			for (int line = 1; line < frame.Height; line++) {
 				
+				//invalidate current row (prevents scrolling around leaving old characters in the frame
+				Move (0,line);
+				Driver.AddStr(new string (' ',bounds.Width));
+
 				//work out what Row to render
 				var rowToRender = RowOffset + (line-1);
+
+				//if we have run off the end of the table
 				if(rowToRender >= Table.Rows.Count)
-					break;
+					continue;
 
 				foreach(var kvp in columnsToRender) {
 					Move (kvp.Value,line);
-					Driver.AddStr(GetRenderedVal(Table.Rows[rowToRender][kvp.Key]));
+					Driver.AddStr(GetRenderedVal(Table.Rows[rowToRender][kvp.Key]) + SeparatorSymbol);
 				}
 			}
-
-			/*
-
-			for (int line = 1; line < frame.Height; line++) {
-				var lineRect = new Rect (0, line, frame.Width, 1);
-				if (!bounds.Contains (lineRect))
-					continue;
-
-				Move (0, line);
-				Driver.SetAttribute (ColorScheme.HotNormal);
-				Driver.AddStr ("test");
-
-				currentAttribute = ColorScheme.HotNormal;
-				SetAttribute (ColorScheme.Normal);
-			}*/
 
 			void SetAttribute (Attribute attribute)
 			{
@@ -119,7 +138,50 @@ namespace Terminal.Gui.Views {
 			}
 
 		}
-
+		
+		/// <inheritdoc/>
+		public override bool ProcessKey (KeyEvent keyEvent)
+		{
+			switch (keyEvent.Key) {
+			case Key.CursorLeft:
+				ColumnOffset--;
+				break;
+			case Key.CursorRight:
+				ColumnOffset++;
+				break;
+			case Key.CursorDown:
+				RowOffset++;
+				break;
+			case Key.CursorUp:
+				RowOffset--;
+				break;
+			case Key.PageUp:
+				 RowOffset -= Frame.Height;
+				break;
+			case Key.V | Key.CtrlMask:
+			case Key.PageDown:
+				 RowOffset += Frame.Height;
+				break;
+			case Key.Home | Key.CtrlMask:
+				RowOffset = 0;
+				ColumnOffset = 0;
+				break;
+			case Key.Home:
+				ColumnOffset = 0;
+				break;
+			case Key.End | Key.CtrlMask:
+				//jump to end of table
+				RowOffset = Table.Rows.Count-1;
+				ColumnOffset = Table.Columns.Count-1;
+				break;
+			case Key.End:
+				//jump to end of row
+				ColumnOffset = Table.Columns.Count-1;				
+				break;
+			}
+			PositionCursor ();
+			return true;
+		}
 		/// <summary>
 		/// Calculates which columns should be rendered given the <paramref name="bounds"/> in which to display and the <see cref="ColumnOffset"/>
 		/// </summary>
@@ -157,7 +219,7 @@ namespace Terminal.Gui.Views {
 		{
 			int spaceRequired = col.ColumnName.Length;
 
-			for(int i = RowOffset; i<rowsToRender && i<Table.Rows.Count;i++) {
+			for(int i = RowOffset; i<RowOffset + rowsToRender && i<Table.Rows.Count;i++) {
 
 				//expand required space if cell is bigger than the last biggest cell or header
 				spaceRequired = Math.Max(spaceRequired,GetRenderedVal(Table.Rows[i][col]).Length);

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -17,6 +17,9 @@ namespace Terminal.Gui.Views {
 		private int selectedColumn;
 		private DataTable table;
 
+		/// <summary>
+		/// The data table to render in the view.  Setting this property automatically updates and redraws the control.
+		/// </summary>
 		public DataTable Table { get => table; set {table = value; Update(); } }
 
 		/// <summary>
@@ -91,11 +94,7 @@ namespace Terminal.Gui.Views {
 		///<inheritdoc/>
 		public override void Redraw (Rect bounds)
 		{
-			Attribute currentAttribute;
-			var current = ColorScheme.Focus;
-			Driver.SetAttribute (current);
 			Move (0, 0);
-
 			var frame = Frame;
 
 			// What columns to render at what X offset in viewport
@@ -141,16 +140,14 @@ namespace Terminal.Gui.Views {
 				}
 			}
 
-			void SetAttribute (Attribute attribute)
-			{
-				if (currentAttribute != attribute) {
-					currentAttribute = attribute;
-					Driver.SetAttribute (attribute);
-				}
-			}
-
 		}
 
+		/// <summary>
+		/// Truncates <paramref name="valueToRender"/> so that it occupies a maximum of <paramref name="availableHorizontalSpace"/>
+		/// </summary>
+		/// <param name="valueToRender"></param>
+		/// <param name="availableHorizontalSpace"></param>
+		/// <returns></returns>
 		private ustring Truncate (string valueToRender, int availableHorizontalSpace)
 		{
 			if (string.IsNullOrEmpty (valueToRender) || valueToRender.Length < availableHorizontalSpace)

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -273,13 +273,15 @@ namespace Terminal.Gui {
 				}
 			}
 					
+			int headerLinesConsumed = line;
+
 			//render the cells
 			for (; line < frame.Height; line++) {
 
 				ClearLine(line,bounds.Width);
 
 				//work out what Row to render
-				var rowToRender = RowOffset + (line - GetHeaderHeight());
+				var rowToRender = RowOffset + (line - headerLinesConsumed);
 
 				//if we have run off the end of the table
 				if ( Table == null || rowToRender >= Table.Rows.Count || rowToRender < 0)
@@ -613,7 +615,7 @@ namespace Terminal.Gui {
 				
 				var viewPort = CalculateViewport(Bounds);
 				
-				var headerHeight = GetHeaderHeight();
+				var headerHeight = ShouldRenderHeaders()? GetHeaderHeight():0;
 
 				var col = viewPort.LastOrDefault(c=>c.X < me.OfX);
 				
@@ -690,7 +692,7 @@ namespace Terminal.Gui {
 			}
 
 			var columnsToRender = CalculateViewport (Bounds).ToArray();
-			var headerHeight = GetHeaderHeight();
+			var headerHeight = ShouldRenderHeaders()? GetHeaderHeight() : 0;
 
 			//if we have scrolled too far to the left 
 			if (SelectedColumn < columnsToRender.Min (r => r.Column.Ordinal)) {

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 
-namespace Terminal.Gui.Views {
+namespace Terminal.Gui {
 
 	/// <summary>
 	/// Describes how to render a given column in  a <see cref="TableView"/> including <see cref="Alignment"/> and textual representation of cells (e.g. date formats)
@@ -148,23 +148,22 @@ namespace Terminal.Gui.Views {
 		public TableStyle Style { get => style; set {style = value; Update(); } }
 						
 		/// <summary>
-		/// Zero indexed offset for the upper left <see cref="DataColumn"/> to display in <see cref="Table"/>.
+		/// Horizontal scroll offset.  The index of the first column in <see cref="Table"/> to display when when rendering the view.
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int ColumnOffset {
 			get => columnOffset;
 
 			//try to prevent this being set to an out of bounds column
-			set => columnOffset = Table == null ? 0 : Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+			set => columnOffset = Table == null ? 0 :Math.Max (0,Math.Min (Table.Columns.Count - 1,  value));
 		}
 
 		/// <summary>
-		/// Zero indexed offset for the <see cref="DataRow"/> to display in <see cref="Table"/> on line 2 of the control (first line being headers)
+		/// Vertical scroll offset.  The index of the first row in <see cref="Table"/> to display in the first non header line of the control when rendering the view.
 		/// </summary>
-		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int RowOffset {
 			get => rowOffset;
-			set => rowOffset = Table == null ? 0 : Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+			set => rowOffset = Table == null ? 0 : Math.Max (0,Math.Min (Table.Rows.Count - 1, value));
 		}
 
 		/// <summary>
@@ -666,7 +665,7 @@ namespace Terminal.Gui.Views {
 		/// <remarks>Changes will not be immediately visible in the display until you call <see cref="View.SetNeedsDisplay()"/></remarks>
 		public void EnsureSelectedCellIsVisible ()
 		{
-			if(Table == null){
+			if(Table == null || Table.Columns.Count <= 0){
 				return;
 			}
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -7,6 +7,37 @@ using System.Linq;
 namespace Terminal.Gui.Views {
 
 	/// <summary>
+	/// Defines rendering options that affect how the table is displayed
+	/// </summary>
+	public class TableStyle {
+		
+		/// <summary>
+		/// When scrolling down always lock the column headers in place as the first row of the table
+		/// </summary>
+		public bool AlwaysShowHeaders {get;set;} = false;
+
+		/// <summary>
+		/// True to render a solid line above the headers
+		/// </summary>
+		public bool ShowHorizontalHeaderOverline {get;set;} = true;
+
+		/// <summary>
+		/// True to render a solid line under the headers
+		/// </summary>
+		public bool ShowHorizontalHeaderUnderline {get;set;} = true;
+
+		/// <summary>
+		/// True to render a solid line vertical line between cells
+		/// </summary>
+		public bool ShowVerticalCellLines {get;set;} = true;
+
+		/// <summary>
+		/// True to render a solid line vertical line between headers
+		/// </summary>
+		public bool ShowVerticalHeaderLines {get;set;} = true;
+	}
+	
+	/// <summary>
 	/// View for tabular data based on a <see cref="DataTable"/>
 	/// </summary>
 	public class TableView : View {
@@ -16,12 +47,18 @@ namespace Terminal.Gui.Views {
 		private int selectedRow;
 		private int selectedColumn;
 		private DataTable table;
+		private TableStyle style = new TableStyle();
 
 		/// <summary>
 		/// The data table to render in the view.  Setting this property automatically updates and redraws the control.
 		/// </summary>
 		public DataTable Table { get => table; set {table = value; Update(); } }
-
+		
+		/// <summary>
+		/// Contains options for changing how the table is rendered
+		/// </summary>
+		public TableStyle Style { get => style; set {style = value; Update(); } }
+						
 		/// <summary>
 		/// Zero indexed offset for the upper left <see cref="DataColumn"/> to display in <see cref="Table"/>.
 		/// </summary>
@@ -71,7 +108,7 @@ namespace Terminal.Gui.Views {
 		public string NullSymbol { get; set; } = "-";
 
 		/// <summary>
-		/// The symbol to add after each cell value and header value to visually seperate values
+		/// The symbol to add after each cell value and header value to visually seperate values (if not using vertical gridlines)
 		/// </summary>
 		public char SeparatorSymbol { get; set; } = ' ';
 
@@ -102,45 +139,204 @@ namespace Terminal.Gui.Views {
 			Dictionary<DataColumn, int> columnsToRender = CalculateViewport (bounds);
 
 			Driver.SetAttribute (ColorScheme.Normal);
-
+			
 			//invalidate current row (prevents scrolling around leaving old characters in the frame
 			Driver.AddStr (new string (' ', bounds.Width));
 
-			// Render the headers
-			foreach (var kvp in columnsToRender) {
+			int line = 0;
 
-				Move (kvp.Value, 0);
-				Driver.AddStr (Truncate (kvp.Key.ColumnName + SeparatorSymbol, bounds.Width - kvp.Value));
-			}
+			if(ShouldRenderHeaders()){
+				// Render something like:
+				/*
+					┌────────────────────┬──────────┬───────────┬──────────────┬─────────┐
+					│ArithmeticComparator│chi       │Healthboard│Interpretation│Labnumber│
+					└────────────────────┴──────────┴───────────┴──────────────┴─────────┘
+				*/
+				if(Style.ShowHorizontalHeaderOverline){
+					RenderHeaderOverline(line,bounds.Width,columnsToRender);
+					line++;
+				}
 
-			//render the cells
-			for (int line = 1; line < frame.Height; line++) {
+				RenderHeaderMidline(line,bounds.Width,columnsToRender);
+				line++;
 
-				//invalidate current row (prevents scrolling around leaving old characters in the frame
-				Move (0, line);
-				Driver.SetAttribute (ColorScheme.Normal);
-				Driver.AddStr (new string (' ', bounds.Width));
-
-				//work out what Row to render
-				var rowToRender = RowOffset + (line - 1);
-
-				//if we have run off the end of the table
-				if ( Table == null || rowToRender >= Table.Rows.Count)
-					continue;
-
-				foreach (var kvp in columnsToRender) {
-					Move (kvp.Value, line);
-
-					bool isSelectedCell = rowToRender == SelectedRow && kvp.Key.Ordinal == SelectedColumn;
-
-					Driver.SetAttribute (isSelectedCell ? ColorScheme.HotFocus : ColorScheme.Normal);
-
-
-					var valueToRender = GetRenderedVal (Table.Rows [rowToRender] [kvp.Key]) + SeparatorSymbol;
-					Driver.AddStr (Truncate (valueToRender, bounds.Width - kvp.Value));
+				if(Style.ShowHorizontalHeaderUnderline){
+					RenderHeaderUnderline(line,bounds.Width,columnsToRender);
+					line++;
 				}
 			}
+					
+			//render the cells
+			for (; line < frame.Height; line++) {
 
+				ClearLine(line,bounds.Width);
+
+				//work out what Row to render
+				var rowToRender = RowOffset + (line - GetHeaderHeight());
+
+				//if we have run off the end of the table
+				if ( Table == null || rowToRender >= Table.Rows.Count || rowToRender < 0)
+					continue;
+
+				RenderRow(line,bounds.Width,rowToRender,columnsToRender);
+			}
+		}
+
+		/// <summary>
+		/// Clears a line of the console by filling it with spaces
+		/// </summary>
+		/// <param name="row"></param>
+		/// <param name="width"></param>
+		private void ClearLine(int row, int width)
+		{            
+			Move (0, row);
+			Driver.SetAttribute (ColorScheme.Normal);
+			Driver.AddStr (new string (' ', width));
+		}
+
+		/// <summary>
+		/// Returns the amount of vertical space required to display the header
+		/// </summary>
+		/// <returns></returns>
+		private int GetHeaderHeight()
+		{
+			int heightRequired = 1;
+			
+			if(Style.ShowHorizontalHeaderOverline)
+				heightRequired++;
+
+			if(Style.ShowHorizontalHeaderUnderline)
+				heightRequired++;
+			
+			return heightRequired;
+		}
+
+		private void RenderHeaderOverline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		{
+			// Renders a line above table headers (when visible) like:
+			// ┌────────────────────┬──────────┬───────────┬──────────────┬─────────┐
+
+			for(int c = 0;c< availableWidth;c++) {
+
+				var rune = Driver.HLine;
+
+				if (Style.ShowVerticalHeaderLines){
+							
+					if(c == 0){
+						rune = Driver.ULCorner;
+					}	
+					// if the next column is the start of a header
+					else if(columnsToRender.Values.Contains(c+1)){
+						rune = Driver.TopTee;
+					}
+					else if(c == availableWidth -1){
+						rune = Driver.URCorner;
+					}
+				}
+
+				AddRuneAt(Driver,c,row,rune);
+			}
+		}
+
+		private void RenderHeaderMidline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		{
+			// Renders something like:
+			// │ArithmeticComparator│chi       │Healthboard│Interpretation│Labnumber│
+						
+			ClearLine(row,availableWidth);
+
+			//render start of line
+			if(style.ShowVerticalHeaderLines)
+				AddRune(0,row,Driver.VLine);
+
+			foreach (var kvp in columnsToRender) {
+				
+				//where the header should start
+				var col = kvp.Value;
+
+				RenderSeparator(col-1,row);
+									
+				Move (col, row);
+				Driver.AddStr(Truncate (kvp.Key.ColumnName, availableWidth - kvp.Value));
+
+			}
+
+			//render end of line
+			if(style.ShowVerticalHeaderLines)
+				AddRune(availableWidth-1,row,Driver.VLine);
+		}
+
+		private void RenderHeaderUnderline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		{
+			// Renders a line below the table headers (when visible) like:
+			// ├──────────┼───────────┼───────────────────┼──────────┼────────┼─────────────┤
+								
+			for(int c = 0;c< availableWidth;c++) {
+
+				var rune = Driver.HLine;
+
+				if (Style.ShowVerticalHeaderLines){
+					if(c == 0){
+						rune = Style.ShowVerticalCellLines ? Driver.LeftTee : Driver.LLCorner;
+					}	
+					// if the next column is the start of a header
+					else if(columnsToRender.Values.Contains(c+1)){
+					
+						/*TODO: is ┼ symbol in Driver?*/ 
+						rune = Style.ShowVerticalCellLines ? '┼' :Driver.BottomTee;
+					}
+					else if(c == availableWidth -1){
+						rune = Style.ShowVerticalCellLines ? Driver.RightTee : Driver.LRCorner;
+					}
+				}
+
+				AddRuneAt(Driver,c,row,rune);
+			}
+			
+		}
+		private void RenderRow(int row, int availableWidth, int rowToRender, Dictionary<DataColumn, int> columnsToRender)
+		{
+			//render start of line
+			if(style.ShowVerticalHeaderLines)
+				AddRune(0,row,Driver.VLine);
+
+			// Render cells for each visible header for the current row
+			foreach (var kvp in columnsToRender) {
+
+				// move to start of cell (in line with header positions)
+				Move (kvp.Value, row);
+
+				// Set color scheme based on whether the current cell is the selected one
+				bool isSelectedCell = rowToRender == SelectedRow && kvp.Key.Ordinal == SelectedColumn;
+				Driver.SetAttribute (isSelectedCell ? ColorScheme.HotFocus : ColorScheme.Normal);
+
+				// Render the (possibly truncated) cell value
+				var valueToRender = GetRenderedVal (Table.Rows [rowToRender] [kvp.Key]);
+				Driver.AddStr (Truncate (valueToRender, availableWidth - kvp.Value));
+				
+				// Reset color scheme to normal and render the vertical line (or space) at the end of the cell
+				Driver.SetAttribute (ColorScheme.Normal);
+				RenderSeparator(kvp.Value-1,row);
+			}
+
+			//render end of line
+			if(style.ShowVerticalHeaderLines)
+				AddRune(availableWidth-1,row,Driver.VLine);
+		}
+		
+		private void RenderSeparator(int col, int row)
+		{
+			if(col<0)
+				return;
+
+			Rune symbol = style.ShowVerticalHeaderLines ? Driver.VLine : SeparatorSymbol;
+			AddRune(col,row,symbol);
+		}
+
+		void AddRuneAt (ConsoleDriver d,int col, int row, Rune ch)
+		{
+			Move (col, row);
+			d.AddRune (ch);
 		}
 
 		/// <summary>
@@ -231,6 +427,7 @@ namespace Terminal.Gui.Views {
 			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
 
 			Dictionary<DataColumn, int> columnsToRender = CalculateViewport (Bounds);
+			var headerHeight = GetHeaderHeight();
 
 			//if we have scrolled too far to the left 
 			if (SelectedColumn < columnsToRender.Keys.Min (col => col.Ordinal)) {
@@ -243,7 +440,7 @@ namespace Terminal.Gui.Views {
 			}
 
 			//if we have scrolled too far down
-			if (SelectedRow > RowOffset + Bounds.Height - 1) {
+			if (SelectedRow >= RowOffset + (Bounds.Height - headerHeight)) {
 				RowOffset = SelectedRow;
 			}
 			//if we have scrolled too far up
@@ -266,22 +463,44 @@ namespace Terminal.Gui.Views {
 
 			if(Table == null)
 				return toReturn;
-
+			
 			int usedSpace = 0;
+
+			//if horizontal space is required at the start of the line (before the first header)
+			if(Style.ShowVerticalHeaderLines || Style.ShowVerticalCellLines)
+				usedSpace+=2;
+			
 			int availableHorizontalSpace = bounds.Width;
-			int rowsToRender = bounds.Height - 1; //1 reserved for the headers row
+			int rowsToRender = bounds.Height;
 
-			foreach (var col in Table.Columns.Cast<DataColumn> ().Skip (ColumnOffset)) {
+			// reserved for the headers row
+			if(ShouldRenderHeaders())
+				rowsToRender -= GetHeaderHeight(); 
 
-				toReturn.Add (col, usedSpace);
+			bool first = true;
+
+			foreach (var col in Table.Columns.Cast<DataColumn>().Skip (ColumnOffset)) {
+
+				int startingIdxForCurrentHeader = usedSpace;
+
+				// is there enough space for this column (and it's data)?
 				usedSpace += CalculateMaxRowSize (col, rowsToRender) + padding;
 
-				if (usedSpace > availableHorizontalSpace)
+				// no (don't render it) unless its the only column we are render (that must be one massively wide column!)
+				if (!first && usedSpace > availableHorizontalSpace)
 					return toReturn;
 
+				// there is space
+				toReturn.Add (col, startingIdxForCurrentHeader);
+				first=false;
 			}
 
 			return toReturn;
+		}
+
+		private bool ShouldRenderHeaders()
+		{
+		    return Style.AlwaysShowHeaders || rowOffset == 0;
 		}
 
 		/// <summary>
@@ -293,6 +512,11 @@ namespace Terminal.Gui.Views {
 		private int CalculateMaxRowSize (DataColumn col, int rowsToRender)
 		{
 			int spaceRequired = col.ColumnName.Length;
+
+			// if table has no rows
+			if(RowOffset < 0)
+				return spaceRequired;
+
 
 			for (int i = RowOffset; i < RowOffset + rowsToRender && i < Table.Rows.Count; i++) {
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -6,6 +6,59 @@ using System.Linq;
 
 namespace Terminal.Gui.Views {
 
+	public class ColumnStyle {
+		
+		/// <summary>
+		/// Defines the default alignment for all values rendered in this column.  For custom alignment based on cell contents use <see cref="AlignmentGetter"/>.
+		/// </summary>
+		public TextAlignment Alignment {get;set;}
+	
+		/// <summary>
+		/// Defines a delegate for returning custom alignment per cell based on cell values.  When specified this will override <see cref="Alignment"/>
+		/// </summary>
+		public Func<object,TextAlignment> AlignmentGetter;
+
+		/// <summary>
+		/// Defines a delegate for returning custom representations of cell values.  If not set then <see cref="object.ToString()"/> is used.  Return values from your delegate may be truncated e.g. based on <see cref="MaxWidth"/>
+		/// </summary>
+		public Func<object,string> RepresentationGetter;
+
+		/// <summary>
+		/// Set the maximum width of the column in characters.  This value will be ignored if more than the tables <see cref="TableView.MaxCellWidth"/>.  Defaults to <see cref="TableView.DefaultMaxCellWidth"/>
+		/// </summary>
+		public int MaxWidth {get;set;} = TableView.DefaultMaxCellWidth;
+
+		/// <summary>
+		/// Set the minimum width of the column in characters.  This value will be ignored if more than the tables <see cref="TableView.MaxCellWidth"/> or the <see cref="MaxWidth"/>
+		/// </summary>
+		public int MinWidth {get;set;}
+
+		/// <summary>
+		/// Returns the alignment for the cell based on <paramref name="cellValue"/> and <see cref="AlignmentGetter"/>/<see cref="Alignment"/>
+		/// </summary>
+		/// <param name="cellValue"></param>
+		/// <returns></returns>
+		public TextAlignment GetAlignment(object cellValue)
+		{
+			if(AlignmentGetter != null)
+				return AlignmentGetter(cellValue);
+
+			return Alignment;
+		}
+
+		/// <summary>
+		/// Returns the full string to render (which may be truncated if too long) that the current style says best represents the given <paramref name="value"/>
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		public string GetRepresentation (object value)
+		{
+			if(RepresentationGetter != null)
+				return RepresentationGetter(value);
+
+			return value?.ToString();
+		}
+	}
 	/// <summary>
 	/// Defines rendering options that affect how the table is displayed
 	/// </summary>
@@ -35,6 +88,21 @@ namespace Terminal.Gui.Views {
 		/// True to render a solid line vertical line between headers
 		/// </summary>
 		public bool ShowVerticalHeaderLines {get;set;} = true;
+
+		/// <summary>
+		/// Collection of columns for which you want special rendering (e.g. custom column lengths, text alignment etc)
+		/// </summary>
+		public Dictionary<DataColumn,ColumnStyle> ColumnStyles {get;set; }  = new Dictionary<DataColumn, ColumnStyle>();
+
+		/// <summary>
+		/// Returns the entry from <see cref="ColumnStyles"/> for the given <paramref name="col"/> or null if no custom styling is defined for it
+		/// </summary>
+		/// <param name="col"></param>
+		/// <returns></returns>
+		public ColumnStyle GetColumnStyleIfAny (DataColumn col)
+		{
+			return ColumnStyles.TryGetValue(col,out ColumnStyle result) ? result : null;
+		}
 	}
 	
 	/// <summary>
@@ -48,6 +116,11 @@ namespace Terminal.Gui.Views {
 		private int selectedColumn;
 		private DataTable table;
 		private TableStyle style = new TableStyle();
+
+		/// <summary>
+		/// The default maximum cell width for <see cref="TableView.MaxCellWidth"/> and <see cref="ColumnStyle.MaxWidth"/>
+		/// </summary>
+		public const int DefaultMaxCellWidth = 100;
 
 		/// <summary>
 		/// The data table to render in the view.  Setting this property automatically updates and redraws the control.
@@ -100,7 +173,7 @@ namespace Terminal.Gui.Views {
 		/// <summary>
 		/// The maximum number of characters to render in any given column.  This prevents one long column from pushing out all the others
 		/// </summary>
-		public int MaximumCellWidth { get; set; } = 100;
+		public int MaxCellWidth { get; set; } = DefaultMaxCellWidth;
 
 		/// <summary>
 		/// The text representation that should be rendered for cells with the value <see cref="DBNull.Value"/>
@@ -136,7 +209,7 @@ namespace Terminal.Gui.Views {
 			var frame = Frame;
 
 			// What columns to render at what X offset in viewport
-			Dictionary<DataColumn, int> columnsToRender = CalculateViewport (bounds);
+			var columnsToRender = CalculateViewport(bounds).ToArray();
 
 			Driver.SetAttribute (ColorScheme.Normal);
 			
@@ -211,7 +284,7 @@ namespace Terminal.Gui.Views {
 			return heightRequired;
 		}
 
-		private void RenderHeaderOverline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		private void RenderHeaderOverline(int row,int availableWidth, ColumnToRender[] columnsToRender)
 		{
 			// Renders a line above table headers (when visible) like:
 			// ┌────────────────────┬──────────┬───────────┬──────────────┬─────────┐
@@ -226,7 +299,7 @@ namespace Terminal.Gui.Views {
 						rune = Driver.ULCorner;
 					}	
 					// if the next column is the start of a header
-					else if(columnsToRender.Values.Contains(c+1)){
+					else if(columnsToRender.Any(r=>r.X == c+1)){
 						rune = Driver.TopTee;
 					}
 					else if(c == availableWidth -1){
@@ -238,7 +311,7 @@ namespace Terminal.Gui.Views {
 			}
 		}
 
-		private void RenderHeaderMidline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		private void RenderHeaderMidline(int row,int availableWidth, ColumnToRender[] columnsToRender)
 		{
 			// Renders something like:
 			// │ArithmeticComparator│chi       │Healthboard│Interpretation│Labnumber│
@@ -249,15 +322,19 @@ namespace Terminal.Gui.Views {
 			if(style.ShowVerticalHeaderLines)
 				AddRune(0,row,Driver.VLine);
 
-			foreach (var kvp in columnsToRender) {
+			for(int i =0 ; i<columnsToRender.Length;i++) {
 				
-				//where the header should start
-				var col = kvp.Value;
+				var current =  columnsToRender[i];
+				var availableWidthForCell = GetCellWidth(columnsToRender,i,availableWidth);
 
-				RenderSeparator(col-1,row,true);
+				var colStyle = Style.GetColumnStyleIfAny(current.Column);
+				var colName = current.Column.ColumnName;
+
+				RenderSeparator(current.X-1,row,true);
 									
-				Move (col, row);
-				Driver.AddStr(Truncate (kvp.Key.ColumnName, availableWidth - kvp.Value));
+				Move (current.X, row);
+				
+				Driver.AddStr(TruncateOrPad(colName,colName,availableWidthForCell ,colStyle));
 
 			}
 
@@ -266,7 +343,29 @@ namespace Terminal.Gui.Views {
 				AddRune(availableWidth-1,row,Driver.VLine);
 		}
 
-		private void RenderHeaderUnderline(int row,int availableWidth, Dictionary<DataColumn, int> columnsToRender)
+		/// <summary>
+		/// Calculates how much space is available to render index <paramref name="i"/> of the <paramref name="columnsToRender"/> given the remaining horizontal space
+		/// </summary>
+		/// <param name="columnsToRender"></param>
+		/// <param name="i"></param>
+		/// <param name="availableWidth"></param>
+		private int GetCellWidth (ColumnToRender [] columnsToRender, int i,int availableWidth)
+		{
+			var current =  columnsToRender[i];
+			var next = i+1 < columnsToRender.Length ? columnsToRender[i+1] : null;
+
+			if(next == null) {
+				// cell can fill to end of the line
+				return availableWidth - current.X;
+			}
+			else {
+				// cell can fill up to next cell start				
+				return next.X - current.X;
+			}
+
+		}
+
+		private void RenderHeaderUnderline(int row,int availableWidth, ColumnToRender[] columnsToRender)
 		{
 			// Renders a line below the table headers (when visible) like:
 			// ├──────────┼───────────┼───────────────────┼──────────┼────────┼─────────────┤
@@ -280,7 +379,7 @@ namespace Terminal.Gui.Views {
 						rune = Style.ShowVerticalCellLines ? Driver.LeftTee : Driver.LLCorner;
 					}	
 					// if the next column is the start of a header
-					else if(columnsToRender.Values.Contains(c+1)){
+					else if(columnsToRender.Any(r=>r.X == c+1)){
 					
 						/*TODO: is ┼ symbol in Driver?*/ 
 						rune = Style.ShowVerticalCellLines ? '┼' :Driver.BottomTee;
@@ -294,29 +393,37 @@ namespace Terminal.Gui.Views {
 			}
 			
 		}
-		private void RenderRow(int row, int availableWidth, int rowToRender, Dictionary<DataColumn, int> columnsToRender)
+		private void RenderRow(int row, int availableWidth, int rowToRender, ColumnToRender[] columnsToRender)
 		{
 			//render start of line
 			if(style.ShowVerticalCellLines)
 				AddRune(0,row,Driver.VLine);
 
 			// Render cells for each visible header for the current row
-			foreach (var kvp in columnsToRender) {
+			for(int i=0;i< columnsToRender.Length ;i++) {
+
+				var current = columnsToRender[i];
+				var availableWidthForCell = GetCellWidth(columnsToRender,i,availableWidth);
+
+				var colStyle = Style.GetColumnStyleIfAny(current.Column);
 
 				// move to start of cell (in line with header positions)
-				Move (kvp.Value, row);
+				Move (current.X, row);
 
 				// Set color scheme based on whether the current cell is the selected one
-				bool isSelectedCell = rowToRender == SelectedRow && kvp.Key.Ordinal == SelectedColumn;
+				bool isSelectedCell = rowToRender == SelectedRow && current.Column.Ordinal == SelectedColumn;
 				Driver.SetAttribute (isSelectedCell ? ColorScheme.HotFocus : ColorScheme.Normal);
 
+				var val = Table.Rows [rowToRender][current.Column];
+
 				// Render the (possibly truncated) cell value
-				var valueToRender = GetRenderedVal (Table.Rows [rowToRender] [kvp.Key]);
-				Driver.AddStr (Truncate (valueToRender, availableWidth - kvp.Value));
+				var representation = GetRepresentation(val,colStyle);
+				
+				Driver.AddStr (TruncateOrPad(val,representation,availableWidthForCell,colStyle));
 				
 				// Reset color scheme to normal and render the vertical line (or space) at the end of the cell
 				Driver.SetAttribute (ColorScheme.Normal);
-				RenderSeparator(kvp.Value-1,row,false);
+				RenderSeparator(current.X-1,row,false);
 			}
 
 			//render end of line
@@ -342,17 +449,49 @@ namespace Terminal.Gui.Views {
 		}
 
 		/// <summary>
-		/// Truncates <paramref name="valueToRender"/> so that it occupies a maximum of <paramref name="availableHorizontalSpace"/>
+		/// Truncates or pads <paramref name="representation"/> so that it occupies a exactly <paramref name="availableHorizontalSpace"/> using the alignment specified in <paramref name="style"/> (or left if no style is defined)
 		/// </summary>
-		/// <param name="valueToRender"></param>
+		/// <param name="originalCellValue">The object in this cell of the <see cref="Table"/></param>
+		/// <param name="representation">The string representation of <paramref name="originalCellValue"/></param>
 		/// <param name="availableHorizontalSpace"></param>
+		/// <param name="colStyle">Optional style indicating custom alignment for the cell</param>
 		/// <returns></returns>
-		private ustring Truncate (string valueToRender, int availableHorizontalSpace)
+		private ustring TruncateOrPad (object originalCellValue,string representation, int availableHorizontalSpace, ColumnStyle colStyle)
 		{
-			if (string.IsNullOrEmpty (valueToRender) || valueToRender.Length < availableHorizontalSpace)
-				return valueToRender;
+			if (string.IsNullOrEmpty (representation))
+				return representation;
 
-			return valueToRender.Substring (0, availableHorizontalSpace);
+			// if value is not wide enough
+			if(representation.Length < availableHorizontalSpace) {
+				
+				// pad it out with spaces to the given alignment
+				int toPad = availableHorizontalSpace - representation.Length;
+
+				switch(colStyle?.GetAlignment(originalCellValue) ?? TextAlignment.Left) {
+
+					case TextAlignment.Left : 
+						representation = representation.PadRight(toPad);
+						break;
+					case TextAlignment.Right : 
+						representation = representation.PadLeft(toPad);
+						break;
+					
+					// TODO: With single line cells, centered and justified are the same right?
+					case TextAlignment.Centered : 
+					case TextAlignment.Justified : 
+						//round down
+						representation = representation.PadRight((int)Math.Floor(toPad/2.0));
+						//round up
+						representation = representation.PadLeft((int)Math.Ceiling(toPad/2.0));
+						break;
+
+				}
+				
+				return representation;
+			}
+
+			// value is too wide
+			return representation.Substring (0, availableHorizontalSpace);
 		}
 
 		/// <inheritdoc/>
@@ -428,16 +567,16 @@ namespace Terminal.Gui.Views {
 			SelectedColumn = Math.Max(Math.Min(SelectedColumn,Table.Columns.Count -1),0);
 			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
 
-			Dictionary<DataColumn, int> columnsToRender = CalculateViewport (Bounds);
+			var columnsToRender = CalculateViewport (Bounds).ToArray();
 			var headerHeight = GetHeaderHeight();
 
 			//if we have scrolled too far to the left 
-			if (SelectedColumn < columnsToRender.Keys.Min (col => col.Ordinal)) {
+			if (SelectedColumn < columnsToRender.Min (r => r.Column.Ordinal)) {
 				ColumnOffset = SelectedColumn;
 			}
 
 			//if we have scrolled too far to the right
-			if (SelectedColumn > columnsToRender.Keys.Max (col => col.Ordinal)) {
+			if (SelectedColumn > columnsToRender.Max (r=> r.Column.Ordinal)) {
 				ColumnOffset = SelectedColumn;
 			}
 
@@ -459,12 +598,10 @@ namespace Terminal.Gui.Views {
 		/// <param name="bounds"></param>
 		/// <param name="padding"></param>
 		/// <returns></returns>
-		private Dictionary<DataColumn, int> CalculateViewport (Rect bounds, int padding = 1)
+		private IEnumerable<ColumnToRender> CalculateViewport (Rect bounds, int padding = 1)
 		{
-			Dictionary<DataColumn, int> toReturn = new Dictionary<DataColumn, int> ();
-
 			if(Table == null)
-				return toReturn;
+				yield break;
 			
 			int usedSpace = 0;
 
@@ -484,20 +621,19 @@ namespace Terminal.Gui.Views {
 			foreach (var col in Table.Columns.Cast<DataColumn>().Skip (ColumnOffset)) {
 
 				int startingIdxForCurrentHeader = usedSpace;
+				var colStyle = Style.GetColumnStyleIfAny(col);
 
 				// is there enough space for this column (and it's data)?
-				usedSpace += CalculateMaxRowSize (col, rowsToRender) + padding;
+				usedSpace += CalculateMaxCellWidth (col, rowsToRender,colStyle) + padding;
 
 				// no (don't render it) unless its the only column we are render (that must be one massively wide column!)
 				if (!first && usedSpace > availableHorizontalSpace)
-					return toReturn;
+					yield break;
 
 				// there is space
-				toReturn.Add (col, startingIdxForCurrentHeader);
+				yield return new ColumnToRender(col, startingIdxForCurrentHeader);
 				first=false;
 			}
-
-			return toReturn;
 		}
 
 		private bool ShouldRenderHeaders()
@@ -513,8 +649,9 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		/// <param name="col"></param>
 		/// <param name="rowsToRender"></param>
+		/// <param name="colStyle"></param>
 		/// <returns></returns>
-		private int CalculateMaxRowSize (DataColumn col, int rowsToRender)
+		private int CalculateMaxCellWidth(DataColumn col, int rowsToRender,ColumnStyle colStyle)
 		{
 			int spaceRequired = col.ColumnName.Length;
 
@@ -526,8 +663,27 @@ namespace Terminal.Gui.Views {
 			for (int i = RowOffset; i < RowOffset + rowsToRender && i < Table.Rows.Count; i++) {
 
 				//expand required space if cell is bigger than the last biggest cell or header
-				spaceRequired = Math.Max (spaceRequired, GetRenderedVal (Table.Rows [i] [col]).Length);
+				spaceRequired = Math.Max (spaceRequired, GetRepresentation(Table.Rows [i][col],colStyle).Length);
 			}
+
+			// Don't require more space than the style allows
+			if(colStyle != null){
+
+				// enforce maximum cell width based on style
+				if(spaceRequired > colStyle.MaxWidth) {
+					spaceRequired = colStyle.MaxWidth;
+				}
+
+				// enforce minimum cell width based on style
+				if(spaceRequired < colStyle.MinWidth) {
+					spaceRequired = colStyle.MinWidth;
+				}
+			}
+			
+			// enforce maximum cell width based on global table style
+			if(spaceRequired > MaxCellWidth)
+				spaceRequired = MaxCellWidth;
+
 
 			return spaceRequired;
 		}
@@ -536,20 +692,37 @@ namespace Terminal.Gui.Views {
 		/// Returns the value that should be rendered to best represent a strongly typed <paramref name="value"/> read from <see cref="Table"/>
 		/// </summary>
 		/// <param name="value"></param>
+		/// <param name="colStyle">Optional style defining how to represent cell values</param>
 		/// <returns></returns>
-		private string GetRenderedVal (object value)
+		private string GetRepresentation(object value,ColumnStyle colStyle)
 		{
 			if (value == null || value == DBNull.Value) {
 				return NullSymbol;
 			}
 
-			var representation = value.ToString ();
+			return colStyle != null ? colStyle.GetRepresentation(value): value.ToString();
+		}
+	}
 
-			//if it is too long to fit
-			if (representation.Length > MaximumCellWidth)
-				return representation.Substring (0, MaximumCellWidth);
+	/// <summary>
+	/// Describes a desire to render a column at a given horizontal position in the UI
+	/// </summary>
+	internal class ColumnToRender {
 
-			return representation;
+		/// <summary>
+		/// The column to render
+		/// </summary>
+		public DataColumn Column {get;set;}
+
+		/// <summary>
+		/// The horizontal position to begin rendering the column at
+		/// </summary>
+		public int X{get;set;}
+
+		public ColumnToRender (DataColumn col, int x)
+		{
+			Column = col;
+			X = x;
 		}
 	}
 }

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -576,11 +576,17 @@ namespace Terminal.Gui.Views {
 			if (me.Flags == MouseFlags.WheeledDown) {
 				
 				RowOffset++;
-				Update ();
+				
+				EnsureValidScrollOffsets();
+				SetNeedsDisplay();
+
 				return true;
 			} else if (me.Flags == MouseFlags.WheeledUp) {
 				RowOffset--;
-				Update ();
+				
+				EnsureValidScrollOffsets();
+				SetNeedsDisplay();
+
 				return true;
 			}
 
@@ -617,11 +623,8 @@ namespace Terminal.Gui.Views {
 				return;
 			}
 
-			//if user opened a large table scrolled down a lot then opened a smaller table (or API deleted a bunch of columns without telling anyone)
-			ColumnOffset = Math.Max(Math.Min(ColumnOffset,Table.Columns.Count -1),0);
-			RowOffset = Math.Max(Math.Min(RowOffset,Table.Rows.Count -1),0);
-			SelectedColumn = Math.Max(Math.Min(SelectedColumn,Table.Columns.Count -1),0);
-			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
+			EnsureValidScrollOffsets();
+			EnsureValidSelection();
 
 			var columnsToRender = CalculateViewport (Bounds).ToArray();
 			var headerHeight = GetHeaderHeight();
@@ -646,6 +649,35 @@ namespace Terminal.Gui.Views {
 			}
 
 			SetNeedsDisplay ();
+		}
+
+		/// <summary>
+		/// Updates <see cref="ColumnOffset"/> and <see cref="RowOffset"/> where they are outside the bounds of the table (by adjusting them to the nearest existing cell).  Has no effect if <see cref="Table"/> has not been set.
+		/// </summary>
+		/// <remarks>Changes will not be immediately visible in the display until you call <see cref="View.SetNeedsDisplay()"/></remarks>
+		public void EnsureValidScrollOffsets ()
+		{
+			if(Table == null){
+				return;
+			}
+
+			ColumnOffset = Math.Max(Math.Min(ColumnOffset,Table.Columns.Count -1),0);
+			RowOffset = Math.Max(Math.Min(RowOffset,Table.Rows.Count -1),0);
+		}
+
+
+		/// <summary>
+		/// Updates <see cref="SelectedColumn"/> and <see cref="SelectedRow"/> where they are outside the bounds of the table (by adjusting them to the nearest existing cell).  Has no effect if <see cref="Table"/> has not been set.
+		/// </summary>
+		/// <remarks>Changes will not be immediately visible in the display until you call <see cref="View.SetNeedsDisplay()"/></remarks>
+		public void EnsureValidSelection ()
+		{
+			if(Table == null){
+				return;
+			}
+
+			SelectedColumn = Math.Max(Math.Min(SelectedColumn,Table.Columns.Count -1),0);
+			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -580,7 +580,7 @@ namespace Terminal.Gui {
 		{
 			if(Table == null){
 				PositionCursor ();
-				return true;
+				return false;
 			}
 
 			if(keyEvent.Key == CellActivationKey && Table != null) {

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -558,6 +558,53 @@ namespace Terminal.Gui.Views {
 			return true;
 		}
 
+		///<inheritdoc/>
+		public override bool MouseEvent (MouseEvent me)
+		{
+			if (!me.Flags.HasFlag (MouseFlags.Button1Clicked) && !me.Flags.HasFlag (MouseFlags.Button1DoubleClicked) &&
+				me.Flags != MouseFlags.WheeledDown && me.Flags != MouseFlags.WheeledUp)
+				return false;
+
+			if (!HasFocus && CanFocus) {
+				SetFocus ();
+			}
+
+			if (Table == null) {
+				return false;
+			}
+
+			if (me.Flags == MouseFlags.WheeledDown) {
+				
+				RowOffset++;
+				Update ();
+				return true;
+			} else if (me.Flags == MouseFlags.WheeledUp) {
+				RowOffset--;
+				return true;
+			}
+
+			if(me.Flags == MouseFlags.Button1Clicked) {
+				
+				var viewPort = CalculateViewport(Bounds);
+				
+				var headerHeight = GetHeaderHeight();
+
+				var col = viewPort.LastOrDefault(c=>c.X < me.OfX);
+				
+				var rowIdx = RowOffset - headerHeight + me.OfY;
+
+				if(col != null && rowIdx >= 0) {
+					
+					SelectedRow = rowIdx;
+					SelectedColumn = col.Column.Ordinal;
+				
+					Update();
+				}
+			}
+
+			return false;
+		}
+
 		/// <summary>
 		/// Updates the view to reflect changes to <see cref="Table"/> and to (<see cref="ColumnOffset"/> / <see cref="RowOffset"/>) etc
 		/// </summary>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NStack;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -12,6 +13,8 @@ namespace Terminal.Gui.Views {
 
 		private int columnOffset;
 		private int rowOffset;
+		private int selectedRow;
+		private int selectedColumn;
 
 		public DataTable Table { get; private set; }
 
@@ -20,42 +23,37 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int ColumnOffset {
-			get {
-				return columnOffset; 
-			}
+			get => columnOffset;
 
 			//try to prevent this being set to an out of bounds column
-			set {
-				//the value before we changed it
-				var origValue = columnOffset;
-
-				columnOffset = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
-				
-				//if value actually changed we must update UI
-				if(columnOffset != origValue)
-					SetNeedsDisplay();
-			}
+			set  => columnOffset = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
 		}
-
 
 		/// <summary>
 		/// Zero indexed offset for the <see cref="DataRow"/> to display in <see cref="Table"/> on line 2 of the control (first line being headers)
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
 		public int RowOffset { 
-			get {
-				return rowOffset; 
-			}
-			set {
-				//the value before we changed it
-				var origValue = rowOffset;
+			get => rowOffset; 
+			set => rowOffset = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+		}
 
-				rowOffset = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+		/// <summary>
+		/// The index of <see cref="DataTable.Columns"/> in <see cref="Table"/> that the user has currently selected
+		/// </summary>
+		public int SelectedColumn {
+			get => selectedColumn;
 
-				//if value actually changed we must update UI
-				if(rowOffset != origValue)
-					SetNeedsDisplay();
-			}
+			//try to prevent this being set to an out of bounds column
+			set  => selectedColumn = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+		}
+
+		/// <summary>
+		/// The index of <see cref="DataTable.Rows"/> in <see cref="Table"/> that the user has currently selected
+		/// </summary>
+		public int SelectedRow { 
+			get => selectedRow; 
+			set => selectedRow = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
 		}
 
 		/// <summary>
@@ -91,22 +89,19 @@ namespace Terminal.Gui.Views {
 
 			var frame = Frame;
 
-			int activeColor = ColorScheme.HotNormal;
-			int trackingColor = ColorScheme.HotFocus;
-
 			// What columns to render at what X offset in viewport
 			Dictionary<DataColumn, int> columnsToRender = CalculateViewport(bounds);
 
-			Driver.SetAttribute (ColorScheme.HotNormal);
+			Driver.SetAttribute (ColorScheme.Normal);
 
 			//invalidate current row (prevents scrolling around leaving old characters in the frame
 			Driver.AddStr(new string (' ',bounds.Width));
-
+			
 			// Render the headers
 			foreach(var kvp in columnsToRender) {
 				
 				Move (kvp.Value,0);
-				Driver.AddStr(kvp.Key.ColumnName+ SeparatorSymbol);
+				Driver.AddStr(Truncate(kvp.Key.ColumnName+ SeparatorSymbol,bounds.Width - kvp.Value));
 			}
 
 			//render the cells
@@ -114,6 +109,7 @@ namespace Terminal.Gui.Views {
 				
 				//invalidate current row (prevents scrolling around leaving old characters in the frame
 				Move (0,line);
+				Driver.SetAttribute(ColorScheme.Normal);
 				Driver.AddStr(new string (' ',bounds.Width));
 
 				//work out what Row to render
@@ -125,7 +121,14 @@ namespace Terminal.Gui.Views {
 
 				foreach(var kvp in columnsToRender) {
 					Move (kvp.Value,line);
-					Driver.AddStr(GetRenderedVal(Table.Rows[rowToRender][kvp.Key]) + SeparatorSymbol);
+
+					bool isSelectedCell = rowToRender == SelectedRow && kvp.Key.Ordinal == SelectedColumn;
+
+					Driver.SetAttribute(isSelectedCell? ColorScheme.HotFocus: ColorScheme.Normal);
+
+					
+					var valueToRender = GetRenderedVal(Table.Rows[rowToRender][kvp.Key]) + SeparatorSymbol;
+					Driver.AddStr(Truncate(valueToRender,bounds.Width - kvp.Value ));
 				}
 			}
 
@@ -138,50 +141,101 @@ namespace Terminal.Gui.Views {
 			}
 
 		}
-		
+
+		private ustring Truncate (string valueToRender, int availableHorizontalSpace)
+		{
+			if(string.IsNullOrEmpty(valueToRender) || valueToRender.Length < availableHorizontalSpace)
+				return valueToRender;
+
+			return valueToRender.Substring(0,availableHorizontalSpace);
+		}
+
 		/// <inheritdoc/>
 		public override bool ProcessKey (KeyEvent keyEvent)
 		{
 			switch (keyEvent.Key) {
 			case Key.CursorLeft:
-				ColumnOffset--;
+				SelectedColumn--;
+				RefreshViewport();
 				break;
 			case Key.CursorRight:
-				ColumnOffset++;
+				SelectedColumn++;
+				RefreshViewport();
 				break;
 			case Key.CursorDown:
-				RowOffset++;
+				SelectedRow++;
+				RefreshViewport();
 				break;
 			case Key.CursorUp:
-				RowOffset--;
+				SelectedRow--;
+				RefreshViewport();
 				break;
 			case Key.PageUp:
-				 RowOffset -= Frame.Height;
+				SelectedRow -= Frame.Height;
+				RefreshViewport();
 				break;
-			case Key.V | Key.CtrlMask:
 			case Key.PageDown:
-				 RowOffset += Frame.Height;
+				SelectedRow += Frame.Height;
+				RefreshViewport();
 				break;
 			case Key.Home | Key.CtrlMask:
-				RowOffset = 0;
-				ColumnOffset = 0;
+				SelectedRow = 0;
+				SelectedColumn = 0;
+				RefreshViewport();
 				break;
 			case Key.Home:
-				ColumnOffset = 0;
+				SelectedColumn = 0;
+				RefreshViewport();
 				break;
 			case Key.End | Key.CtrlMask:
 				//jump to end of table
-				RowOffset = Table.Rows.Count-1;
-				ColumnOffset = Table.Columns.Count-1;
+				SelectedRow = Table.Rows.Count-1;
+				SelectedColumn = Table.Columns.Count-1;
+				RefreshViewport();
 				break;
 			case Key.End:
 				//jump to end of row
-				ColumnOffset = Table.Columns.Count-1;				
+				SelectedColumn = Table.Columns.Count-1;
+				RefreshViewport();		
 				break;
 			}
 			PositionCursor ();
 			return true;
 		}
+
+		/// <summary>
+		/// Updates the viewport (<see cref="ColumnOffset"/> / <see cref="RowOffset"/>) to ensure that the users selected cell is visible and redraws control
+		/// </summary>
+		/// <remarks>This always calls <see cref="View.SetNeedsDisplay()"/></remarks>
+		public void RefreshViewport ()
+		{
+			//TODO: implement
+
+			Dictionary<DataColumn, int> columnsToRender = CalculateViewport(Bounds);
+
+
+			//if we have scrolled too far to the left 
+			if(SelectedColumn < columnsToRender.Keys.Min(col=>col.Ordinal)) {
+				ColumnOffset = SelectedColumn;
+			}
+
+			//if we have scrolled too far to the right
+			if(SelectedColumn > columnsToRender.Keys.Max(col=>col.Ordinal)) {
+				ColumnOffset = SelectedColumn;
+			}
+
+			//if we have scrolled too far down
+			if(SelectedRow > RowOffset + Bounds.Height-1) {
+				RowOffset = SelectedRow;
+			}
+			//if we have scrolled too far up
+			if(SelectedRow < RowOffset) {
+				RowOffset = SelectedRow;
+			}
+
+			SetNeedsDisplay();
+		}
+
 		/// <summary>
 		/// Calculates which columns should be rendered given the <paramref name="bounds"/> in which to display and the <see cref="ColumnOffset"/>
 		/// </summary>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -583,7 +583,8 @@ namespace Terminal.Gui {
 		public override bool MouseEvent (MouseEvent me)
 		{
 			if (!me.Flags.HasFlag (MouseFlags.Button1Clicked) && !me.Flags.HasFlag (MouseFlags.Button1DoubleClicked) &&
-				me.Flags != MouseFlags.WheeledDown && me.Flags != MouseFlags.WheeledUp)
+				me.Flags != MouseFlags.WheeledDown && me.Flags != MouseFlags.WheeledUp &&
+				me.Flags != MouseFlags.WheeledLeft && me.Flags != MouseFlags.WheeledRight)
 				return false;
 
 			if (!HasFocus && CanFocus) {
@@ -594,21 +595,32 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (me.Flags == MouseFlags.WheeledDown) {
-				
-				RowOffset++;
-				
-				EnsureValidScrollOffsets();
-				SetNeedsDisplay();
+			// Scroll wheel flags
+			switch(me.Flags)
+			{
+				case MouseFlags.WheeledDown: 
+					RowOffset++;
+					EnsureValidScrollOffsets();
+					SetNeedsDisplay();
+					return true;
 
-				return true;
-			} else if (me.Flags == MouseFlags.WheeledUp) {
-				RowOffset--;
-				
-				EnsureValidScrollOffsets();
-				SetNeedsDisplay();
+				case MouseFlags.WheeledUp:
+					RowOffset--;
+					EnsureValidScrollOffsets();
+					SetNeedsDisplay();
+					return true;
 
-				return true;
+				case MouseFlags.WheeledRight:
+					ColumnOffset++;
+					EnsureValidScrollOffsets();
+					SetNeedsDisplay();
+					return true;
+
+				case  MouseFlags.WheeledLeft:
+					ColumnOffset--;
+					EnsureValidScrollOffsets();
+					SetNeedsDisplay();
+					return true;
 			}
 
 			if(me.Flags == MouseFlags.Button1Clicked) {

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -148,6 +148,11 @@ namespace Terminal.Gui {
 		public TableStyle Style { get => style; set {style = value; Update(); } }
 						
 		/// <summary>
+		/// True to select the entire row at once.  False to select individual cells.  Defaults to false
+		/// </summary>
+		public bool FullRowSelect {get;set;}
+
+		/// <summary>
 		/// Horizontal scroll offset.  The index of the first column in <see cref="Table"/> to display when when rendering the view.
 		/// </summary>
 		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
@@ -446,7 +451,9 @@ namespace Terminal.Gui {
 				Move (current.X, row);
 
 				// Set color scheme based on whether the current cell is the selected one
-				bool isSelectedCell = rowToRender == SelectedRow && current.Column.Ordinal == SelectedColumn;
+				bool isSelectedCell = rowToRender == SelectedRow && 
+					(current.Column.Ordinal == SelectedColumn || FullRowSelect);
+
 				Driver.SetAttribute (isSelectedCell ? ColorScheme.HotFocus : ColorScheme.Normal);
 
 				var val = Table.Rows [rowToRender][current.Column];
@@ -456,8 +463,10 @@ namespace Terminal.Gui {
 				
 				Driver.AddStr (TruncateOrPad(val,representation,availableWidthForCell,colStyle));
 				
-				// Reset color scheme to normal and render the vertical line (or space) at the end of the cell
-				Driver.SetAttribute (ColorScheme.Normal);
+				// If not in full row select mode always, reset color scheme to normal and render the vertical line (or space) at the end of the cell
+				if(!FullRowSelect)
+					Driver.SetAttribute (ColorScheme.Normal);
+
 				RenderSeparator(current.X-1,row,false);
 			}
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Terminal.Gui.Views {
+
+	/// <summary>
+	/// View for tabular data based on a <see cref="DataTable"/>
+	/// </summary>
+	public class TableView : View {
+
+		private int columnOffset;
+		private int rowOffset;
+
+		public DataTable Table { get; private set; }
+
+		/// <summary>
+		/// Zero indexed offset for the upper left <see cref="DataColumn"/> to display in <see cref="Table"/>.
+		/// </summary>
+		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
+		public int ColumnOffset {
+			get => columnOffset; 
+
+			//try to prevent this being set to an out of bounds column
+			set => columnOffset = Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
+		}
+
+
+		/// <summary>
+		/// Zero indexed offset for the <see cref="DataRow"/> to display in <see cref="Table"/> on line 2 of the control (first line being headers)
+		/// </summary>
+		/// <remarks>This property allows very wide tables to be rendered with horizontal scrolling</remarks>
+		public int RowOffset { 
+			get => rowOffset; 
+			set => rowOffset = Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
+			}
+
+		/// <summary>
+		/// The maximum number of characters to render in any given column.  This prevents one long column from pushing out all the others
+		/// </summary>
+		public int MaximumCellWidth {get;set;} = 100;
+
+		/// <summary>
+		/// The text representation that should be rendered for cells with the value <see cref="DBNull.Value"/>
+		/// </summary>
+		public string NullSymbol {get;set;} = "-";
+
+		/// <summary>
+		/// Initialzies a <see cref="TableView"/> class using <see cref="LayoutStyle.Computed"/> layout. 
+		/// </summary>
+		/// <param name="table">The table to display in the control</param>
+		public TableView (DataTable table) : base ()
+		{
+			this.Table = table ?? throw new ArgumentNullException (nameof (table));
+		}
+		///<inheritdoc/>
+		public override void Redraw (Rect bounds)
+		{
+			Attribute currentAttribute;
+			var current = ColorScheme.Focus;
+			Driver.SetAttribute (current);
+			Move (0, 0);
+
+			var frame = Frame;
+
+			int activeColor = ColorScheme.HotNormal;
+			int trackingColor = ColorScheme.HotFocus;
+
+			// What columns to render at what X offset in viewport
+			Dictionary<DataColumn, int> columnsToRender = CalculateViewport(bounds);
+
+			Driver.SetAttribute (ColorScheme.HotNormal);
+
+			// Render the headers
+			foreach(var kvp in columnsToRender) {
+				
+				Move (kvp.Value,0);
+				Driver.AddStr(kvp.Key.ColumnName);
+			}
+
+			//render the cells
+			for (int line = 1; line < frame.Height; line++) {
+				
+				//work out what Row to render
+				var rowToRender = RowOffset + (line-1);
+				if(rowToRender >= Table.Rows.Count)
+					break;
+
+				foreach(var kvp in columnsToRender) {
+					Move (kvp.Value,line);
+					Driver.AddStr(GetRenderedVal(Table.Rows[rowToRender][kvp.Key]));
+				}
+			}
+
+			/*
+
+			for (int line = 1; line < frame.Height; line++) {
+				var lineRect = new Rect (0, line, frame.Width, 1);
+				if (!bounds.Contains (lineRect))
+					continue;
+
+				Move (0, line);
+				Driver.SetAttribute (ColorScheme.HotNormal);
+				Driver.AddStr ("test");
+
+				currentAttribute = ColorScheme.HotNormal;
+				SetAttribute (ColorScheme.Normal);
+			}*/
+
+			void SetAttribute (Attribute attribute)
+			{
+				if (currentAttribute != attribute) {
+					currentAttribute = attribute;
+					Driver.SetAttribute (attribute);
+				}
+			}
+
+		}
+
+		/// <summary>
+		/// Calculates which columns should be rendered given the <paramref name="bounds"/> in which to display and the <see cref="ColumnOffset"/>
+		/// </summary>
+		/// <param name="bounds"></param>
+		/// <param name="padding"></param>
+		/// <returns></returns>
+		private Dictionary<DataColumn,int> CalculateViewport(Rect bounds, int padding = 1)
+		{
+			Dictionary<DataColumn,int> toReturn = new Dictionary<DataColumn, int>();
+
+			int usedSpace = 0;
+			int availableHorizontalSpace = bounds.Width;
+			int rowsToRender = bounds.Height-1; //1 reserved for the headers row
+			
+			foreach(var col in Table.Columns.Cast<DataColumn>().Skip(ColumnOffset)) {
+				
+				toReturn.Add(col,usedSpace);
+				usedSpace += CalculateMaxRowSize(col,rowsToRender) + padding;
+
+				if(usedSpace > availableHorizontalSpace)
+					return toReturn;
+				
+			}
+			
+			return toReturn;
+		}
+
+		/// <summary>
+		/// Returns the maximum of the <paramref name="col"/> name and the maximum length of data that will be rendered starting at <see cref="RowOffset"/> and rendering <paramref name="rowsToRender"/>
+		/// </summary>
+		/// <param name="col"></param>
+		/// <param name="rowsToRender"></param>
+		/// <returns></returns>
+		private int CalculateMaxRowSize (DataColumn col, int rowsToRender)
+		{
+			int spaceRequired = col.ColumnName.Length;
+
+			for(int i = RowOffset; i<rowsToRender && i<Table.Rows.Count;i++) {
+
+				//expand required space if cell is bigger than the last biggest cell or header
+				spaceRequired = Math.Max(spaceRequired,GetRenderedVal(Table.Rows[i][col]).Length);
+			}
+
+			return spaceRequired;
+		}
+
+		/// <summary>
+		/// Returns the value that should be rendered to best represent a strongly typed <paramref name="value"/> read from <see cref="Table"/>
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		private string GetRenderedVal (object value)
+		{
+			if(value == null || value == DBNull.Value) 
+			{
+				return NullSymbol;
+			}
+			
+			var representation = value.ToString();
+
+			//if it is too long to fit
+			if(representation.Length > MaximumCellWidth)
+				return representation.Substring(0,MaximumCellWidth);
+
+			return representation;
+		}
+	}
+}

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -617,8 +617,12 @@ namespace Terminal.Gui {
 				
 				var headerHeight = ShouldRenderHeaders()? GetHeaderHeight():0;
 
-				var col = viewPort.LastOrDefault(c=>c.X < me.OfX);
+				var col = viewPort.LastOrDefault(c=>c.X <= me.OfX);
 				
+				// Click is on the header section of rendered UI
+				if(me.OfY < headerHeight)
+					return false;
+
 				var rowIdx = RowOffset - headerHeight + me.OfY;
 
 				if(col != null && rowIdx >= 0) {

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -223,6 +223,12 @@ namespace Terminal.Gui.Views {
 				return;
 			}
 
+			//if user opened a large table scrolled down a lot then opened a smaller table (or API deleted a bunch of columns without telling anyone)
+			ColumnOffset = Math.Max(Math.Min(ColumnOffset,Table.Columns.Count -1),0);
+			RowOffset = Math.Max(Math.Min(RowOffset,Table.Rows.Count -1),0);
+			SelectedColumn = Math.Max(Math.Min(SelectedColumn,Table.Columns.Count -1),0);
+			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
+
 			Dictionary<DataColumn, int> columnsToRender = CalculateViewport (Bounds);
 
 			//if we have scrolled too far to the left 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -179,7 +179,7 @@ namespace Terminal.Gui {
 				selectedColumn = Table == null ? 0 :  Math.Min (Table.Columns.Count - 1, Math.Max (0, value));
 
 				if(oldValue != selectedColumn)
-					OnSelectedCellChanged();
+					OnSelectedCellChanged(new SelectedCellChangedEventArgs(Table,oldValue,SelectedColumn,SelectedRow,SelectedRow));
 			} 
 		}
 
@@ -190,12 +190,12 @@ namespace Terminal.Gui {
 			get => selectedRow;
 			set {
 
-				var oldValue = selectedColumn;
+				var oldValue = selectedRow;
 
 				selectedRow =  Table == null ? 0 : Math.Min (Table.Rows.Count - 1, Math.Max (0, value));
 
 				if(oldValue != selectedRow)
-					OnSelectedCellChanged();
+					OnSelectedCellChanged(new SelectedCellChangedEventArgs(Table,SelectedColumn,SelectedColumn,oldValue,selectedRow));
 			}
 		}
 
@@ -217,7 +217,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// This event is raised when the selected cell in the table changes.
 		/// </summary>
-		public event Action<EventArgs> SelectedCellChanged;
+		public event Action<SelectedCellChangedEventArgs> SelectedCellChanged;
 
 		/// <summary>
 		/// Initialzies a <see cref="TableView"/> class using <see cref="LayoutStyle.Computed"/> layout. 
@@ -715,9 +715,9 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Invokes the <see cref="SelectedCellChanged"/> event
 		/// </summary>
-		protected virtual void OnSelectedCellChanged()
+		protected virtual void OnSelectedCellChanged(SelectedCellChangedEventArgs args)
 		{
-			SelectedCellChanged?.Invoke(new EventArgs());
+			SelectedCellChanged?.Invoke(args);
 		}
 
 		/// <summary>
@@ -851,6 +851,63 @@ namespace Terminal.Gui {
 		{
 			Column = col;
 			X = x;
+		}
+	}
+
+	/// <summary>
+	/// Defines the event arguments for <see cref="TableView.SelectedCellChanged"/> 
+	/// </summary>
+	public class SelectedCellChangedEventArgs : EventArgs
+	{
+		/// <summary>
+		/// The current table to which the new indexes refer.  May be null e.g. if selection change is the result of clearing the table from the view
+		/// </summary>
+		/// <value></value>
+		public DataTable Table {get;}
+
+
+		/// <summary>
+		/// The previous selected column index.  May be invalid e.g. when the selection has been changed as a result of replacing the existing Table with a smaller one
+		/// </summary>
+		/// <value></value>
+		public int OldCol {get;}
+
+
+		/// <summary>
+		/// The newly selected column index.
+		/// </summary>
+		/// <value></value>
+		public int NewCol {get;}
+
+
+		/// <summary>
+		/// The previous selected row index.  May be invalid e.g. when the selection has been changed as a result of deleting rows from the table
+		/// </summary>
+		/// <value></value>
+		public int OldRow {get;}
+
+
+		/// <summary>
+		/// The newly selected row index.
+		/// </summary>
+		/// <value></value>
+		public int NewRow {get;}
+
+		/// <summary>
+		/// Creates a new instance of arguments describing a change in selected cell in a <see cref="TableView"/>
+		/// </summary>
+		/// <param name="t"></param>
+		/// <param name="oldCol"></param>
+		/// <param name="newCol"></param>
+		/// <param name="oldRow"></param>
+		/// <param name="newRow"></param>
+		public SelectedCellChangedEventArgs(DataTable t, int oldCol, int newCol, int oldRow, int newRow)
+		{
+			Table = t;
+			OldCol = oldCol;
+			NewCol = newCol;
+			OldRow = oldRow;
+			NewRow = newRow;
 		}
 	}
 }

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -580,6 +580,7 @@ namespace Terminal.Gui.Views {
 				return true;
 			} else if (me.Flags == MouseFlags.WheeledUp) {
 				RowOffset--;
+				Update ();
 				return true;
 			}
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -205,6 +205,9 @@ namespace Terminal.Gui.Views {
 				SelectedColumn =  Table == null ? 0 : Table.Columns.Count - 1;
 				Update ();
 				break;
+			default:
+				// Not a keystroke we care about
+				return false;
 			}
 			PositionCursor ();
 			return true;

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -497,10 +497,10 @@ namespace Terminal.Gui {
 				return representation;
 
 			// if value is not wide enough
-			if(representation.Length < availableHorizontalSpace) {
+			if(representation.Sum(c=>Rune.ColumnWidth(c)) < availableHorizontalSpace) {
 				
 				// pad it out with spaces to the given alignment
-				int toPad = availableHorizontalSpace - (representation.Length+1 /*leave 1 space for cell boundary*/);
+				int toPad = availableHorizontalSpace - (representation.Sum(c=>Rune.ColumnWidth(c)) +1 /*leave 1 space for cell boundary*/);
 
 				switch(colStyle?.GetAlignment(originalCellValue) ?? TextAlignment.Left) {
 
@@ -520,7 +520,7 @@ namespace Terminal.Gui {
 			}
 
 			// value is too wide
-			return representation.Substring (0, availableHorizontalSpace);
+			return new string(representation.TakeWhile(c=>(availableHorizontalSpace-= Rune.ColumnWidth(c))>0).ToArray());
 		}
 
 		/// <inheritdoc/>
@@ -787,7 +787,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private int CalculateMaxCellWidth(DataColumn col, int rowsToRender,ColumnStyle colStyle)
 		{
-			int spaceRequired = col.ColumnName.Length;
+			int spaceRequired = col.ColumnName.Sum(c=>Rune.ColumnWidth(c));
 
 			// if table has no rows
 			if(RowOffset < 0)
@@ -797,7 +797,7 @@ namespace Terminal.Gui {
 			for (int i = RowOffset; i < RowOffset + rowsToRender && i < Table.Rows.Count; i++) {
 
 				//expand required space if cell is bigger than the last biggest cell or header
-				spaceRequired = Math.Max (spaceRequired, GetRepresentation(Table.Rows [i][col],colStyle).Length);
+				spaceRequired = Math.Max (spaceRequired, GetRepresentation(Table.Rows [i][col],colStyle).Sum(c=>Rune.ColumnWidth(c)));
 			}
 
 			// Don't require more space than the style allows

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -79,7 +79,7 @@ namespace Terminal.Gui.Views {
 		/// Initialzies a <see cref="TableView"/> class using <see cref="LayoutStyle.Computed"/> layout. 
 		/// </summary>
 		/// <param name="table">The table to display in the control</param>
-		public TableView (DataTable table) : base ()
+		public TableView (DataTable table) : this ()
 		{
 			this.Table = table;
 		}
@@ -89,6 +89,7 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		public TableView () : base ()
 		{
+			CanFocus = true;
 		}
 
 		///<inheritdoc/>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -254,7 +254,7 @@ namespace Terminal.Gui.Views {
 				//where the header should start
 				var col = kvp.Value;
 
-				RenderSeparator(col-1,row);
+				RenderSeparator(col-1,row,true);
 									
 				Move (col, row);
 				Driver.AddStr(Truncate (kvp.Key.ColumnName, availableWidth - kvp.Value));
@@ -297,7 +297,7 @@ namespace Terminal.Gui.Views {
 		private void RenderRow(int row, int availableWidth, int rowToRender, Dictionary<DataColumn, int> columnsToRender)
 		{
 			//render start of line
-			if(style.ShowVerticalHeaderLines)
+			if(style.ShowVerticalCellLines)
 				AddRune(0,row,Driver.VLine);
 
 			// Render cells for each visible header for the current row
@@ -316,20 +316,22 @@ namespace Terminal.Gui.Views {
 				
 				// Reset color scheme to normal and render the vertical line (or space) at the end of the cell
 				Driver.SetAttribute (ColorScheme.Normal);
-				RenderSeparator(kvp.Value-1,row);
+				RenderSeparator(kvp.Value-1,row,false);
 			}
 
 			//render end of line
-			if(style.ShowVerticalHeaderLines)
+			if(style.ShowVerticalCellLines)
 				AddRune(availableWidth-1,row,Driver.VLine);
 		}
 		
-		private void RenderSeparator(int col, int row)
+		private void RenderSeparator(int col, int row,bool isHeader)
 		{
 			if(col<0)
 				return;
+				
+			var renderLines = isHeader ? style.ShowVerticalHeaderLines : style.ShowVerticalCellLines;
 
-			Rune symbol = style.ShowVerticalHeaderLines ? Driver.VLine : SeparatorSymbol;
+			Rune symbol =  renderLines ? Driver.VLine : SeparatorSymbol;
 			AddRune(col,row,symbol);
 		}
 
@@ -468,7 +470,7 @@ namespace Terminal.Gui.Views {
 
 			//if horizontal space is required at the start of the line (before the first header)
 			if(Style.ShowVerticalHeaderLines || Style.ShowVerticalCellLines)
-				usedSpace+=2;
+				usedSpace+=1;
 			
 			int availableHorizontalSpace = bounds.Width;
 			int rowsToRender = bounds.Height;
@@ -500,6 +502,9 @@ namespace Terminal.Gui.Views {
 
 		private bool ShouldRenderHeaders()
 		{
+			if(Table == null || Table.Columns.Count == 0)
+				return false;
+
 		    return Style.AlwaysShowHeaders || rowOffset == 0;
 		}
 

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -626,27 +626,7 @@ namespace Terminal.Gui.Views {
 			EnsureValidScrollOffsets();
 			EnsureValidSelection();
 
-			var columnsToRender = CalculateViewport (Bounds).ToArray();
-			var headerHeight = GetHeaderHeight();
-
-			//if we have scrolled too far to the left 
-			if (SelectedColumn < columnsToRender.Min (r => r.Column.Ordinal)) {
-				ColumnOffset = SelectedColumn;
-			}
-
-			//if we have scrolled too far to the right
-			if (SelectedColumn > columnsToRender.Max (r=> r.Column.Ordinal)) {
-				ColumnOffset = SelectedColumn;
-			}
-
-			//if we have scrolled too far down
-			if (SelectedRow >= RowOffset + (Bounds.Height - headerHeight)) {
-				RowOffset = SelectedRow;
-			}
-			//if we have scrolled too far up
-			if (SelectedRow < RowOffset) {
-				RowOffset = SelectedRow;
-			}
+			EnsureSelectedCellIsVisible();
 
 			SetNeedsDisplay ();
 		}
@@ -678,6 +658,39 @@ namespace Terminal.Gui.Views {
 
 			SelectedColumn = Math.Max(Math.Min(SelectedColumn,Table.Columns.Count -1),0);
 			SelectedRow = Math.Max(Math.Min(SelectedRow,Table.Rows.Count -1),0);
+		}
+
+		/// <summary>
+		/// Updates scroll offsets to ensure that the selected cell is visible.  Has no effect if <see cref="Table"/> has not been set.
+		/// </summary>
+		/// <remarks>Changes will not be immediately visible in the display until you call <see cref="View.SetNeedsDisplay()"/></remarks>
+		public void EnsureSelectedCellIsVisible ()
+		{
+			if(Table == null){
+				return;
+			}
+
+			var columnsToRender = CalculateViewport (Bounds).ToArray();
+			var headerHeight = GetHeaderHeight();
+
+			//if we have scrolled too far to the left 
+			if (SelectedColumn < columnsToRender.Min (r => r.Column.Ordinal)) {
+				ColumnOffset = SelectedColumn;
+			}
+
+			//if we have scrolled too far to the right
+			if (SelectedColumn > columnsToRender.Max (r=> r.Column.Ordinal)) {
+				ColumnOffset = SelectedColumn;
+			}
+
+			//if we have scrolled too far down
+			if (SelectedRow >= RowOffset + (Bounds.Height - headerHeight)) {
+				RowOffset = SelectedRow;
+			}
+			//if we have scrolled too far up
+			if (SelectedRow < RowOffset) {
+				RowOffset = SelectedRow;
+			}
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -118,6 +118,19 @@ namespace Terminal.Gui {
 		{
 			return ColumnStyles.TryGetValue(col,out ColumnStyle result) ? result : null;
 		}
+
+		/// <summary>
+		/// Returns an existing <see cref="ColumnStyle"/> for the given <paramref name="col"/> or creates a new one with default options
+		/// </summary>
+		/// <param name="col"></param>
+		/// <returns></returns>
+		public ColumnStyle GetOrCreateColumnStyle (DataColumn col)
+		{
+			if(!ColumnStyles.ContainsKey(col))
+				ColumnStyles.Add(col,new ColumnStyle());
+
+			return ColumnStyles[col];
+		}
 	}
 	
 	/// <summary>

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -225,7 +225,8 @@ namespace UICatalog.Scenarios {
 
 					var arrayItems = currentRow.ItemArray;
 					tableView.Table.Rows.Remove(currentRow);
-					
+
+					// Removing and Inserting the same DataRow seems to result in it loosing its values so we have to create a new instance
 					var newRow = tableView.Table.NewRow();
 					newRow.ItemArray = arrayItems;
 					
@@ -297,7 +298,11 @@ namespace UICatalog.Scenarios {
 				return;
 			}
 
-			tableView.Table.Rows.Add();
+			var newRow = tableView.Table.NewRow();
+
+			var newRowIdx = Math.Min(Math.Max(0,tableView.SelectedRow+1),tableView.Table.Rows.Count);
+
+			tableView.Table.Rows.InsertAt(newRow,newRowIdx);
 			tableView.Update();
 		}
 
@@ -311,6 +316,8 @@ namespace UICatalog.Scenarios {
 
 				var col = new DataColumn(colName);
 
+				var newColIdx = Math.Min(Math.Max(0,tableView.SelectedColumn + 1),tableView.Table.Columns.Count);
+				
 				int result = MessageBox.Query(40,15,"Column Type","Pick a data type for the column",new ustring[]{"Date","Integer","Double","Text","Cancel"});
 
 				if(result <= -1 || result >= 4)
@@ -327,6 +334,7 @@ namespace UICatalog.Scenarios {
 				}
 
 				tableView.Table.Columns.Add(col);
+				col.SetOrdinal(newColIdx);
 				tableView.Update();
 			}
 

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -1,0 +1,428 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Terminal.Gui;
+using System.Linq;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace UICatalog.Scenarios {
+
+	[ScenarioMetadata (Name: "Csv Editor", Description: "Open and edit simple CSV files")]
+	[ScenarioCategory ("Controls")]
+	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("Text")]
+	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("TopLevel")]
+	public class CsvEditor : Scenario 
+	{
+		TableView tableView;
+		private string currentFile;
+
+		public override void Setup ()
+		{
+			Win.Title = this.GetName();
+			Win.Y = 1; // menu
+			Win.Height = Dim.Fill (1); // status bar
+			Top.LayoutSubviews ();
+
+			this.tableView = new TableView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (1),
+			};
+
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem ("_File", new MenuItem [] {
+					new MenuItem ("_Open CSV", "", () => Open()),
+					new MenuItem ("_Save", "", () => Save()),
+					new MenuItem ("_Quit", "", () => Quit()),
+				}),
+				new MenuBarItem ("_Edit", new MenuItem [] {
+					new MenuItem ("_Rename Column", "", () => RenameColumn()),
+				}),
+				new MenuBarItem ("_Insert", new MenuItem [] {
+					new MenuItem ("_New Column", "", () => AddColumn()),
+					new MenuItem ("_New Row", "", () => AddRow()),
+				})
+			});
+			Top.Add (menu);
+
+			var statusBar = new StatusBar (new StatusItem [] {
+				new StatusItem(Key.CtrlMask | Key.O, "~^O~ Open", () => Open()),
+				new StatusItem(Key.CtrlMask | Key.S, "~^S~ Save", () => Save()),
+				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
+			});
+			Top.Add (statusBar);
+
+			Win.Add (tableView);
+
+			var selectedCellLabel = new Label(){
+				X = 0,
+				Y = Pos.Bottom(tableView),
+				Text = "0,0",
+				Width = Dim.Fill(),
+				TextAlignment = TextAlignment.Right
+				
+			};
+
+			Win.Add(selectedCellLabel);
+
+			tableView.SelectedCellChanged += (e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
+			tableView.CellActivated += EditCurrentCell;
+			tableView.KeyPress += TableViewKeyPress;
+
+			SetupScrollBar();
+		}
+
+		private void RenameColumn ()
+		{
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			var currentCol = tableView.Table.Columns[tableView.SelectedColumn];
+
+			if(GetText("Rename Column","Name:",currentCol.ColumnName,out string newName)) {
+				currentCol.ColumnName = newName;
+				tableView.Update();
+			}
+
+
+		}
+
+		private bool NoTableLoaded ()
+		{
+			if(tableView.Table == null) {
+				MessageBox.ErrorQuery("No Table Loaded","No table has currently be opened","Ok");
+				return true;
+			}
+
+			return false;
+		}
+
+		private void AddRow ()
+		{
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			tableView.Table.Rows.Add();
+			tableView.Update();
+		}
+
+		private void AddColumn ()
+		{
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			if(GetText("Enter column name","Name:","",out string colName)) {
+				tableView.Table.Columns.Add(new DataColumn(colName));
+				tableView.Update();
+			}
+				
+		}
+
+		private void Save()
+		{
+			if(tableView.Table == null || string.IsNullOrWhiteSpace(currentFile)) {
+				MessageBox.ErrorQuery("No file loaded","No file is currently loaded","Ok");
+				return;
+			}
+
+			var sb = new StringBuilder();
+
+			sb.AppendLine(string.Join(",",tableView.Table.Columns.Cast<DataColumn>().Select(c=>c.ColumnName)));
+
+			foreach(DataRow row in tableView.Table.Rows) {
+				sb.AppendLine(string.Join(",",row.ItemArray));
+			}
+			
+			File.WriteAllText(currentFile,sb.ToString());
+		}
+
+		private void Open()
+		{
+			var ofd = new FileDialog("Select File","Open","File","Select a CSV file to open (does not support newlines, escaping etc)");
+			ofd.AllowedFileTypes = new string[]{".csv" };
+
+			Application.Run(ofd);
+			
+			if(!string.IsNullOrWhiteSpace(ofd.FilePath?.ToString()))
+			{
+				Open(ofd.FilePath.ToString());
+			}
+		}
+		
+		private void Open(string filename)
+		{
+			
+			int lineNumber = 0;
+			currentFile = null;
+
+			try {
+				var dt = new DataTable();
+				var lines = File.ReadAllLines(filename);
+			
+				foreach(var h in lines[0].Split(',')){
+					dt.Columns.Add(h);
+				}
+				
+
+				foreach(var line in lines.Skip(1)) {
+					lineNumber++;
+					dt.Rows.Add(line.Split(','));
+				}
+				
+				tableView.Table = dt;
+				
+				// Only set the current filename if we succesfully loaded the entire file
+				currentFile = filename;
+			}
+			catch(Exception ex) {
+				MessageBox.ErrorQuery("Open Failed",$"Error on line {lineNumber}{Environment.NewLine}{ex.Message}","Ok");
+			}
+		}
+		private void SetupScrollBar ()
+		{
+			var _scrollBar = new ScrollBarView (tableView, true);
+
+			_scrollBar.ChangedPosition += () => {
+				tableView.RowOffset = _scrollBar.Position;
+				if (tableView.RowOffset != _scrollBar.Position) {
+					_scrollBar.Position = tableView.RowOffset;
+				}
+				tableView.SetNeedsDisplay ();
+			};
+			/*
+			_scrollBar.OtherScrollBarView.ChangedPosition += () => {
+				_listView.LeftItem = _scrollBar.OtherScrollBarView.Position;
+				if (_listView.LeftItem != _scrollBar.OtherScrollBarView.Position) {
+					_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+				}
+				_listView.SetNeedsDisplay ();
+			};*/
+
+			tableView.DrawContent += (e) => {
+				_scrollBar.Size = tableView.Table?.Rows?.Count ??0;
+				_scrollBar.Position = tableView.RowOffset;
+			//	_scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
+			//	_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+				_scrollBar.Refresh ();
+			};
+		
+		}
+
+		private void TableViewKeyPress (View.KeyEventEventArgs e)
+		{
+			if(e.KeyEvent.Key == Key.DeleteChar){
+
+				if(tableView.FullRowSelect)
+				{
+					// Delete button deletes all rows when in full row mode
+					foreach(int toRemove in tableView.GetAllSelectedCells().Select(p=>p.Y).Distinct().OrderByDescending(i=>i))
+						tableView.Table.Rows.RemoveAt(toRemove);
+				}
+				else{
+
+					// otherwise set all selected cells to null
+					foreach(var pt in tableView.GetAllSelectedCells())
+					{
+						tableView.Table.Rows[pt.Y][pt.X] = DBNull.Value;
+					}
+				}
+
+				tableView.Update();
+				e.Handled = true;
+			}
+		}
+
+		private void ClearColumnStyles ()
+		{
+			tableView.Style.ColumnStyles.Clear();
+			tableView.Update();
+		}
+			
+
+		private void CloseExample ()
+		{
+			tableView.Table = null;
+		}
+
+		private void Quit ()
+		{
+			Application.RequestStop ();
+		}
+
+		private void OpenExample (bool big)
+		{
+			tableView.Table = BuildDemoDataTable(big ? 30 : 5, big ? 1000 : 5);
+			SetDemoTableStyles();
+		}
+
+		private void SetDemoTableStyles ()
+		{
+			var alignMid = new ColumnStyle() {
+				Alignment = TextAlignment.Centered
+			};
+			var alignRight = new ColumnStyle() {
+				Alignment = TextAlignment.Right
+			};
+
+			var dateFormatStyle = new ColumnStyle() {
+				Alignment = TextAlignment.Right,
+				RepresentationGetter = (v)=> v is DateTime d ? d.ToString("yyyy-MM-dd"):v.ToString()
+			};
+
+			var negativeRight = new ColumnStyle() {
+				
+				Format = "0.##",
+				MinWidth = 10,
+				AlignmentGetter = (v)=>v is double d ? 
+								// align negative values right
+								d < 0 ? TextAlignment.Right : 
+								// align positive values left
+								TextAlignment.Left:
+								// not a double
+								TextAlignment.Left
+			};
+			
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["DateCol"],dateFormatStyle);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["DoubleCol"],negativeRight);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["NullsCol"],alignMid);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["IntCol"],alignRight);
+			
+			tableView.Update();
+		}
+
+		private void OpenSimple (bool big)
+		{
+			tableView.Table = BuildSimpleDataTable(big ? 30 : 5, big ? 1000 : 5);
+		}
+		private bool GetText(string title, string label, string initialText, out string enteredText)
+		{
+			bool okPressed = false;
+
+			var ok = new Button ("Ok", is_default: true);
+			ok.Clicked += () => { okPressed = true; Application.RequestStop (); };
+			var cancel = new Button ("Cancel");
+			cancel.Clicked += () => { Application.RequestStop (); };
+			var d = new Dialog (title, 60, 20, ok, cancel);
+
+			var lbl = new Label() {
+				X = 0,
+				Y = 1,
+				Text = label
+			};
+
+			var tf = new TextField()
+				{
+					Text = initialText,
+					X = 0,
+					Y = 2,
+					Width = Dim.Fill()
+				};
+			
+			d.Add (lbl,tf);
+			tf.SetFocus();
+
+			Application.Run (d);
+
+			enteredText = okPressed? tf.Text.ToString() : null;
+			return okPressed;
+		}
+		private void EditCurrentCell (CellActivatedEventArgs e)
+		{
+			if(e.Table == null)
+				return;
+
+			var oldValue = e.Table.Rows[e.Row][e.Col].ToString();
+
+			if(GetText("Enter new value",e.Table.Columns[e.Col].ColumnName,oldValue, out string newText)) {
+				try {
+					e.Table.Rows[e.Row][e.Col] = string.IsNullOrWhiteSpace(newText) ? DBNull.Value : (object)newText;
+				}
+				catch(Exception ex) {
+					MessageBox.ErrorQuery(60,20,"Failed to set text", ex.Message,"Ok");
+				}
+				
+				tableView.Update();
+			}
+		}
+
+		/// <summary>
+		/// Generates a new demo <see cref="DataTable"/> with the given number of <paramref name="cols"/> (min 5) and <paramref name="rows"/>
+		/// </summary>
+		/// <param name="cols"></param>
+		/// <param name="rows"></param>
+		/// <returns></returns>
+		public static DataTable BuildDemoDataTable(int cols, int rows)
+		{
+			var dt = new DataTable();
+
+			int explicitCols = 6;
+			dt.Columns.Add(new DataColumn("StrCol",typeof(string)));
+			dt.Columns.Add(new DataColumn("DateCol",typeof(DateTime)));
+			dt.Columns.Add(new DataColumn("IntCol",typeof(int)));
+			dt.Columns.Add(new DataColumn("DoubleCol",typeof(double)));
+			dt.Columns.Add(new DataColumn("NullsCol",typeof(string)));
+			dt.Columns.Add(new DataColumn("Unicode",typeof(string)));
+
+			for(int i=0;i< cols -explicitCols; i++) {
+				dt.Columns.Add("Column" + (i+explicitCols));
+			}
+			
+			var r = new Random(100);
+
+			for(int i=0;i< rows;i++) {
+				
+				List<object> row = new List<object>(){ 
+					"Some long text that is super cool",
+					new DateTime(2000+i,12,25),
+					r.Next(i),
+					(r.NextDouble()*i)-0.5 /*add some negatives to demo styles*/,
+					DBNull.Value,
+					"Les Mise" + Char.ConvertFromUtf32(Int32.Parse("0301", NumberStyles.HexNumber)) + "rables"
+				};
+				
+				for(int j=0;j< cols -explicitCols; j++) {
+					row.Add("SomeValue" + r.Next(100));
+				}
+
+				dt.Rows.Add(row.ToArray());
+			}
+
+			return dt;
+		}
+
+		/// <summary>
+		/// Builds a simple table in which cell values contents are the index of the cell.  This helps testing that scrolling etc is working correctly and not skipping out any rows/columns when paging
+		/// </summary>
+		/// <param name="cols"></param>
+		/// <param name="rows"></param>
+		/// <returns></returns>
+		public static DataTable BuildSimpleDataTable(int cols, int rows)
+		{
+			var dt = new DataTable();
+
+			for(int c = 0; c < cols; c++) {
+				dt.Columns.Add("Col"+c);
+			}
+				
+			for(int r = 0; r < rows; r++) {
+				var newRow = dt.NewRow();
+
+				for(int c = 0; c < cols; c++) {
+					newRow[c] = $"R{r}C{c}";
+				}
+
+				dt.Rows.Add(newRow);
+			}
+			
+			return dt;
+		}
+	}
+}

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -51,6 +51,9 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Rename Column", "", () => RenameColumn()),
 					new MenuItem ("_Delete Column", "", () => DeleteColum()),
 					new MenuItem ("_Move Column", "", () => MoveColumn()),
+					new MenuItem ("_Move Row", "", () => MoveRow()),
+					new MenuItem ("_Sort Asc", "", () => Sort(true)),
+					new MenuItem ("_Sort Desc", "", () => Sort(false)),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
 					miLeft = new MenuItem ("_Align Left", "", () => Align(TextAlignment.Left)),
@@ -166,6 +169,69 @@ namespace UICatalog.Scenarios {
 					currentCol.SetOrdinal(newIdx);
 
 					tableView.SetSelection(newIdx,tableView.SelectedRow,false);
+					tableView.EnsureSelectedCellIsVisible();
+					tableView.SetNeedsDisplay();
+				}
+
+			}catch(Exception ex)
+			{
+				MessageBox.ErrorQuery("Error moving column",ex.Message, "Ok");
+			}
+		}
+		private void Sort (bool asc)
+		{
+
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			if(tableView.SelectedColumn == -1) {
+				
+				MessageBox.ErrorQuery("No Column","No column selected", "Ok");
+				return;
+			}
+
+			var colName = tableView.Table.Columns[tableView.SelectedColumn].ColumnName;
+
+			tableView.Table.DefaultView.Sort = colName + (asc ? " asc" : " desc");
+			tableView.Table = tableView.Table.DefaultView.ToTable();
+		}
+
+		private void MoveRow ()
+		{
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			if(tableView.SelectedRow == -1) {
+				
+				MessageBox.ErrorQuery("No Rows","No row selected", "Ok");
+				return;
+			}
+			
+			try{
+
+				int oldIdx = tableView.SelectedRow;
+
+				var currentRow = tableView.Table.Rows[oldIdx];
+
+				if(GetText("Move Row","New Row:",oldIdx.ToString(),out string newOrdinal)) {
+
+					var newIdx = Math.Min(Math.Max(0,int.Parse(newOrdinal)),tableView.Table.Rows.Count-1);
+
+
+					if(newIdx == oldIdx)
+						return;
+
+					var arrayItems = currentRow.ItemArray;
+					tableView.Table.Rows.Remove(currentRow);
+					
+					var newRow = tableView.Table.NewRow();
+					newRow.ItemArray = arrayItems;
+					
+					tableView.Table.Rows.InsertAt(newRow,newIdx);
+					
+					tableView.SetSelection(tableView.SelectedColumn,newIdx,false);
 					tableView.EnsureSelectedCellIsVisible();
 					tableView.SetNeedsDisplay();
 				}

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -50,6 +50,7 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_New Row", "", () => AddRow()),
 					new MenuItem ("_Rename Column", "", () => RenameColumn()),
 					new MenuItem ("_Delete Column", "", () => DeleteColum()),
+					new MenuItem ("_Move Column", "", () => MoveColumn()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
 					miLeft = new MenuItem ("_Align Left", "", () => Align(TextAlignment.Left)),
@@ -88,6 +89,7 @@ namespace UICatalog.Scenarios {
 
 			SetupScrollBar();
 		}
+
 
 		private void OnSelectedCellChanged (SelectedCellChangedEventArgs e)
 		{
@@ -138,6 +140,39 @@ namespace UICatalog.Scenarios {
 
 			} catch (Exception ex) {
 				MessageBox.ErrorQuery("Could not remove column",ex.Message, "Ok");
+			}
+		}
+
+		private void MoveColumn ()
+		{
+			if(NoTableLoaded()) {
+				return;
+			}
+
+			if(tableView.SelectedColumn == -1) {
+				
+				MessageBox.ErrorQuery("No Column","No column selected", "Ok");
+				return;
+			}
+			
+			try{
+
+				var currentCol = tableView.Table.Columns[tableView.SelectedColumn];
+
+				if(GetText("Move Column","New Index:",currentCol.Ordinal.ToString(),out string newOrdinal)) {
+
+					var newIdx = Math.Min(Math.Max(0,int.Parse(newOrdinal)),tableView.Table.Columns.Count-1);
+
+					currentCol.SetOrdinal(newIdx);
+
+					tableView.SetSelection(newIdx,tableView.SelectedRow,false);
+					tableView.EnsureSelectedCellIsVisible();
+					tableView.SetNeedsDisplay();
+				}
+
+			}catch(Exception ex)
+			{
+				MessageBox.ErrorQuery("Error moving column",ex.Message, "Ok");
 			}
 		}
 

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -93,7 +93,7 @@ namespace UICatalog.Scenarios {
 		{
 			selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";
 			
-			if(tableView.Table == null)
+			if(tableView.Table == null || tableView.SelectedColumn == -1)
 				return;
 
 			var col = tableView.Table.Columns[tableView.SelectedColumn];
@@ -125,8 +125,20 @@ namespace UICatalog.Scenarios {
 				return;
 			}
 
-			tableView.Table.Columns.RemoveAt(tableView.SelectedColumn);
-			tableView.Update();
+			if(tableView.SelectedColumn == -1) {
+				
+				MessageBox.ErrorQuery("No Column","No column selected", "Ok");
+				return;
+			}
+
+
+			try {
+				tableView.Table.Columns.RemoveAt(tableView.SelectedColumn);
+				tableView.Update();
+
+			} catch (Exception ex) {
+				MessageBox.ErrorQuery("Could not remove column",ex.Message, "Ok");
+			}
 		}
 
 		private void Align (TextAlignment newAlignment)

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -48,8 +48,6 @@ namespace UICatalog.Scenarios {
 				Width = Dim.Fill (),
 				Height = Dim.Fill (),
 			};
-			tableView.CanFocus = true;
-
 
 			Win.Add (tableView);
 		}

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -84,6 +84,38 @@ namespace UICatalog.Scenarios {
 			tableView.SelectedCellChanged += (e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
 			tableView.CellActivated += EditCurrentCell;
 			tableView.KeyPress += TableViewKeyPress;
+
+			SetupScrollBar();
+		}
+
+		private void SetupScrollBar ()
+		{
+			var _scrollBar = new ScrollBarView (tableView, true);
+
+			_scrollBar.ChangedPosition += () => {
+				tableView.RowOffset = _scrollBar.Position;
+				if (tableView.RowOffset != _scrollBar.Position) {
+					_scrollBar.Position = tableView.RowOffset;
+				}
+				tableView.SetNeedsDisplay ();
+			};
+			/*
+			_scrollBar.OtherScrollBarView.ChangedPosition += () => {
+				_listView.LeftItem = _scrollBar.OtherScrollBarView.Position;
+				if (_listView.LeftItem != _scrollBar.OtherScrollBarView.Position) {
+					_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+				}
+				_listView.SetNeedsDisplay ();
+			};*/
+
+			tableView.DrawContent += (e) => {
+				_scrollBar.Size = tableView.Table?.Rows?.Count ??0;
+				_scrollBar.Position = tableView.RowOffset;
+			//	_scrollBar.OtherScrollBarView.Size = _listView.Maxlength - 1;
+			//	_scrollBar.OtherScrollBarView.Position = _listView.LeftItem;
+				_scrollBar.Refresh ();
+			};
+		
 		}
 
 		private void TableViewKeyPress (View.KeyEventEventArgs e)

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -32,7 +32,61 @@ namespace UICatalog.Scenarios {
 				Height = Dim.Fill (),
 			};
 			tableView.CanFocus = true;
+
+			tableView.KeyPress += KeyPressed; 
+
 			Win.Add (tableView);
+		}
+
+		private void KeyPressed (View.KeyEventEventArgs obj)
+		{
+			if(obj.KeyEvent.Key == Key.Enter) {
+				EditCurrentCell();
+			}
+			
+		}
+
+		private void EditCurrentCell ()
+		{
+			var oldValue = tableView.Table.Rows[tableView.SelectedRow][tableView.SelectedColumn].ToString();
+			bool okPressed = false;
+
+			var ok = new Button ("Ok", is_default: true);
+			ok.Clicked += () => { okPressed = true; Application.RequestStop (); };
+			var cancel = new Button ("Cancel");
+			cancel.Clicked += () => { Application.RequestStop (); };
+			var d = new Dialog ("Enter new value", 60, 20, ok, cancel);
+
+			var lbl = new Label() {
+				X = 0,
+				Y = 1,
+				Text = tableView.Table.Columns[tableView.SelectedColumn].ColumnName
+			};
+
+			var tf = new TextField()
+				{
+					Text = oldValue,
+					X = 0,
+					Y = 2,
+					Width = Dim.Fill()
+				};
+			
+			d.Add (lbl,tf);
+			tf.SetFocus();
+
+			Application.Run (d);
+
+			if(okPressed) {
+
+				try {
+					tableView.Table.Rows[tableView.SelectedRow][tableView.SelectedColumn] = tf.Text;
+				}
+				catch(Exception ex) {
+					MessageBox.ErrorQuery(60,20,"Failed to set text", ex.Message,"Ok");
+				}
+				
+				tableView.RefreshViewport();
+			}
 		}
 
 		/// <summary>
@@ -60,7 +114,7 @@ namespace UICatalog.Scenarios {
 			for(int i=0;i< rows;i++) {
 				
 				List<object> row = new List<object>(){ 
-					"Some long text with unicode '😀'",
+					"Some long text that is super cool",
 					new DateTime(2000+i,12,25),
 					r.Next(i),
 					r.NextDouble()*i,

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using Terminal.Gui;
+using System.Linq;
 using System.Globalization;
 
 namespace UICatalog.Scenarios {
@@ -60,7 +61,6 @@ namespace UICatalog.Scenarios {
 
 
 			var statusBar = new StatusBar (new StatusItem [] {
-				//new StatusItem(Key.Enter, "~ENTER~ ApplyEdits", () => { _hexView.ApplyEdits(); }),
 				new StatusItem(Key.F2, "~F2~ OpenExample", () => OpenExample(true)),
 				new StatusItem(Key.F3, "~F3~ CloseExample", () => CloseExample()),
 				new StatusItem(Key.F4, "~F4~ OpenSimple", () => OpenSimple(true)),
@@ -83,6 +83,33 @@ namespace UICatalog.Scenarios {
 
 			tableView.SelectedCellChanged += (e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
 			tableView.CellActivated += EditCurrentCell;
+			tableView.KeyPress += TableViewKeyPress;
+		}
+
+		private void TableViewKeyPress (View.KeyEventEventArgs e)
+		{
+			if(e.KeyEvent.Key == Key.DeleteChar){
+
+				if(tableView.FullRowSelect)
+				{
+					// Delete button deletes all rows when in full row mode
+					foreach(int toRemove in tableView.GetAllSelectedCells().Select(p=>p.Y).Distinct().OrderByDescending(i=>i))
+						tableView.Table.Rows.RemoveAt(toRemove);
+				}
+				else{
+
+					// otherwise set all selected cells to null
+					foreach(var pt in tableView.GetAllSelectedCells())
+					{
+						tableView.Table.Rows[pt.Y][pt.X] = DBNull.Value;
+					}
+				}
+
+				tableView.Update();
+				e.Handled = true;
+			}
+
+
 		}
 
 		private void ClearColumnStyles ()

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Terminal.Gui;
+using Terminal.Gui.Views;
+
+namespace UICatalog.Scenarios {
+
+	[ScenarioMetadata (Name: "TableEditor", Description: "A Terminal.Gui DataTable editor via TableView")]
+	[ScenarioCategory ("Controls")]
+	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("Text")]
+	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("TopLevel")]
+	public class TableEditor : Scenario 
+	{
+		TableView tableView;
+
+		public override void Setup ()
+		{
+			var dt = BuildDemoDataTable(30,1000);
+
+			Win.Title = this.GetName() + "-" + dt.TableName ?? "Untitled";
+			Win.Y = 1; // menu
+			Win.Height = Dim.Fill (1); // status bar
+			Top.LayoutSubviews ();
+
+			this.tableView = new TableView (dt) {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (),
+			};
+			tableView.CanFocus = true;
+			Win.Add (tableView);
+		}
+
+		/// <summary>
+		/// Generates a new demo <see cref="DataTable"/> with the given number of <paramref name="cols"/> (min 4) and <paramref name="rows"/>
+		/// </summary>
+		/// <param name="cols"></param>
+		/// <param name="rows"></param>
+		/// <returns></returns>
+		public static DataTable BuildDemoDataTable(int cols, int rows)
+		{
+			var dt = new DataTable();
+
+			dt.Columns.Add(new DataColumn("StrCol",typeof(string)));
+			dt.Columns.Add(new DataColumn("DateCol",typeof(DateTime)));
+			dt.Columns.Add(new DataColumn("IntCol",typeof(int)));
+			dt.Columns.Add(new DataColumn("DoubleCol",typeof(double)));
+
+			for(int i=0;i< cols -4; i++) {
+				dt.Columns.Add("Column" + (i+4));
+			}
+			
+			var r = new Random(100);
+
+			for(int i=0;i< rows;i++) {
+				
+				List<object> row = new List<object>(){ 
+					"Some long text with unicode '😀'",
+					new DateTime(2000+i,12,25),
+					r.Next(i),
+					r.NextDouble()*i
+				};
+				
+				for(int j=0;j< cols -4; j++) {
+					row.Add("SomeValue" + r.Next(100));
+				}
+
+				dt.Rows.Add(row.ToArray());
+			}
+
+			return dt;
+		}
+	}
+}

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -20,6 +20,7 @@ namespace UICatalog.Scenarios {
 		private MenuItem miHeaderMidline;
 		private MenuItem miHeaderUnderline;
 		private MenuItem miCellLines;
+		private MenuItem miFullRowSelect;
 
 		public override void Setup ()
 		{
@@ -47,6 +48,7 @@ namespace UICatalog.Scenarios {
 					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderUnderline =new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
+					miFullRowSelect =new MenuItem ("_FullRowSelect", "", () => ToggleFullRowSelect()){Checked = tableView.FullRowSelect, CheckType = MenuItemCheckStyle.Checked },
 					miCellLines =new MenuItem ("_CellLines", "", () => ToggleCellLines()){Checked = tableView.Style.ShowVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
 					new MenuItem ("_AllLines", "", () => ToggleAllCellLines()),
 					new MenuItem ("_NoLines", "", () => ToggleNoCellLines()),
@@ -112,6 +114,12 @@ namespace UICatalog.Scenarios {
 		{
 			miHeaderUnderline.Checked = !miHeaderUnderline.Checked;
 			tableView.Style.ShowHorizontalHeaderUnderline = miHeaderUnderline.Checked;
+			tableView.Update();
+		}
+		private void ToggleFullRowSelect ()
+		{
+			miFullRowSelect.Checked = !miFullRowSelect.Checked;
+			tableView.FullRowSelect= miFullRowSelect.Checked;
 			tableView.Update();
 		}
 		private void ToggleCellLines()

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -38,6 +38,7 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_CellLines", "", () => ToggleCellLines()),
 					new MenuItem ("_AllLines", "", () => ToggleAllCellLines()),
 					new MenuItem ("_NoLines", "", () => ToggleNoCellLines()),
+					new MenuItem ("_ClearColumnStyles", "", () => ClearColumnStyles()),
 				}),
 			});
 			Top.Add (menu);
@@ -62,7 +63,11 @@ namespace UICatalog.Scenarios {
 			Win.Add (tableView);
 		}
 
-
+		private void ClearColumnStyles ()
+		{
+			tableView.Style.ColumnStyles.Clear();
+			tableView.Update();
+		}
 
 		private void ToggleAlwaysShowHeader ()
 		{
@@ -121,10 +126,48 @@ namespace UICatalog.Scenarios {
 		private void OpenExample (bool big)
 		{
 			tableView.Table = BuildDemoDataTable(big ? 30 : 5, big ? 1000 : 5);
+			SetDemoTableStyles();
 		}
+
+		private void SetDemoTableStyles ()
+		{
+			var alignMid = new ColumnStyle() {
+				Alignment = TextAlignment.Centered
+			};
+			var alignRight = new ColumnStyle() {
+				Alignment = TextAlignment.Right
+			};
+
+			var dateFormatStyle = new ColumnStyle() {
+				Alignment = TextAlignment.Right,
+				RepresentationGetter = (v)=> v is DateTime d ? d.ToString("yyyy-MM-dd"):v.ToString()
+			};
+
+			var negativeRight = new ColumnStyle() {
+				
+				RepresentationGetter = (v)=> v is double d ? 
+								d.ToString("0.##"):
+								v.ToString(),
+				MinWidth = 10,
+				AlignmentGetter = (v)=>v is double d ? 
+								// align negative values right
+								d < 0 ? TextAlignment.Right : 
+								// align positive values left
+								TextAlignment.Left:
+								// not a double
+								TextAlignment.Left
+			};
+			
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["DateCol"],dateFormatStyle);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["DoubleCol"],negativeRight);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["NullsCol"],alignMid);
+			tableView.Style.ColumnStyles.Add(tableView.Table.Columns["IntCol"],alignRight);
+			
+			tableView.Update();
+		}
+
 		private void OpenSimple (bool big)
 		{
-			
 			tableView.Table = BuildSimpleDataTable(big ? 30 : 5, big ? 1000 : 5);
 		}
 
@@ -202,7 +245,7 @@ namespace UICatalog.Scenarios {
 					"Some long text that is super cool",
 					new DateTime(2000+i,12,25),
 					r.Next(i),
-					r.NextDouble()*i,
+					(r.NextDouble()*i)-0.5 /*add some negatives to demo styles*/,
 					DBNull.Value
 				};
 				

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -72,7 +72,7 @@ namespace UICatalog.Scenarios {
 
 			Win.Add(selectedCellLabel);
 
-			tableView.SelectedCellChanged += (s,e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
+			tableView.SelectedCellChanged += (e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
 		}
 
 		private void ClearColumnStyles ()

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -14,6 +14,11 @@ namespace UICatalog.Scenarios {
 	public class TableEditor : Scenario 
 	{
 		TableView tableView;
+		private MenuItem miAlwaysShowHeaders;
+		private MenuItem miHeaderOverline;
+		private MenuItem miHeaderMidline;
+		private MenuItem miHeaderUnderline;
+		private MenuItem miCellLines;
 
 		public override void Setup ()
 		{
@@ -21,6 +26,13 @@ namespace UICatalog.Scenarios {
 			Win.Y = 1; // menu
 			Win.Height = Dim.Fill (1); // status bar
 			Top.LayoutSubviews ();
+
+			this.tableView = new TableView () {
+				X = 0,
+				Y = 0,
+				Width = Dim.Fill (),
+				Height = Dim.Fill (1),
+			};
 
 			var menu = new MenuBar (new MenuBarItem [] {
 				new MenuBarItem ("_File", new MenuItem [] {
@@ -30,17 +42,19 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeader()),
-					new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()),
-					new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()),
-					new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()),
-					new MenuItem ("_CellLines", "", () => ToggleCellLines()),
+					miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeader()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
+					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
+					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
+					miHeaderUnderline =new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()){Checked = tableView.Style.ShowHorizontalHeaderUnderline, CheckType = MenuItemCheckStyle.Checked },
+					miCellLines =new MenuItem ("_CellLines", "", () => ToggleCellLines()){Checked = tableView.Style.ShowVerticalCellLines, CheckType = MenuItemCheckStyle.Checked },
 					new MenuItem ("_AllLines", "", () => ToggleAllCellLines()),
 					new MenuItem ("_NoLines", "", () => ToggleNoCellLines()),
 					new MenuItem ("_ClearColumnStyles", "", () => ClearColumnStyles()),
 				}),
 			});
 			Top.Add (menu);
+
+
 
 			var statusBar = new StatusBar (new StatusItem [] {
 				//new StatusItem(Key.Enter, "~ENTER~ ApplyEdits", () => { _hexView.ApplyEdits(); }),
@@ -51,13 +65,6 @@ namespace UICatalog.Scenarios {
 				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
 			});
 			Top.Add (statusBar);
-
-			this.tableView = new TableView () {
-				X = 0,
-				Y = 0,
-				Width = Dim.Fill (),
-				Height = Dim.Fill (1),
-			};
 
 			Win.Add (tableView);
 
@@ -83,28 +90,33 @@ namespace UICatalog.Scenarios {
 
 		private void ToggleAlwaysShowHeader ()
 		{
-			tableView.Style.AlwaysShowHeaders = !tableView.Style.AlwaysShowHeaders;
+			miAlwaysShowHeaders.Checked = !miAlwaysShowHeaders.Checked;
+			tableView.Style.AlwaysShowHeaders = miAlwaysShowHeaders.Checked;
 			tableView.Update();
 		}
 
 		private void ToggleOverline ()
 		{
-			tableView.Style.ShowHorizontalHeaderOverline = !tableView.Style.ShowHorizontalHeaderOverline;
+			miHeaderOverline.Checked = !miHeaderOverline.Checked;
+			tableView.Style.ShowHorizontalHeaderOverline = miHeaderOverline.Checked;
 			tableView.Update();
 		}
 		private void ToggleHeaderMidline ()
 		{
-			tableView.Style.ShowVerticalHeaderLines = !tableView.Style.ShowVerticalHeaderLines;
+			miHeaderMidline.Checked = !miHeaderMidline.Checked;
+			tableView.Style.ShowVerticalHeaderLines = miHeaderMidline.Checked;
 			tableView.Update();
 		}
 		private void ToggleUnderline ()
 		{
-			tableView.Style.ShowHorizontalHeaderUnderline = !tableView.Style.ShowHorizontalHeaderUnderline;
+			miHeaderUnderline.Checked = !miHeaderUnderline.Checked;
+			tableView.Style.ShowHorizontalHeaderUnderline = miHeaderUnderline.Checked;
 			tableView.Update();
 		}
 		private void ToggleCellLines()
 		{
-			tableView.Style.ShowVerticalCellLines = !tableView.Style.ShowVerticalCellLines;
+			miCellLines.Checked = !miCellLines.Checked;
+			tableView.Style.ShowVerticalCellLines = miCellLines.Checked;
 			tableView.Update();
 		}
 		private void ToggleAllCellLines()
@@ -113,6 +125,12 @@ namespace UICatalog.Scenarios {
 			tableView.Style.ShowVerticalHeaderLines = true;
 			tableView.Style.ShowHorizontalHeaderUnderline = true;
 			tableView.Style.ShowVerticalCellLines = true;
+						
+			miHeaderOverline.Checked = true;
+			miHeaderMidline.Checked = true;
+			miHeaderUnderline.Checked = true;
+			miCellLines.Checked = true;
+
 			tableView.Update();
 		}
 		private void ToggleNoCellLines()
@@ -121,6 +139,12 @@ namespace UICatalog.Scenarios {
 			tableView.Style.ShowVerticalHeaderLines = false;
 			tableView.Style.ShowHorizontalHeaderUnderline = false;
 			tableView.Style.ShowVerticalCellLines = false;
+
+			miHeaderOverline.Checked = false;
+			miHeaderMidline.Checked = false;
+			miHeaderUnderline.Checked = false;
+			miCellLines.Checked = false;
+
 			tableView.Update();
 		}
 		

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -36,7 +36,7 @@ namespace UICatalog.Scenarios {
 		}
 
 		/// <summary>
-		/// Generates a new demo <see cref="DataTable"/> with the given number of <paramref name="cols"/> (min 4) and <paramref name="rows"/>
+		/// Generates a new demo <see cref="DataTable"/> with the given number of <paramref name="cols"/> (min 5) and <paramref name="rows"/>
 		/// </summary>
 		/// <param name="cols"></param>
 		/// <param name="rows"></param>
@@ -49,8 +49,9 @@ namespace UICatalog.Scenarios {
 			dt.Columns.Add(new DataColumn("DateCol",typeof(DateTime)));
 			dt.Columns.Add(new DataColumn("IntCol",typeof(int)));
 			dt.Columns.Add(new DataColumn("DoubleCol",typeof(double)));
+			dt.Columns.Add(new DataColumn("NullsCol",typeof(string)));
 
-			for(int i=0;i< cols -4; i++) {
+			for(int i=0;i< cols -5; i++) {
 				dt.Columns.Add("Column" + (i+4));
 			}
 			
@@ -62,10 +63,11 @@ namespace UICatalog.Scenarios {
 					"Some long text with unicode '😀'",
 					new DateTime(2000+i,12,25),
 					r.Next(i),
-					r.NextDouble()*i
+					r.NextDouble()*i,
+					DBNull.Value
 				};
 				
-				for(int j=0;j< cols -4; j++) {
+				for(int j=0;j< cols -5; j++) {
 					row.Add("SomeValue" + r.Next(100));
 				}
 

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -79,7 +79,7 @@ namespace UICatalog.Scenarios {
 			if(okPressed) {
 
 				try {
-					tableView.Table.Rows[tableView.SelectedRow][tableView.SelectedColumn] = tf.Text;
+					tableView.Table.Rows[tableView.SelectedRow][tableView.SelectedColumn] = string.IsNullOrWhiteSpace(tf.Text.ToString()) ? DBNull.Value : (object)tf.Text;
 				}
 				catch(Exception ex) {
 					MessageBox.ErrorQuery(60,20,"Failed to set text", ex.Message,"Ok");

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -25,7 +25,8 @@ namespace UICatalog.Scenarios {
 
 			var menu = new MenuBar (new MenuBarItem [] {
 				new MenuBarItem ("_File", new MenuItem [] {
-					new MenuItem ("_OpenExample", "", () => OpenExample()),
+					new MenuItem ("_OpenBigExample", "", () => OpenExample(true)),
+					new MenuItem ("_OpenSmallExample", "", () => OpenExample(false)),
 					new MenuItem ("_CloseExample", "", () => CloseExample()),
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
@@ -34,7 +35,7 @@ namespace UICatalog.Scenarios {
 
 			var statusBar = new StatusBar (new StatusItem [] {
 				//new StatusItem(Key.Enter, "~ENTER~ ApplyEdits", () => { _hexView.ApplyEdits(); }),
-				new StatusItem(Key.F2, "~F2~ OpenExample", () => OpenExample()),
+				new StatusItem(Key.F2, "~F2~ OpenExample", () => OpenExample(true)),
 				new StatusItem(Key.F3, "~F3~ EditCell", () => EditCurrentCell()),
 				new StatusItem(Key.F4, "~F4~ CloseExample", () => CloseExample()),
 				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
@@ -63,9 +64,9 @@ namespace UICatalog.Scenarios {
 			Application.RequestStop ();
 		}
 
-		private void OpenExample ()
+		private void OpenExample (bool big)
 		{
-			tableView.Table = BuildDemoDataTable(30,1000);
+			tableView.Table = BuildDemoDataTable(big ? 30 : 5, big ? 1000 : 5);
 		}
 
 		private void EditCurrentCell ()

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -145,9 +145,7 @@ namespace UICatalog.Scenarios {
 
 			var negativeRight = new ColumnStyle() {
 				
-				RepresentationGetter = (v)=> v is double d ? 
-								d.ToString("0.##"):
-								v.ToString(),
+				Format = "0.##",
 				MinWidth = 10,
 				AlignmentGetter = (v)=>v is double d ? 
 								// align negative values right

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using Terminal.Gui;
-using Terminal.Gui.Views;
 
 namespace UICatalog.Scenarios {
 

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -56,10 +56,23 @@ namespace UICatalog.Scenarios {
 				X = 0,
 				Y = 0,
 				Width = Dim.Fill (),
-				Height = Dim.Fill (),
+				Height = Dim.Fill (1),
 			};
 
 			Win.Add (tableView);
+
+			var selectedCellLabel = new Label(){
+				X = 0,
+				Y = Pos.Bottom(tableView),
+				Text = "0,0",
+				Width = Dim.Fill(),
+				TextAlignment = TextAlignment.Right
+				
+			};
+
+			Win.Add(selectedCellLabel);
+
+			tableView.SelectedCellChanged += (s,e)=>{selectedCellLabel.Text = $"{tableView.SelectedRow},{tableView.SelectedColumn}";};
 		}
 
 		private void ClearColumnStyles ()
@@ -231,7 +244,7 @@ namespace UICatalog.Scenarios {
 			dt.Columns.Add(new DataColumn("NullsCol",typeof(string)));
 
 			for(int i=0;i< cols -5; i++) {
-				dt.Columns.Add("Column" + (i+4));
+				dt.Columns.Add("Column" + (i+5));
 			}
 			
 			var r = new Random(100);

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using Terminal.Gui;
+using System.Globalization;
 
 namespace UICatalog.Scenarios {
 
@@ -261,14 +262,16 @@ namespace UICatalog.Scenarios {
 		{
 			var dt = new DataTable();
 
+			int explicitCols = 6;
 			dt.Columns.Add(new DataColumn("StrCol",typeof(string)));
 			dt.Columns.Add(new DataColumn("DateCol",typeof(DateTime)));
 			dt.Columns.Add(new DataColumn("IntCol",typeof(int)));
 			dt.Columns.Add(new DataColumn("DoubleCol",typeof(double)));
 			dt.Columns.Add(new DataColumn("NullsCol",typeof(string)));
+			dt.Columns.Add(new DataColumn("Unicode",typeof(string)));
 
-			for(int i=0;i< cols -5; i++) {
-				dt.Columns.Add("Column" + (i+5));
+			for(int i=0;i< cols -explicitCols; i++) {
+				dt.Columns.Add("Column" + (i+explicitCols));
 			}
 			
 			var r = new Random(100);
@@ -280,10 +283,11 @@ namespace UICatalog.Scenarios {
 					new DateTime(2000+i,12,25),
 					r.Next(i),
 					(r.NextDouble()*i)-0.5 /*add some negatives to demo styles*/,
-					DBNull.Value
+					DBNull.Value,
+					"Les Mise" + Char.ConvertFromUtf32(Int32.Parse("0301", NumberStyles.HexNumber)) + "rables"
 				};
 				
-				for(int j=0;j< cols -5; j++) {
+				for(int j=0;j< cols -explicitCols; j++) {
 					row.Add("SomeValue" + r.Next(100));
 				}
 

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -30,6 +30,15 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_CloseExample", "", () => CloseExample()),
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
+				new MenuBarItem ("_View", new MenuItem [] {
+					new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeader()),
+					new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()),
+					new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()),
+					new MenuItem ("_HeaderUnderLine", "", () => ToggleUnderline()),
+					new MenuItem ("_CellLines", "", () => ToggleCellLines()),
+					new MenuItem ("_AllLines", "", () => ToggleAllCellLines()),
+					new MenuItem ("_NoLines", "", () => ToggleNoCellLines()),
+				}),
 			});
 			Top.Add (menu);
 
@@ -38,6 +47,7 @@ namespace UICatalog.Scenarios {
 				new StatusItem(Key.F2, "~F2~ OpenExample", () => OpenExample(true)),
 				new StatusItem(Key.F3, "~F3~ EditCell", () => EditCurrentCell()),
 				new StatusItem(Key.F4, "~F4~ CloseExample", () => CloseExample()),
+				new StatusItem(Key.F5, "~F5~ OpenSimple", () => OpenSimple(true)),
 				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
 			});
 			Top.Add (statusBar);
@@ -52,6 +62,52 @@ namespace UICatalog.Scenarios {
 			Win.Add (tableView);
 		}
 
+
+
+		private void ToggleAlwaysShowHeader ()
+		{
+			tableView.Style.AlwaysShowHeaders = !tableView.Style.AlwaysShowHeaders;
+			tableView.Update();
+		}
+
+		private void ToggleOverline ()
+		{
+			tableView.Style.ShowHorizontalHeaderOverline = !tableView.Style.ShowHorizontalHeaderOverline;
+			tableView.Update();
+		}
+		private void ToggleHeaderMidline ()
+		{
+			tableView.Style.ShowVerticalHeaderLines = !tableView.Style.ShowVerticalHeaderLines;
+			tableView.Update();
+		}
+		private void ToggleUnderline ()
+		{
+			tableView.Style.ShowHorizontalHeaderUnderline = !tableView.Style.ShowHorizontalHeaderUnderline;
+			tableView.Update();
+		}
+		private void ToggleCellLines()
+		{
+			tableView.Style.ShowVerticalCellLines = !tableView.Style.ShowVerticalCellLines;
+			tableView.Update();
+		}
+		private void ToggleAllCellLines()
+		{
+			tableView.Style.ShowHorizontalHeaderOverline = true;
+			tableView.Style.ShowVerticalHeaderLines = true;
+			tableView.Style.ShowHorizontalHeaderUnderline = true;
+			tableView.Style.ShowVerticalCellLines = true;
+			tableView.Update();
+		}
+		private void ToggleNoCellLines()
+		{
+			tableView.Style.ShowHorizontalHeaderOverline = false;
+			tableView.Style.ShowVerticalHeaderLines = false;
+			tableView.Style.ShowHorizontalHeaderUnderline = false;
+			tableView.Style.ShowVerticalCellLines = false;
+			tableView.Update();
+		}
+		
+
 		private void CloseExample ()
 		{
 			tableView.Table = null;
@@ -65,6 +121,11 @@ namespace UICatalog.Scenarios {
 		private void OpenExample (bool big)
 		{
 			tableView.Table = BuildDemoDataTable(big ? 30 : 5, big ? 1000 : 5);
+		}
+		private void OpenSimple (bool big)
+		{
+			
+			tableView.Table = BuildSimpleDataTable(big ? 30 : 5, big ? 1000 : 5);
 		}
 
 		private void EditCurrentCell ()
@@ -152,6 +213,33 @@ namespace UICatalog.Scenarios {
 				dt.Rows.Add(row.ToArray());
 			}
 
+			return dt;
+		}
+
+		/// <summary>
+		/// Builds a simple table in which cell values contents are the index of the cell.  This helps testing that scrolling etc is working correctly and not skipping out any rows/columns when paging
+		/// </summary>
+		/// <param name="cols"></param>
+		/// <param name="rows"></param>
+		/// <returns></returns>
+		public static DataTable BuildSimpleDataTable(int cols, int rows)
+		{
+			var dt = new DataTable();
+
+			for(int c = 0; c < cols; c++) {
+				dt.Columns.Add("Col"+c);
+			}
+				
+			for(int r = 0; r < rows; r++) {
+				var newRow = dt.NewRow();
+
+				for(int c = 0; c < cols; c++) {
+					newRow[c] = $"R{r}C{c}";
+				}
+
+				dt.Rows.Add(newRow);
+			}
+			
 			return dt;
 		}
 	}

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -18,14 +18,30 @@ namespace UICatalog.Scenarios {
 
 		public override void Setup ()
 		{
-			var dt = BuildDemoDataTable(30,1000);
-
-			Win.Title = this.GetName() + "-" + dt.TableName ?? "Untitled";
+			Win.Title = this.GetName();
 			Win.Y = 1; // menu
 			Win.Height = Dim.Fill (1); // status bar
 			Top.LayoutSubviews ();
 
-			this.tableView = new TableView (dt) {
+			var menu = new MenuBar (new MenuBarItem [] {
+				new MenuBarItem ("_File", new MenuItem [] {
+					new MenuItem ("_OpenExample", "", () => OpenExample()),
+					new MenuItem ("_CloseExample", "", () => CloseExample()),
+					new MenuItem ("_Quit", "", () => Quit()),
+				}),
+			});
+			Top.Add (menu);
+
+			var statusBar = new StatusBar (new StatusItem [] {
+				//new StatusItem(Key.Enter, "~ENTER~ ApplyEdits", () => { _hexView.ApplyEdits(); }),
+				new StatusItem(Key.F2, "~F2~ OpenExample", () => OpenExample()),
+				new StatusItem(Key.F3, "~F3~ EditCell", () => EditCurrentCell()),
+				new StatusItem(Key.F4, "~F4~ CloseExample", () => CloseExample()),
+				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
+			});
+			Top.Add (statusBar);
+
+			this.tableView = new TableView () {
 				X = 0,
 				Y = 0,
 				Width = Dim.Fill (),
@@ -33,21 +49,30 @@ namespace UICatalog.Scenarios {
 			};
 			tableView.CanFocus = true;
 
-			tableView.KeyPress += KeyPressed; 
 
 			Win.Add (tableView);
 		}
 
-		private void KeyPressed (View.KeyEventEventArgs obj)
+		private void CloseExample ()
 		{
-			if(obj.KeyEvent.Key == Key.Enter) {
-				EditCurrentCell();
-			}
-			
+			tableView.Table = null;
+		}
+
+		private void Quit ()
+		{
+			Application.RequestStop ();
+		}
+
+		private void OpenExample ()
+		{
+			tableView.Table = BuildDemoDataTable(30,1000);
 		}
 
 		private void EditCurrentCell ()
 		{
+			if(tableView.Table == null)
+				return;
+
 			var oldValue = tableView.Table.Rows[tableView.SelectedRow][tableView.SelectedColumn].ToString();
 			bool okPressed = false;
 
@@ -85,7 +110,7 @@ namespace UICatalog.Scenarios {
 					MessageBox.ErrorQuery(60,20,"Failed to set text", ex.Message,"Ok");
 				}
 				
-				tableView.RefreshViewport();
+				tableView.Update();
 			}
 		}
 

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -67,6 +67,66 @@ namespace UnitTests {
             Assert.Equal(1,tableView.RowOffset);
             Assert.Equal(1,tableView.ColumnOffset);
         }
+
+        [Fact]
+        public void SelectedCellChanged_NotFiredForSameValue()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50)
+            };
+
+            bool called = false;
+            tableView.SelectedCellChanged += (e)=>{called=true;};
+
+            Assert.Equal(0,tableView.SelectedColumn);
+            Assert.False(called);
+            
+            // Changing value to same as it already was should not raise an event
+            tableView.SelectedColumn = 0;
+
+            Assert.False(called);
+
+            tableView.SelectedColumn = 10;
+            Assert.True(called);
+        }
+
+
+
+        [Fact]
+        public void SelectedCellChanged_SelectedColumnIndexesCorrect()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50)
+            };
+
+            bool called = false;
+            tableView.SelectedCellChanged += (e)=>{
+                called=true;
+                Assert.Equal(0,e.OldCol);
+                Assert.Equal(10,e.NewCol);
+            };
+            
+            tableView.SelectedColumn = 10;
+            Assert.True(called);
+        }
+
+        [Fact]
+        public void SelectedCellChanged_SelectedRowIndexesCorrect()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50)
+            };
+
+            bool called = false;
+            tableView.SelectedCellChanged += (e)=>{
+                called=true;
+                Assert.Equal(0,e.OldRow);
+                Assert.Equal(10,e.NewRow);
+            };
+            
+            tableView.SelectedRow = 10;
+            Assert.True(called);
+        }
         
         /// <summary>
 		/// Builds a simple table of string columns with the requested number of columns and rows

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Terminal.Gui;
 using Xunit;
+using System.Globalization;
 
 namespace UnitTests {
 	public class TableViewTests 
@@ -126,6 +126,19 @@ namespace UnitTests {
             
             tableView.SelectedRow = 10;
             Assert.True(called);
+        }
+
+        [Fact]
+        public void Test_SumColumnWidth_UnicodeLength()
+        {
+            Assert.Equal(11,"hello there".Sum(c=>Rune.ColumnWidth(c)));
+
+            // Creates a string with the peculiar (french?) r symbol
+            String surrogate = "Les Mise" + Char.ConvertFromUtf32(Int32.Parse("0301", NumberStyles.HexNumber)) + "rables";
+
+            // The unicode width of this string is shorter than the string length! 
+            Assert.Equal(14,surrogate.Sum(c=>Rune.ColumnWidth(c)));
+            Assert.Equal(15,surrogate.Length);
         }
         
         /// <summary>

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -224,6 +224,39 @@ namespace UnitTests {
             Assert.False(tableView.IsSelected(1,2));
             Assert.False(tableView.IsSelected(2,2));
         }
+
+        [Fact]
+        public void PageDown_ExcludesHeaders()
+        {
+
+			var driver = new FakeDriver ();
+			Application.Init (driver, new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+			driver.Init (() => { });
+
+
+            var tableView = new TableView(){
+                Table = BuildTable(25,50),
+                MultiSelect = true,
+                Bounds = new Rect(0,0,10,5)
+            };
+
+            // Header should take up 2 lines
+            tableView.Style.ShowHorizontalHeaderOverline = false;
+            tableView.Style.ShowHorizontalHeaderUnderline = true;
+            tableView.Style.AlwaysShowHeaders = false;
+
+            Assert.Equal(0,tableView.RowOffset);
+
+            tableView.ProcessKey(new KeyEvent(Key.PageDown,new KeyModifiers()));
+
+            // window height is 5 rows 2 are header so page down should give 3 new rows
+            Assert.Equal(3,tableView.RowOffset);
+
+            // header is no longer visible so page down should give 5 new rows
+            tableView.ProcessKey(new KeyEvent(Key.PageDown,new KeyModifiers()));
+            
+            Assert.Equal(8,tableView.RowOffset);
+        }
         
         /// <summary>
 		/// Builds a simple table of string columns with the requested number of columns and rows

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -140,6 +140,90 @@ namespace UnitTests {
             Assert.Equal(14,surrogate.Sum(c=>Rune.ColumnWidth(c)));
             Assert.Equal(15,surrogate.Length);
         }
+
+        [Fact]
+        public void IsSelected_MultiSelectionOn_Vertical()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50),
+                MultiSelect = true
+            };
+
+            // 3 cell vertical selection
+            tableView.SetSelection(1,1,false);
+            tableView.SetSelection(1,3,true);
+
+            Assert.False(tableView.IsSelected(0,0));
+            Assert.False(tableView.IsSelected(1,0));
+            Assert.False(tableView.IsSelected(2,0));
+
+            Assert.False(tableView.IsSelected(0,1));
+            Assert.True(tableView.IsSelected(1,1));
+            Assert.False(tableView.IsSelected(2,1));
+
+            Assert.False(tableView.IsSelected(0,2));
+            Assert.True(tableView.IsSelected(1,2));
+            Assert.False(tableView.IsSelected(2,2));
+
+            Assert.False(tableView.IsSelected(0,3));
+            Assert.True(tableView.IsSelected(1,3));
+            Assert.False(tableView.IsSelected(2,3));
+
+            Assert.False(tableView.IsSelected(0,4));
+            Assert.False(tableView.IsSelected(1,4));
+            Assert.False(tableView.IsSelected(2,4));
+        }
+
+
+        [Fact]
+        public void IsSelected_MultiSelectionOn_Horizontal()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50),
+                MultiSelect = true
+            };
+
+            // 2 cell horizontal selection
+            tableView.SetSelection(1,0,false);
+            tableView.SetSelection(2,0,true);
+
+            Assert.False(tableView.IsSelected(0,0));
+            Assert.True(tableView.IsSelected(1,0));
+            Assert.True(tableView.IsSelected(2,0));
+            Assert.False(tableView.IsSelected(3,0));
+
+            Assert.False(tableView.IsSelected(0,1));
+            Assert.False(tableView.IsSelected(1,1));
+            Assert.False(tableView.IsSelected(2,1));
+            Assert.False(tableView.IsSelected(3,1));
+        }
+
+
+
+        [Fact]
+        public void IsSelected_MultiSelectionOn_BoxSelection()
+        {
+            var tableView = new TableView(){
+                Table = BuildTable(25,50),
+                MultiSelect = true
+            };
+
+            // 4 cell horizontal in box 2x2
+            tableView.SetSelection(0,0,false);
+            tableView.SetSelection(1,1,true);
+
+            Assert.True(tableView.IsSelected(0,0));
+            Assert.True(tableView.IsSelected(1,0));
+            Assert.False(tableView.IsSelected(2,0));
+
+            Assert.True(tableView.IsSelected(0,1));
+            Assert.True(tableView.IsSelected(1,1));
+            Assert.False(tableView.IsSelected(2,1));
+
+            Assert.False(tableView.IsSelected(0,2));
+            Assert.False(tableView.IsSelected(1,2));
+            Assert.False(tableView.IsSelected(2,2));
+        }
         
         /// <summary>
 		/// Builds a simple table of string columns with the requested number of columns and rows

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terminal.Gui;
+using Xunit;
+
+namespace UnitTests {
+	public class TableViewTests 
+	{
+
+        [Fact]
+        public void EnsureValidScrollOffsets_WithNoCells()
+        {
+            var tableView = new TableView();
+
+            Assert.Equal(0,tableView.RowOffset);
+            Assert.Equal(0,tableView.ColumnOffset);
+
+            // Set empty table
+            tableView.Table = new DataTable();
+
+            // Since table has no rows or columns scroll offset should default to 0
+            tableView.EnsureValidScrollOffsets();
+            Assert.Equal(0,tableView.RowOffset);
+            Assert.Equal(0,tableView.ColumnOffset);
+        }
+
+
+
+        [Fact]
+        public void EnsureValidScrollOffsets_LoadSmallerTable()
+        {
+            var tableView = new TableView();
+            tableView.Bounds = new Rect(0,0,25,10);
+
+            Assert.Equal(0,tableView.RowOffset);
+            Assert.Equal(0,tableView.ColumnOffset);
+
+            // Set big table
+            tableView.Table = BuildTable(25,50);
+
+            // Scroll down and along
+            tableView.RowOffset = 20;
+            tableView.ColumnOffset = 10;
+
+            tableView.EnsureValidScrollOffsets();
+
+            // The scroll should be valid at the moment
+            Assert.Equal(20,tableView.RowOffset);
+            Assert.Equal(10,tableView.ColumnOffset);
+
+            // Set small table
+            tableView.Table = BuildTable(2,2);
+
+            // Setting a small table should automatically trigger fixing the scroll offsets to ensure valid cells
+            Assert.Equal(0,tableView.RowOffset);
+            Assert.Equal(0,tableView.ColumnOffset);
+
+
+            // Trying to set invalid indexes should not be possible
+            tableView.RowOffset = 20;
+            tableView.ColumnOffset = 10;
+
+            Assert.Equal(1,tableView.RowOffset);
+            Assert.Equal(1,tableView.ColumnOffset);
+        }
+        
+        /// <summary>
+		/// Builds a simple table of string columns with the requested number of columns and rows
+		/// </summary>
+		/// <param name="cols"></param>
+		/// <param name="rows"></param>
+		/// <returns></returns>
+		public static DataTable BuildTable(int cols, int rows)
+		{
+			var dt = new DataTable();
+
+			for(int c = 0; c < cols; c++) {
+				dt.Columns.Add("Col"+c);
+			}
+				
+			for(int r = 0; r < rows; r++) {
+				var newRow = dt.NewRow();
+
+				for(int c = 0; c < cols; c++) {
+					newRow[c] = $"R{r}C{c}";
+				}
+
+				dt.Rows.Add(newRow);
+			}
+			
+			return dt;
+		}
+	}
+}

--- a/docfx/articles/tableview.md
+++ b/docfx/articles/tableview.md
@@ -18,7 +18,6 @@ foreach(var h in lines[0].Split(',')){
 				
 
 foreach(var line in lines.Skip(1)) {
-	lineNumber++;
 	dt.Rows.Add(line.Split(','));
 }
 ```

--- a/docfx/articles/tableview.md
+++ b/docfx/articles/tableview.md
@@ -1,0 +1,57 @@
+# Table View
+
+This control supports viewing and editing tabular data.  It provides a view of a [System.DataTable](https://docs.microsoft.com/en-us/dotnet/api/system.data.datatable?view=net-5.0).
+
+System.DataTable is a core class of .net standard and can be created very easily
+
+## Csv Example
+
+You can create a DataTable from a CSV file by creating a new instance and adding columns and rows as you read them.  For a robust solution however you might want to look into a CSV parser library that deals with escaping, multi line rows etc.
+
+```csharp
+var dt = new DataTable();
+var lines = File.ReadAllLines(filename);
+			
+foreach(var h in lines[0].Split(',')){
+	dt.Columns.Add(h);
+}
+				
+
+foreach(var line in lines.Skip(1)) {
+	lineNumber++;
+	dt.Rows.Add(line.Split(','));
+}
+```
+
+## Database Example
+
+All Ado.net database providers (Oracle, MySql, SqlServer etc) support reading data as DataTables for example:
+
+```csharp
+var dt = new DataTable();
+
+using(var con = new SqlConnection("Server=myServerAddress;Database=myDataBase;Trusted_Connection=True;"))
+{
+    con.Open();
+    var cmd = new SqlCommand("select * from myTable;",con);
+    var adapter = new SqlDataAdapter(cmd);
+
+    adapter.Fill(dt);
+}
+```
+
+## Displaying the table
+
+Once you have set up your data table set it in the view:
+
+```csharp
+tableView = new TableView () {
+	X = 0,
+	Y = 0,
+	Width = 50,
+	Height = 10,
+};
+
+tableView.Table = yourDataTable;
+```
+


### PR DESCRIPTION
Hey,

I have been using your awesome framework for a while and wanted to contribute.  I have written a control for #255 .  I have reviewed the contribution guidelines and code of conduct.

I have added a new `Scenario` and tested it in Windows and MXLinux.

- The control works with `System.DataTable`
   - I thought that would be a good way to avoid parsing CSVs as well as supporting viewing results from relational databases etc
- Columns autosize based on the column widths and the widths of the **visible** cells
- Supports horizontal and vertical scrolling including PageUp/Down/Home/End
- User can configure 
  - Maximum cell width
  - How to represent nulls
  - What character to use as a column separator (defaults to space)

Currently when you change the contents of the `Table` or the `ColumnOffset` or `SelectedColumn` you will also have to call `Update` before it will re-render.  This lets the API user drop columns or make many changes to the `System.DataTable` without having to respond to every one.  But it could also be confusing if the user changes the `SelectedRow` and doesn't see the UI immediately update.

![image](https://user-images.githubusercontent.com/31306100/99684377-4f03f180-2a79-11eb-972f-7cfe3726ab92.png)

Let me know if there are inefficiencies in the `Redraw`.  I noticed that the `HexView` (which I based this on) has a local method `SetAttribute` which I kept... although I'm not using it.

I'm unsure about the guidline (any guidance on how to do that would be great please):
> Ensure the UICatalog demo for the new class illustrates both Absolutle Layout and Computed Layout.

Currently the control doesn't explicitly handle newlines in cell values but those seem to be replaced by spaces in DrawString anyway.