### PR TITLE
get productversion of terminal.gui not version

### DIFF
--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -162,7 +162,7 @@ namespace UICatalog {
 			aboutMessage.AppendLine (@" |___/                   ");
 			aboutMessage.AppendLine ("");
 			aboutMessage.AppendLine ($"Version: {typeof (UICatalogApp).Assembly.GetName ().Version}");
-			aboutMessage.AppendLine ($"Using Terminal.Gui Version: {typeof (Terminal.Gui.Application).Assembly.GetName ().Version}");
+			aboutMessage.AppendLine ($"Using Terminal.Gui Version: {FileVersionInfo.GetVersionInfo (typeof (Terminal.Gui.Application).Assembly.Location).ProductVersion}");
 			aboutMessage.AppendLine ("");
 
 			_menu = new MenuBar (new MenuBarItem [] {


### PR DESCRIPTION
The nuget package version is actually stored in ProductVersion within the DLL, not Version.

This PR fixes how UI Catalog shows this so it is more useful in daignosing things. 