### PR TITLE
Fixes #1020. NetDriver does not deal well with unicode characters yet.

### DIFF
--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -565,7 +565,7 @@ static class Demo {
 		Application.UseSystemConsole = true;
 
 		Application.Init();
-		Application.HeightSize = HeightSize.BufferHeight;
+		Application.HeightAsBuffer = true;
 		//ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.FramePadding | ConsoleDriver.DiagnosticFlags.FrameRuler;
 
 		var top = Application.Top;

--- a/Example/demo.cs
+++ b/Example/demo.cs
@@ -562,9 +562,11 @@ static class Demo {
 		if (Debugger.IsAttached)
 			CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo ("en-US");
 
-		//Application.UseSystemConsole = true;
+		Application.UseSystemConsole = true;
 
 		Application.Init();
+		Application.HeightSize = HeightSize.BufferHeight;
+		//ConsoleDriver.Diagnostics = ConsoleDriver.DiagnosticFlags.FramePadding | ConsoleDriver.DiagnosticFlags.FrameRuler;
 
 		var top = Application.Top;
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -20,7 +20,7 @@ namespace Terminal.Gui {
 		public override int Cols => Curses.Cols;
 		public override int Rows => Curses.Lines;
 		public override int Top => 0;
-		public override HeightSize HeightSize { get; set; }
+		public override bool HeightAsBuffer { get; set; }
 
 		// Current row, and current col, tracked by Move/AddRune only
 		int ccol, crow;

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -20,6 +20,7 @@ namespace Terminal.Gui {
 		public override int Cols => Curses.Cols;
 		public override int Rows => Curses.Lines;
 		public override int Top => 0;
+		public override HeightSize HeightSize { get; set; }
 
 		// Current row, and current col, tracked by Move/AddRune only
 		int ccol, crow;
@@ -70,6 +71,7 @@ namespace Terminal.Gui {
 		public override void Refresh () {
 			Curses.refresh ();
 			if (Curses.CheckWinChange ()) {
+				Clip = new Rect (0, 0, Cols, Rows);
 				TerminalResized?.Invoke ();
 			}
 		}

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -647,16 +647,16 @@ namespace Terminal.Gui {
 		}
 
 		Action<MouseEvent> mouseHandler;
-		MainLoop mainLoop;
 
 		public override void PrepareToRun (MainLoop mainLoop, Action<KeyEvent> keyHandler, Action<KeyEvent> keyDownHandler, Action<KeyEvent> keyUpHandler, Action<MouseEvent> mouseHandler)
 		{
 			// Note: Curses doesn't support keydown/up events and thus any passed keyDown/UpHandlers will never be called
 			Curses.timeout (0);
 			this.mouseHandler = mouseHandler;
-			this.mainLoop = mainLoop;
 
-			(mainLoop.Driver as UnixMainLoop).AddWatch (0, UnixMainLoop.Condition.PollIn, x => {
+			var mLoop = mainLoop.Driver as UnixMainLoop;
+
+			mLoop.AddWatch (0, UnixMainLoop.Condition.PollIn, x => {
 				ProcessInput (keyHandler, keyDownHandler, keyUpHandler, mouseHandler);
 				return true;
 			});

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -20,7 +20,7 @@ namespace Terminal.Gui {
 		public override int Cols => cols;
 		public override int Rows => rows;
 		public override int Top => 0;
-		public override HeightSize HeightSize { get; set; }
+		public override bool HeightAsBuffer { get; set; }
 
 		// The format is rows, columns and 3 values on the last column: Rune, Attribute and Dirty Flag
 		int [,,] contents;

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -20,6 +20,7 @@ namespace Terminal.Gui {
 		public override int Cols => cols;
 		public override int Rows => rows;
 		public override int Top => 0;
+		public override HeightSize HeightSize { get; set; }
 
 		// The format is rows, columns and 3 values on the last column: Rune, Attribute and Dirty Flag
 		int [,,] contents;

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -191,13 +191,11 @@ namespace Terminal.Gui {
 				break;
 			case HeightSize.BufferHeight:
 				if (isWinPlatform && Console.WindowHeight > 0) {
-					if (isWinPlatform) {
-						// Can raise an exception while is still resizing.
-						try {
-							Console.WindowTop = Math.Max (Math.Min (top, Console.BufferHeight - Console.WindowHeight), 0);
-						} catch (Exception) {
-							return;
-						}
+					// Can raise an exception while is still resizing.
+					try {
+						Console.WindowTop = Math.Max (Math.Min (top, Console.BufferHeight - Console.WindowHeight), 0);
+					} catch (Exception) {
+						return;
 					}
 				} else {
 					Console.Out.Write ($"\x1b[{top};{Console.WindowLeft}" +

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -166,12 +166,14 @@ namespace Terminal.Gui {
 					try {
 						// Not supported on Unix.
 						if (isWinPlatform) {
+#pragma warning disable CA1416
 							Console.CursorTop = 0;
 							Console.CursorLeft = 0;
 							Console.WindowTop = 0;
 							Console.WindowLeft = 0;
 							Console.SetBufferSize (Math.Max (Min_WindowWidth, Console.WindowWidth),
 								Console.WindowHeight);
+#pragma warning restore CA1416
 						} else {
 							//Console.Out.Write ($"\x1b[8;{Console.WindowHeight};{Console.WindowWidth}t");
 							//Console.Out.Flush ();
@@ -193,7 +195,9 @@ namespace Terminal.Gui {
 				if (isWinPlatform && Console.WindowHeight > 0) {
 					// Can raise an exception while is still resizing.
 					try {
+#pragma warning disable CA1416
 						Console.WindowTop = Math.Max (Math.Min (top, Console.BufferHeight - Console.WindowHeight), 0);
+#pragma warning restore CA1416
 					} catch (Exception) {
 						return;
 					}

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -252,7 +252,6 @@ namespace Terminal.Gui {
 					continue;
 				}
 				dirtyLine [row] = false;
-				int [,,] damage = new int [0, 0, 0];
 				for (int col = 0; col < cols; col++) {
 					if (contents [row, col, 2] != 1) {
 						continue;

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -586,7 +586,6 @@ namespace Terminal.Gui {
 						lastWindowHeight = Console.WindowHeight;
 						return;
 					}
-					break;
 				}
 			}
 		}

--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -534,6 +534,7 @@ namespace Terminal.Gui {
 			}
 		}
 
+		int lastWindowHeight;
 		void WaitWinChange ()
 		{
 			while (true) {
@@ -545,8 +546,10 @@ namespace Terminal.Gui {
 					break;
 				case HeightSize.BufferHeight:
 					if (Console.BufferWidth != consoleDriver.Cols || Console.BufferHeight != consoleDriver.Rows
-						|| Console.WindowTop != consoleDriver.Top) {
+						|| Console.WindowTop != consoleDriver.Top
+						|| Console.WindowHeight != lastWindowHeight) {
 						newTop = Console.WindowTop;
+						lastWindowHeight = Console.WindowHeight;
 						return;
 					}
 					break;

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -523,7 +523,7 @@ namespace Terminal.Gui {
 		public override int Cols => cols;
 		public override int Rows => rows;
 		public override int Top => top;
-		public override HeightSize HeightSize { get; set; }
+		public override bool HeightAsBuffer { get; set; }
 
 		public WindowsConsole WinConsole {
 			get => winConsole;
@@ -1334,14 +1334,12 @@ namespace Terminal.Gui {
 		void WaitWinChange ()
 		{
 			while (true) {
-				switch (consoleDriver.HeightSize) {
-				case HeightSize.WindowHeight:
+				if (!consoleDriver.HeightAsBuffer) {
 					if (Console.WindowWidth != consoleDriver.Cols || Console.WindowHeight != consoleDriver.Rows
 						|| Console.WindowTop != consoleDriver.Top) {    // Top only working on Windows.
 						return;
 					}
-					break;
-				case HeightSize.BufferHeight:
+				} else {
 					if (Console.BufferWidth != consoleDriver.Cols || Console.BufferHeight != consoleDriver.Rows) {
 						return;
 					}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -455,10 +455,10 @@ namespace Terminal.Gui {
 
 #if false      // Not needed on the constructor. Perhaps could be used on resizing. To study.
 		[DllImport ("kernel32.dll", ExactSpelling = true)]
-		private static extern IntPtr GetConsoleWindow ();
+		static extern IntPtr GetConsoleWindow ();
 
 		[DllImport ("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-		private static extern bool ShowWindow (IntPtr hWnd, int nCmdShow);
+		static extern bool ShowWindow (IntPtr hWnd, int nCmdShow);
 
 		public const int HIDE = 0;
 		public const int MAXIMIZE = 3;
@@ -525,67 +525,20 @@ namespace Terminal.Gui {
 		public override int Top => top;
 		public override HeightSize HeightSize { get; set; }
 
-		public WindowsDriver ()
-		{
-			winConsole = new WindowsConsole ();
-
-			SetupColorsAndBorders ();
-
-			cols = Console.WindowWidth;
-			rows = Console.WindowHeight;
-#if false
-			winConsole.ShowWindow (WindowsConsole.RESTORE);
-#endif
-			WindowsConsole.SmallRect.MakeEmpty (ref damageRegion);
-
-			ResizeScreen ();
-			UpdateOffScreen ();
-		}
-
 		public WindowsConsole WinConsole {
 			get => winConsole;
 			private set => winConsole = value;
-		}
-
-		private void SetupColorsAndBorders ()
-		{
-			Colors.TopLevel = new ColorScheme ();
-			Colors.Base = new ColorScheme ();
-			Colors.Dialog = new ColorScheme ();
-			Colors.Menu = new ColorScheme ();
-			Colors.Error = new ColorScheme ();
-
-			Colors.TopLevel.Normal = MakeColor (ConsoleColor.Green, ConsoleColor.Black);
-			Colors.TopLevel.Focus = MakeColor (ConsoleColor.White, ConsoleColor.DarkCyan);
-			Colors.TopLevel.HotNormal = MakeColor (ConsoleColor.DarkYellow, ConsoleColor.Black);
-			Colors.TopLevel.HotFocus = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.DarkCyan);
-
-			Colors.Base.Normal = MakeColor (ConsoleColor.White, ConsoleColor.DarkBlue);
-			Colors.Base.Focus = MakeColor (ConsoleColor.Black, ConsoleColor.Gray);
-			Colors.Base.HotNormal = MakeColor (ConsoleColor.DarkCyan, ConsoleColor.DarkBlue);
-			Colors.Base.HotFocus = MakeColor (ConsoleColor.Blue, ConsoleColor.Gray);
-
-			Colors.Menu.Normal = MakeColor (ConsoleColor.White, ConsoleColor.DarkGray);
-			Colors.Menu.Focus = MakeColor (ConsoleColor.White, ConsoleColor.Black);
-			Colors.Menu.HotNormal = MakeColor (ConsoleColor.Yellow, ConsoleColor.DarkGray);
-			Colors.Menu.HotFocus = MakeColor (ConsoleColor.Yellow, ConsoleColor.Black);
-			Colors.Menu.Disabled = MakeColor (ConsoleColor.Gray, ConsoleColor.DarkGray);
-
-			Colors.Dialog.Normal = MakeColor (ConsoleColor.Black, ConsoleColor.Gray);
-			Colors.Dialog.Focus = MakeColor (ConsoleColor.Black, ConsoleColor.DarkGray);
-			Colors.Dialog.HotNormal = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.Gray);
-			Colors.Dialog.HotFocus = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.DarkGray);
-
-			Colors.Error.Normal = MakeColor (ConsoleColor.DarkRed, ConsoleColor.White);
-			Colors.Error.Focus = MakeColor (ConsoleColor.White, ConsoleColor.DarkRed);
-			Colors.Error.HotNormal = MakeColor (ConsoleColor.Black, ConsoleColor.White);
-			Colors.Error.HotFocus = MakeColor (ConsoleColor.Black, ConsoleColor.DarkRed);
 		}
 
 		Action<KeyEvent> keyHandler;
 		Action<KeyEvent> keyDownHandler;
 		Action<KeyEvent> keyUpHandler;
 		Action<MouseEvent> mouseHandler;
+
+		public WindowsDriver ()
+		{
+			winConsole = new WindowsConsole ();
+		}
 
 		public override void PrepareToRun (MainLoop mainLoop, Action<KeyEvent> keyHandler, Action<KeyEvent> keyDownHandler, Action<KeyEvent> keyUpHandler, Action<MouseEvent> mouseHandler)
 		{
@@ -1081,7 +1034,7 @@ namespace Terminal.Gui {
 			return (Key)(0xffffffff);
 		}
 
-		private Key MapKeyModifiers (ConsoleKeyInfo keyInfo, Key key)
+		Key MapKeyModifiers (ConsoleKeyInfo keyInfo, Key key)
 		{
 			Key keyMod = new Key ();
 			if ((keyInfo.Modifiers & ConsoleModifiers.Shift) != 0)
@@ -1097,7 +1050,48 @@ namespace Terminal.Gui {
 		public override void Init (Action terminalResized)
 		{
 			TerminalResized = terminalResized;
-			SetupColorsAndBorders ();
+
+			cols = Console.WindowWidth;
+			rows = Console.WindowHeight;
+#if false
+			winConsole.ShowWindow (WindowsConsole.RESTORE);
+#endif
+			WindowsConsole.SmallRect.MakeEmpty (ref damageRegion);
+
+			ResizeScreen ();
+			UpdateOffScreen ();
+
+			Colors.TopLevel = new ColorScheme ();
+			Colors.Base = new ColorScheme ();
+			Colors.Dialog = new ColorScheme ();
+			Colors.Menu = new ColorScheme ();
+			Colors.Error = new ColorScheme ();
+
+			Colors.TopLevel.Normal = MakeColor (ConsoleColor.Green, ConsoleColor.Black);
+			Colors.TopLevel.Focus = MakeColor (ConsoleColor.White, ConsoleColor.DarkCyan);
+			Colors.TopLevel.HotNormal = MakeColor (ConsoleColor.DarkYellow, ConsoleColor.Black);
+			Colors.TopLevel.HotFocus = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.DarkCyan);
+
+			Colors.Base.Normal = MakeColor (ConsoleColor.White, ConsoleColor.DarkBlue);
+			Colors.Base.Focus = MakeColor (ConsoleColor.Black, ConsoleColor.Gray);
+			Colors.Base.HotNormal = MakeColor (ConsoleColor.DarkCyan, ConsoleColor.DarkBlue);
+			Colors.Base.HotFocus = MakeColor (ConsoleColor.Blue, ConsoleColor.Gray);
+
+			Colors.Menu.Normal = MakeColor (ConsoleColor.White, ConsoleColor.DarkGray);
+			Colors.Menu.Focus = MakeColor (ConsoleColor.White, ConsoleColor.Black);
+			Colors.Menu.HotNormal = MakeColor (ConsoleColor.Yellow, ConsoleColor.DarkGray);
+			Colors.Menu.HotFocus = MakeColor (ConsoleColor.Yellow, ConsoleColor.Black);
+			Colors.Menu.Disabled = MakeColor (ConsoleColor.Gray, ConsoleColor.DarkGray);
+
+			Colors.Dialog.Normal = MakeColor (ConsoleColor.Black, ConsoleColor.Gray);
+			Colors.Dialog.Focus = MakeColor (ConsoleColor.Black, ConsoleColor.DarkGray);
+			Colors.Dialog.HotNormal = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.Gray);
+			Colors.Dialog.HotFocus = MakeColor (ConsoleColor.DarkBlue, ConsoleColor.DarkGray);
+
+			Colors.Error.Normal = MakeColor (ConsoleColor.DarkRed, ConsoleColor.White);
+			Colors.Error.Focus = MakeColor (ConsoleColor.White, ConsoleColor.DarkRed);
+			Colors.Error.HotNormal = MakeColor (ConsoleColor.Black, ConsoleColor.White);
+			Colors.Error.HotFocus = MakeColor (ConsoleColor.Black, ConsoleColor.DarkRed);
 		}
 
 		void ResizeScreen ()
@@ -1300,6 +1294,9 @@ namespace Terminal.Gui {
 
 		public WindowsMainLoop (ConsoleDriver consoleDriver = null)
 		{
+			if (consoleDriver == null) {
+				throw new ArgumentNullException ("Console driver instance must be provided.");
+			}
 			this.consoleDriver = consoleDriver;
 			winConsole = ((WindowsDriver)consoleDriver).WinConsole;
 		}

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -79,21 +79,21 @@ namespace Terminal.Gui {
 		public static View CurrentView { get; set; }
 
 		/// <summary>
-		/// The current <see cref="Terminal.Gui.HeightSize"/> used in the terminal.
+		/// The current <see cref="ConsoleDriver.HeightAsBuffer"/> used in the terminal.
 		/// </summary>
-		public static HeightSize HeightSize {
+		public static bool HeightAsBuffer {
 			get {
 				if (Driver == null) {
 					throw new ArgumentNullException ("The driver must be initialized first.");
 				}
-				return Driver.HeightSize;
+				return Driver.HeightAsBuffer;
 			}
 			set {
 				if (Driver == null) {
 					throw new ArgumentNullException ("The driver must be initialized first.");
 				}
-				if (Driver.HeightSize != value) {
-					Driver.HeightSize = value;
+				if (Driver.HeightAsBuffer != value) {
+					Driver.HeightAsBuffer = value;
 					Driver.Refresh ();
 				}
 			}

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -59,7 +59,7 @@ namespace Terminal.Gui {
 		/// The current <see cref="ConsoleDriver"/> in use.
 		/// </summary>
 		public static ConsoleDriver Driver;
-
+		
 		/// <summary>
 		/// The <see cref="Toplevel"/> object used for the application on startup (<seealso cref="Application.Top"/>)
 		/// </summary>
@@ -73,10 +73,31 @@ namespace Terminal.Gui {
 		public static Toplevel Current { get; private set; }
 
 		/// <summary>
-		/// TThe current <see cref="View"/> object being redrawn.
+		/// The current <see cref="View"/> object being redrawn.
 		/// </summary>
 		/// /// <value>The current.</value>
 		public static View CurrentView { get; set; }
+
+		/// <summary>
+		/// The current <see cref="Terminal.Gui.HeightSize"/> used in the terminal.
+		/// </summary>
+		public static HeightSize HeightSize {
+			get {
+				if (Driver == null) {
+					throw new ArgumentNullException ("The driver must be initialized first.");
+				}
+				return Driver.HeightSize;
+			}
+			set {
+				if (Driver == null) {
+					throw new ArgumentNullException ("The driver must be initialized first.");
+				}
+				if (Driver.HeightSize != value) {
+					Driver.HeightSize = value;
+					Driver.Refresh ();
+				}
+			}
+		}
 
 		/// <summary>
 		/// The <see cref="MainLoop"/>  driver for the application
@@ -167,7 +188,7 @@ namespace Terminal.Gui {
 		static void Init (Func<Toplevel> topLevelFactory, ConsoleDriver driver = null, IMainLoopDriver mainLoopDriver = null)
 		{
 			if (_initialized && driver == null) return;
-
+			
 			// Used only for start debugging on Unix.
 //#if DEBUG
 //			while (!System.Diagnostics.Debugger.IsAttached) {
@@ -193,9 +214,8 @@ namespace Terminal.Gui {
 					Driver = new NetDriver ();
 					mainLoopDriver = new NetMainLoop (Driver);
 				} else if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows) {
-					var windowsDriver = new WindowsDriver ();
-					mainLoopDriver = windowsDriver;
-					Driver = windowsDriver;
+					Driver = new WindowsDriver ();
+					mainLoopDriver = new WindowsMainLoop (Driver);
 				} else {
 					mainLoopDriver = new UnixMainLoop ();
 					Driver = new CursesDriver ();

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -608,11 +608,11 @@ namespace Terminal.Gui {
 				} else if (!wait) {
 					return;
 				}
-				if (state.Toplevel != Top && (!Top.NeedDisplay.IsEmpty || Top.ChildNeedsDisplay)) {
+				if (state.Toplevel != Top && (!Top.NeedDisplay.IsEmpty || Top.ChildNeedsDisplay || Top.LayoutNeeded)) {
 					Top.Redraw (Top.Bounds);
 					state.Toplevel.SetNeedsDisplay (state.Toplevel.Bounds);
 				}
-				if (!state.Toplevel.NeedDisplay.IsEmpty || state.Toplevel.ChildNeedsDisplay) {
+				if (!state.Toplevel.NeedDisplay.IsEmpty || state.Toplevel.ChildNeedsDisplay || state.Toplevel.LayoutNeeded) {
 					state.Toplevel.Redraw (state.Toplevel.Bounds);
 					if (DebugDrawBounds) {
 						DrawBounds (state.Toplevel);

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -589,12 +589,10 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public static Rune MakePrintable (Rune c)
 		{
-			if (c <= 0x1F) {
-				// ASCII (C0) control characters. 
-				return new Rune (c + 0x2400);
-			} else if (c >= 0x80 && c <= 0x9F) {
+			if (c <= 0x1F || (c >= 0x80 && c <= 0x9F)) {
+				// ASCII (C0) control characters.
 				// C1 control characters (https://www.aivosto.com/articles/control-characters.html#c1)
-				return new Rune (0x25a1); // U+25A1, WHITE SQUARE, □: 
+				return new Rune (c + 0x2400);
 			} else {
 				return c;
 			}

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -458,6 +458,20 @@ namespace Terminal.Gui {
 		public static Dictionary<string, ColorScheme> ColorSchemes { get; }
 	}
 
+	/// <summary>
+	/// The visible height should be used on the window.
+	/// </summary>
+	public enum HeightSize {
+		/// <summary>
+		/// Only window height will be visible not allowing scroll.
+		/// </summary>
+		WindowHeight,
+		/// <summary>
+		/// All buffer height will be visible allowing scroll.
+		/// </summary>
+		BufferHeight
+	}
+
 	///// <summary>
 	///// Special characters that can be drawn with 
 	///// </summary>
@@ -545,6 +559,11 @@ namespace Terminal.Gui {
 		/// The current top in the terminal.
 		/// </summary>
 		public abstract int Top { get; }
+
+		/// <summary>
+		/// The current <see cref="HeightSize"/> used in the terminal.
+		/// </summary>
+		public abstract HeightSize HeightSize { get; set; }
 
 		/// <summary>
 		/// Initializes the driver

--- a/Terminal.Gui/Core/ConsoleDriver.cs
+++ b/Terminal.Gui/Core/ConsoleDriver.cs
@@ -458,20 +458,6 @@ namespace Terminal.Gui {
 		public static Dictionary<string, ColorScheme> ColorSchemes { get; }
 	}
 
-	/// <summary>
-	/// The visible height should be used on the window.
-	/// </summary>
-	public enum HeightSize {
-		/// <summary>
-		/// Only window height will be visible not allowing scroll.
-		/// </summary>
-		WindowHeight,
-		/// <summary>
-		/// All buffer height will be visible allowing scroll.
-		/// </summary>
-		BufferHeight
-	}
-
 	///// <summary>
 	///// Special characters that can be drawn with 
 	///// </summary>
@@ -561,9 +547,10 @@ namespace Terminal.Gui {
 		public abstract int Top { get; }
 
 		/// <summary>
-		/// The current <see cref="HeightSize"/> used in the terminal.
+		/// If false height is measured by the window height and thus no scrolling.
+		/// If true then height is measured by the buffer height, enabling scrolling.
 		/// </summary>
-		public abstract HeightSize HeightSize { get; set; }
+		public abstract bool HeightAsBuffer { get; set; }
 
 		/// <summary>
 		/// Initializes the driver

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -401,10 +401,10 @@ namespace Terminal.Gui {
 		{
 			EnsureVisibleBounds (top, top.Frame.X, top.Frame.Y, out int nx, out int ny);
 			if ((nx != top.Frame.X || ny != top.Frame.Y) && top.LayoutStyle == LayoutStyle.Computed) {
-				if (top.X is Pos.PosAbsolute && top.Bounds.X != nx) {
+				if ((top.X == null || top.X is Pos.PosAbsolute) && top.Bounds.X != nx) {
 					top.X = nx;
 				}
-				if (top.Y is Pos.PosAbsolute && top.Bounds.Y != ny) {
+				if ((top.Y == null || top.Y is Pos.PosAbsolute) && top.Bounds.Y != ny) {
 					top.Y = ny;
 				}
 			}
@@ -421,6 +421,35 @@ namespace Terminal.Gui {
 			}
 		}
 
+		///<inheritdoc/>
+		public override void Redraw (Rect bounds)
+		{
+			Application.CurrentView = this;
+
+			if (IsCurrentTop || this == Application.Top) {
+				if (!NeedDisplay.IsEmpty || LayoutNeeded) {
+					Driver.SetAttribute (Colors.TopLevel.Normal);
+
+					// This is the Application.Top. Clear just the region we're being asked to redraw 
+					// (the bounds passed to us).
+					Clear (bounds);
+					Driver.SetAttribute (Colors.Base.Normal);
+					PositionToplevels ();
+
+					foreach (var view in Subviews) {
+						if (view.Frame.IntersectsWith (bounds)) {
+							view.SetNeedsLayout ();
+							view.SetNeedsDisplay (view.Bounds);
+						}
+					}
+
+					ClearLayoutNeeded ();
+					ClearNeedsDisplay ();
+				}
+			}
+
+			base.Redraw (base.Bounds);
+		}
 
 		/// <summary>
 		/// Invoked by <see cref="Application.Begin"/> as part of the <see cref="Application.Run(Toplevel)"/> after

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -421,35 +421,6 @@ namespace Terminal.Gui {
 			}
 		}
 
-		///<inheritdoc/>
-		public override void Redraw (Rect bounds)
-		{
-			Application.CurrentView = this;
-
-			if (IsCurrentTop || this == Application.Top) {
-				if (!NeedDisplay.IsEmpty || LayoutNeeded) {
-					Driver.SetAttribute (Colors.TopLevel.Normal);
-
-					// This is the Application.Top. Clear just the region we're being asked to redraw 
-					// (the bounds passed to us).
-					Clear (bounds);
-					Driver.SetAttribute (Colors.Base.Normal);
-					PositionToplevels ();
-
-					foreach (var view in Subviews) {
-						if (view.Frame.IntersectsWith (bounds)) {
-							view.SetNeedsLayout ();
-							view.SetNeedsDisplay (view.Bounds);
-						}
-					}
-
-					ClearLayoutNeeded ();
-					ClearNeedsDisplay ();
-				}
-			}
-
-			base.Redraw (base.Bounds);
-		}
 
 		/// <summary>
 		/// Invoked by <see cref="Application.Begin"/> as part of the <see cref="Application.Run(Toplevel)"/> after

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1310,11 +1310,11 @@ namespace Terminal.Gui {
 		/// </remarks>
 		public virtual void Redraw (Rect bounds)
 		{
-			Application.CurrentView = this;
-
 			if (!CanBeVisible (this)) {
 				return;
 			}
+
+			Application.CurrentView = this;
 
 			var clipRect = new Rect (Point.Empty, frame.Size);
 
@@ -1331,25 +1331,6 @@ namespace Terminal.Gui {
 				textFormatter?.Draw (ViewToScreen (Bounds), HasFocus ? ColorScheme.Focus : ColorScheme.Normal, HasFocus ? ColorScheme.HotFocus : ColorScheme.HotNormal);
 			}
 
-			if (IsCurrentTop || this == Application.Top) {
-				if (!NeedDisplay.IsEmpty || LayoutNeeded) {
-					Driver.SetAttribute (Colors.TopLevel.Normal);
-
-					// This is the Application.Top. Clear just the region we're being asked to redraw 
-					// (the bounds passed to us).
-					Clear (bounds);
-					Driver.SetAttribute (Colors.Base.Normal);
-					((Toplevel)this).PositionToplevels ();
-
-					foreach (var view in Subviews) {
-						if (view.Frame.IntersectsWith (bounds)) {
-							view.SetNeedsLayout ();
-							view.SetNeedsDisplay (view.Bounds);
-						}
-					}
-				}
-			}
-
 			// Invoke DrawContentEvent
 			OnDrawContent (bounds);
 
@@ -1362,7 +1343,7 @@ namespace Terminal.Gui {
 							Application.CurrentView = view;
 
 							// Draw the subview
-							// Use the view's bounds (view-relative; Location will always be (0,0) because
+							// Use the view's bounds (view-relative; Location will always be (0,0)
 							if (view.Visible) {
 								view.Redraw (view.Bounds);
 							}

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -1415,7 +1415,7 @@ namespace Terminal.Gui {
 				CloseMenu ();
 				if (openedByAltKey) {
 					openedByAltKey = false;
-					LastFocused.SetFocus ();
+					LastFocused?.SetFocus ();
 				}
 				break;
 

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -74,6 +74,7 @@ namespace UICatalog {
 			Win.Add (jumpList);
 
 			jumpList.Refresh ();
+			jumpList.SetFocus ();
 		}
 
 		public override void Run ()

--- a/UICatalog/Scenarios/CharacterMap.cs
+++ b/UICatalog/Scenarios/CharacterMap.cs
@@ -1,4 +1,7 @@
-﻿using NStack;
+﻿#define DRAW_CONTENT
+//#define BASE_DRAW_CONTENT
+
+using NStack;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -58,15 +61,19 @@ namespace UICatalog {
 				CreateRadio("End", CharMap.MaxCodePointVal - 16, CharMap.MaxCodePointVal),
 			};
 
-			var jumpList = new RadioGroup (radioItems.Select (t => t.radioLabel).ToArray ());
-			jumpList.X = Pos.X (label);
-			jumpList.Y = Pos.Bottom (label);
-			jumpList.Width = Dim.Fill ();
+			var jumpList = new RadioGroup (radioItems.Select (t => t.radioLabel).ToArray ()) {
+				X = Pos.X (label),
+				Y = Pos.Bottom (label),
+				Width = Dim.Fill (),
+				SelectedItem = 8
+			};
 			jumpList.SelectedItemChanged += (args) => {
-				_charMap.Start = radioItems[args.SelectedItem].start;
+				_charMap.Start = radioItems [args.SelectedItem].start;
 			};
 
 			Win.Add (jumpList);
+
+			jumpList.Refresh ();
 		}
 
 		public override void Run ()
@@ -91,11 +98,14 @@ namespace UICatalog {
 		}
 		int _start = 0x2500;
 
+		public const int H_SPACE = 2;
+		public const int V_SPACE = 2;
+
 		public static int MaxCodePointVal => 0xE0FFF;
 
 		// Row Header + space + (space + char + space)
 		public static int RowHeaderWidth => $"U+{MaxCodePointVal:x5}".Length;
-		public static int RowWidth => RowHeaderWidth + (" c".Length * 16);
+		public static int RowWidth => RowHeaderWidth + (H_SPACE * 16);
 
 		public CharMap ()
 		{
@@ -109,10 +119,12 @@ namespace UICatalog {
 					ShowHorizontalScrollIndicator = false;
 				}
 			};
+#if DRAW_CONTENT
 
 			DrawContent += CharMap_DrawContent;
+#endif
 		}
-#if true
+
 		private void CharMap_DrawContent (Rect viewport)
 		{
 			//Rune ReplaceNonPrintables (Rune c)
@@ -125,10 +137,10 @@ namespace UICatalog {
 			//}
 
 			for (int header = 0; header < 16; header++) {
-				Move (viewport.X + RowHeaderWidth + (header * 2), 0);
+				Move (viewport.X + RowHeaderWidth + (header * H_SPACE), 0);
 				Driver.AddStr ($" {header:x} ");
 			}
-			for (int row = 0, y = 0; row < viewport.Height / 2 - 1; row++, y += 2) {
+			for (int row = 0, y = 0; row < viewport.Height / 2 - 1; row++, y+= V_SPACE) {
 				int val = (-viewport.Y + row) * 16;
 				if (val < MaxCodePointVal) {
 					var rowLabel = $"U+{val / 16:x4}x";
@@ -137,17 +149,17 @@ namespace UICatalog {
 					var prevColWasWide = false;
 					for (int col = 0; col < 16; col++) {
 						var rune = new Rune ((uint)((uint)(-viewport.Y + row) * 16 + col));
-						Move (viewport.X + RowHeaderWidth + (col * 2) + (prevColWasWide ? 0 : 1), 0 + y + 1);
+						Move (viewport.X + RowHeaderWidth + (col * H_SPACE) + (prevColWasWide ? 0 : 1), y + 1);
 						Driver.AddRune (rune);
-						//prevColWasWide = Rune.ColumnWidth(rune) > 1;
+						//prevColWasWide = Rune.ColumnWidth (rune) > 1;
 					}
 				}
 			}
 		}
-#else
+#if BASE_DRAW_CONTENT
 		public override void OnDrawContent (Rect viewport)
 		{
-			CharMap_DrawContent(this, viewport);
+			CharMap_DrawContent (viewport);
 			base.OnDrawContent (viewport);
 		}
 #endif


### PR DESCRIPTION
- In this fix I included a new `Enum `property that is `HeightSize `which allows to use the window height or the buffer height  size.
- I also splited the `WindowsDriver `main loop class allowing `DI` (Dependency Injection) and thus works like the `NetDriver `and the `CursesDriver`.
- I changed the `CharacterMap `scenario to allows to toggle to `DRAW_CONTENT `or `BASE_DRAW_CONTENT `more easily.
- In the `CharacterMap `scenario with the `Consolas `font only the "`Chess Symbols (U+1fa00-1fa0f)`" fail with unicode, but I already submit a PR (https://github.com/migueldeicaza/NStack/pull/52) that fixes this.
- The `Rune.ColumnWidth` method will fail with others not true fonts because it calculates the column width based on a range of unicode characters tested with true font and the same range will fail with other fonts types, like "`MS Gothic`", with the same range but with diferents sizes. I hope if it has another way to solves this one day.
- I didn't use the` OperatingSystem.IsWindows` because it isn't available on `net472 `and `netstandard2.0`.
- The menu can be accessed in `Windows `pressing `Ctrl+Space` and in `Unix `as it's usual by pressing `Alt+Space`. In `Windows `this combination  open the window menu.
