### PR TITLE
Fix for  #1152 (Generic TreeView`1 breaks upon selection in All Views Tester) 

### DIFF
--- a/UICatalog/Scenarios/AllViewsTester.cs
+++ b/UICatalog/Scenarios/AllViewsTester.cs
@@ -344,6 +344,20 @@ namespace UICatalog {
 
 		View CreateClass (Type type)
 		{
+			// If we are to create a generic Type
+			if (type.IsGenericType) {
+
+				// For each of the <T> arguments
+				List<Type> typeArguments = new List<Type> ();
+
+				// use <object>
+				foreach (var arg in type.GetGenericArguments ()) {
+					typeArguments.Add (typeof (object));
+				}
+
+				// And change what type we are instantiating from MyClass<T> to MyClass<object>
+				type = type.MakeGenericType (typeArguments.ToArray ());
+			}
 			// Instantiate view
 			var view = (View)Activator.CreateInstance (type);
 


### PR DESCRIPTION
Fix for #1152 

This PR makes `CreateClass ` method in the 'All Views Tester' Scenario handle generic types.

Now when asked to create `MyClass<T>` (which is impossible) it will create an instance of `MyClass<object>`