### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # default location of `.github/workflows`
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    # location of package manifests
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- add `dependabot.yml` which serves as a configuration file for the Dependabot dependency versioning scan by listing what ecosystems it should look and scan for
- Dependabot versioning scan and PR creation are enabled just by having the `dependaboy.yml` in the ".github" folder

Also [enable security scan and PR creation for vulnerable dependencies](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates) by enabling both "Dependabot alerts" (scan) and "Dependabot security updates" (PR creation).

Resolves #1135 