### PR TITLE
Fix link and styling of Toplevel

### DIFF
--- a/docfx/articles/overview.md
+++ b/docfx/articles/overview.md
@@ -44,7 +44,7 @@ In the example above, you can see that we have initialized the runtime by callin
 [`Init`](../api/Terminal.Gui/Terminal.Gui.Application.html#Terminal_Gui_Application_Init) method in the Application class - this sets up the environment, initializes the color
 schemes available for your application and clears the screen to start your application.
 
-The [`Application`](../api/Terminal.Gui/Terminal.Gui.Application.html) class, additionally creates an instance of the [Toplevel](../api/Terminal.Gui/Terminal.Gui.Toplevel.html) class that is ready to be consumed, 
+The [`Application`](../api/Terminal.Gui/Terminal.Gui.Application.html) class, additionally creates an instance of the [`Toplevel`](../api/Terminal.Gui/Terminal.Gui.Toplevel.html) class that is ready to be consumed, 
 this instance is available in the `Application.Top` property, and can be used like this:
 
 ```csharp

--- a/docfx/articles/overview.md
+++ b/docfx/articles/overview.md
@@ -44,7 +44,7 @@ In the example above, you can see that we have initialized the runtime by callin
 [`Init`](../api/Terminal.Gui/Terminal.Gui.Application.html#Terminal_Gui_Application_Init) method in the Application class - this sets up the environment, initializes the color
 schemes available for your application and clears the screen to start your application.
 
-The [`Application`](../api/Terminal.Gui/Terminal.Gui.Application.html) class, additionally creates an instance of the [Toplevel]((../api/Terminal.Gui/Terminal.Gui.Toplevel.html) class that is ready to be consumed, 
+The [`Application`](../api/Terminal.Gui/Terminal.Gui.Application.html) class, additionally creates an instance of the [Toplevel](../api/Terminal.Gui/Terminal.Gui.Toplevel.html) class that is ready to be consumed, 
 this instance is available in the `Application.Top` property, and can be used like this:
 
 ```csharp


### PR DESCRIPTION
1. Remove the extra `(` causing the link not to render.
2. Use backtick to style the Toplevel link similar to other links in the doc.