### PR TITLE
Code coverage

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Build Terminal.Gui with .NET Core
 
 on:
   push:
@@ -26,7 +26,9 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
+      run: |
+        dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
+        copy UnitTests/TestResults/*/coverage.opencover.xml UnitTests/TestResults
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0
@@ -34,7 +36,7 @@ jobs:
       with:
         label: Unit Test Coverage
         color: brightgreen
-        path: UnitTest/TestResults/<uuid>/coverage.opencover.xml
+        path: UnitTest/TestResults/coverage.opencover.xml
         gist-filename: code-coverage.json
         # https://gist.github.com/migueldeicaza/90ef67a684cb71db1817921a970f8d27
         gist-id: 90ef67a684cb71db1817921a970f8d27

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -26,7 +26,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage" --Format:opencover --results-directory:TestResults
+      run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -26,7 +26,8 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: |
+      id: test_step
+        run: |
         dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
         mv -v UnitTests/TestResults/*/*.* UnitTests/TestResults/
 
@@ -44,6 +45,5 @@ jobs:
 
     - name: Print Code Coverage
       run: |
-        echo "Code coverage percentage ${{steps.create_coverage_badge.outputs.percentage}}%"
-        echo "Badge data ${{steps.test_step.outputs.badge}}"
-        
+        echo "Code coverage percentage: ${{steps.create_coverage_badge.outputs.percentage}}%"
+        echo "Badge data: ${{steps.create_coverage_badge.outputs.badge}}"

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: |
         dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
-        copy UnitTests/TestResults/*/coverage.opencover.xml UnitTests/TestResults
+        cp UnitTests/TestResults/*/coverage.opencover.xml UnitTests/TestResults
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Test
       run: |
         dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
-        echo "moving UnitTests/TestResults/*/coverage.opencover.xml to UnitTests/TestResults"
         mv -v UnitTests/TestResults/*/*.* UnitTests/TestResults/
 
     - name: Create Test Coverage Badge
@@ -37,7 +36,7 @@ jobs:
       with:
         label: Unit Test Coverage
         color: brightgreen
-        path: UnitTest/TestResults/coverage.opencover.xml
+        path: UnitTests/TestResults/coverage.opencover.xml
         gist-filename: code-coverage.json
         # https://gist.github.com/migueldeicaza/90ef67a684cb71db1817921a970f8d27
         gist-id: 90ef67a684cb71db1817921a970f8d27

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -26,8 +26,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      id: test_step
-        run: |
+      run: |
         dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
         mv -v UnitTests/TestResults/*/*.* UnitTests/TestResults/
 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -26,7 +26,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test --no-restore --verbosity normal -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover
+      run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage" --Format:opencover --results-directory:TestResults
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0
@@ -34,7 +34,8 @@ jobs:
       with:
         label: Unit Test Coverage
         color: brightgreen
-        path: TestResults/coverage.opencover.xml
+        path: UnitTest/TestResults/<uuid>/coverage.opencover.xml
         gist-filename: code-coverage.json
-        gist-id: 1234567890abcdef1234567890abcdef
+        # https://gist.github.com/migueldeicaza/90ef67a684cb71db1817921a970f8d27
+        gist-id: 90ef67a684cb71db1817921a970f8d27
         gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}   

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -13,14 +13,28 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.100
+
     - name: Install dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
+
     - name: Test
-      #run: dotnet test --no-restore --verbosity normal
       run: dotnet test --no-restore --verbosity normal -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover
+
+    - name: Create Test Coverage Badge
+      uses: simon-k/dotnet-code-coverage-badge@v1.0.0
+      id: create_coverage_badge
+      with:
+        label: Unit Test Coverage
+        color: brightgreen
+        path: TestResults/coverage.opencover.xml
+        gist-filename: code-coverage.json
+        gist-id: 1234567890abcdef1234567890abcdef
+        gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}   

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -28,7 +28,8 @@ jobs:
     - name: Test
       run: |
         dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage"  --settings UnitTests/coverlet.runsettings
-        cp UnitTests/TestResults/*/coverage.opencover.xml UnitTests/TestResults
+        echo "moving UnitTests/TestResults/*/coverage.opencover.xml to UnitTests/TestResults"
+        mv -v UnitTests/TestResults/*/*.* UnitTests/TestResults/
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -22,4 +22,5 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      #run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -41,3 +41,9 @@ jobs:
         # https://gist.github.com/migueldeicaza/90ef67a684cb71db1817921a970f8d27
         gist-id: 90ef67a684cb71db1817921a970f8d27
         gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}   
+
+    - name: Print Code Coverage
+      run: |
+        echo "Code coverage percentage ${{steps.create_coverage_badge.outputs.percentage}}%"
+        echo "Badge data ${{steps.test_step.outputs.badge}}"
+        

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ packages
 
 docfx/api
 
+UnitTests/TestResults
+
 #git merge files
 *.orig
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ A simple toolkit for building console GUI apps for .NET, .NET Core, and Mono tha
 
 ![Sample app](https://raw.githubusercontent.com/migueldeicaza/gui.cs/master/docfx/sample.gif)
 
-The most recent released [Nuget package is version `0.90.x`](https://www.nuget.org/packages/Terminal.Gui) which is the "Stable, Feature Complete" pre-release of 1.0.
-
-Nuget also contains pre-release versions of 1.0; they are identified with `-pre` or `-beta` in the version number (e.g. `1.0.0-pre.1`)
-
 ## Controls & Features
 
 *Terminal.Gui* contains various controls for building text user interfaces:
@@ -222,4 +218,4 @@ A presentation of this was part of the [Retro.NET](https://channel9.msdn.com/Eve
 
 Release history can be found in the [Terminal.Gui.csproj](https://github.com/migueldeicaza/gui.cs/blob/master/Terminal.Gui/Terminal.Gui.csproj) file.
 
-In 2019 and 2020, Charlie Kindel (https://github.com/tig) and @BDisp (https://github.com/BDisp) vastly extended, improved, polished and fixed gui.cs to what it is today.
+In 2019, 2020, and 2021, Charlie Kindel (https://github.com/tig), @BDisp (https://github.com/BDisp), and Thomas Nind (https://github.com/tznind) vastly extended, improved, polished and fixed gui.cs to what it is today.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![.NET Core](https://github.com/migueldeicaza/gui.cs/workflows/.NET%20Core/badge.svg?branch=master)
 ![Code scanning - action](https://github.com/migueldeicaza/gui.cs/workflows/Code%20scanning%20-%20action/badge.svg)
 [![Version](https://img.shields.io/nuget/v/Terminal.Gui.svg)](https://www.nuget.org/packages/Terminal.Gui)
+![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/migueldeicaza/<gist-id>/raw/<gist-filename>)
 [![Downloads](https://img.shields.io/nuget/dt/Terminal.Gui)](https://www.nuget.org/packages/Terminal.Gui)
 [![License](https://img.shields.io/github/license/migueldeicaza/gui.cs.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![.NET Core](https://github.com/migueldeicaza/gui.cs/workflows/.NET%20Core/badge.svg?branch=master)
 ![Code scanning - action](https://github.com/migueldeicaza/gui.cs/workflows/Code%20scanning%20-%20action/badge.svg)
 [![Version](https://img.shields.io/nuget/v/Terminal.Gui.svg)](https://www.nuget.org/packages/Terminal.Gui)
-![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/migueldeicaza/<gist-id>/raw/<gist-filename>)
+![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/migueldeicaza/90ef67a684cb71db1817921a970f8d27/raw/a315df88b9a7b81136b708bd669614099dd95979/code-coverage.json)
 [![Downloads](https://img.shields.io/nuget/dt/Terminal.Gui)](https://www.nuget.org/packages/Terminal.Gui)
 [![License](https://img.shields.io/github/license/migueldeicaza/gui.cs.svg)](LICENSE)
 

--- a/Terminal.Gui/Core/Application.cs
+++ b/Terminal.Gui/Core/Application.cs
@@ -208,6 +208,9 @@ namespace Terminal.Gui {
 //			System.Diagnostics.Debugger.Break ();
 //#endif
 
+			// Reset all class variables (Application is a singleton).
+			ResetState ();
+
 			// This supports Unit Tests and the passing of a mock driver/loopdriver
 			if (driver != null) {
 				if (mainLoopDriver == null) {
@@ -523,6 +526,14 @@ namespace Terminal.Gui {
 		/// </summary>
 		public static void Shutdown ()
 		{
+			ResetState ();
+		}
+
+		// Encapsulate all setting of initial state for Application; Having
+		// this in a function like this ensures we don't make mistakes in
+		// guranteeing that the state of this singleton is deterministic when Init
+		// starts running and after Shutdown returns.
+		static void ResetState () {
 			// Shutdown is the bookend for Init. As such it needs to clean up all resources
 			// Init created. Apps that do any threading will need to code defensively for this.
 			// e.g. see Issue #537
@@ -538,6 +549,10 @@ namespace Terminal.Gui {
 			MainLoop = null;
 			Driver?.End ();
 			Driver = null;
+			Iteration = null;
+			UseSystemConsole = false;
+			RootMouseEvent = null;
+			Resized = null;
 			_initialized = false;
 
 			// Reset synchronization context to allow the user to run async/await,
@@ -546,6 +561,7 @@ namespace Terminal.Gui {
 			// (https://github.com/migueldeicaza/gui.cs/issues/1084).
 			SynchronizationContext.SetSynchronizationContext (syncContext: null);
 		}
+
 
 		static void Redraw (View view)
 		{

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -17,7 +17,18 @@
     <Summary>Application framework for creating modern console applications using .NET</Summary>
     <Title>Terminal.Gui is a framework for creating console user interfaces</Title>
     <PackageReleaseNotes>
-      v1.0.???
+      v1.0.0-beta.9
+      * NEW CONTROL: Tabview - thanks @tznind!
+      * UI Catalog now shows correct Terminal.gui.dll version
+      * Fixes #939 - README sample does not compile - thanks @buzzfrog!
+      * Fixes #1154 - FileDialog blank constructor results in unstable window
+      * Fixes #1155 - MoveForward/MoveBackward not bound on Text controls.
+      * Fixes #1152 - Generic TreeView`1 breaks upon selection in All Views Tester)
+      * Fixes #1148 - TextFormatter.Format does not keep the end spaces on wrapped text.
+      * Fixes #134 - (HUGE) TextView: Add line wrapping.
+      * Fixes #1145 - ScrollBar down arrow is not showing.
+      * Fixes #1143 - Cannot change the MenuBar's background color.
+      * Fixes #1141 - Cannot change the StatusBar's background color.
       * Fixes #1048 - BrighCyan to BrightCyan spelling
       * Fixes #1130 - Broken Table/TreeView links in docs.
 

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>Terminal.Gui</AssemblyName>
     <DocumentationFile>bin\Release\Terminal.Gui.xml</DocumentationFile>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
     <PackageId>Terminal.Gui</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -17,7 +17,7 @@
     <Summary>Application framework for creating modern console applications using .NET</Summary>
     <Title>Terminal.Gui is a framework for creating console user interfaces</Title>
     <PackageReleaseNotes>
-      v1.0.0-beta.10
+      v1.0.0-beta.11
       * NEW CONTROL: Tabview - thanks @tznind!
       * UI Catalog now shows correct Terminal.gui.dll version
       * Fixes #939 - README sample does not compile - thanks @buzzfrog!

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -17,7 +17,7 @@
     <Summary>Application framework for creating modern console applications using .NET</Summary>
     <Title>Terminal.Gui is a framework for creating console user interfaces</Title>
     <PackageReleaseNotes>
-      v1.0.0-beta.9
+      v1.0.0-beta.10
       * NEW CONTROL: Tabview - thanks @tznind!
       * UI Catalog now shows correct Terminal.gui.dll version
       * Fixes #939 - README sample does not compile - thanks @buzzfrog!

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -17,6 +17,33 @@
     <Summary>Application framework for creating modern console applications using .NET</Summary>
     <Title>Terminal.Gui is a framework for creating console user interfaces</Title>
     <PackageReleaseNotes>
+      v1.0.0.0
+      ************************
+      * Version 1.0 Release!!! 
+      * Thank you to @migueldeicaza, @tig, @bdisp, @tznind, @jmprricone, and many more!
+      ************************
+      * Added Dependabot support and updated dependencies
+      * Renamed master branch to main
+      * Fixes #1211. Added support to TextView for word based operations Ctrl+Del and Ctrl+Backspace
+      * Fixes #1208. Now the selected text is overwritten if SelectedStart is greater than CursorPosition.
+      * Fixes #1206. NetDriver now print the selected text. Attribute struct now create a valid Value for the current driver. Insert key is detected by NetDriver.
+      * Fixes #1202. CheckBox now deals with a functional '_' underscore hotkey.
+      * Fixes #1199. Normalize views constructors and did some typo fixing.
+      * Fixes #1197. Prevents width negative value if added directly to the A
+      * Added Vertical Alignment and Text Direction + UICatalog Demo (thanks @jmprricone!)
+      * Fixes #1193. A non auto size default Button now preserves his width and thus the text alignment now work.
+      * Fixes #1187. Prevents WordBackward throwing an exception if point is greater than the text length
+      * Fixes #1185. Button click is only processed if there are no mouse mov
+      * Fixes #1183. ListView now return true on the handled keys
+      * Fixes #1179. TextView does not copy to the clipboard on deleting
+      * Fixes #1177. Now is possible to copy or cut on the TextView with the...
+      * Fixes #1175. demo.cs editor now implement "Copy", "Cut" and "Paste".
+      * Fixes #1173. TextField only need to handle a single line.
+      * Fixes #1171. Delete and Backspace now deletes the selected text
+      * Fixes #1167. Application.Run method with #DEBUG can be simplified.
+      * Fixes #1165. Changing the directory name label or the field name crashes
+      * Fixes #1159. Dialog must have a default button if none is provided.
+
       v1.0.0-beta.11
       * NEW CONTROL: Tabview - thanks @tznind!
       * UI Catalog now shows correct Terminal.gui.dll version

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -145,6 +145,43 @@ namespace Terminal.Gui {
 	/// </summary>
 	public class TableView : View {
 
+		/// <summary>
+		///  Defines the event arguments for <see cref="TableView.CellActivated"/> event
+		/// </summary>
+		public class CellActivatedEventArgs : EventArgs {
+			/// <summary>
+			/// The current table to which the new indexes refer.  May be null e.g. if selection change is the result of clearing the table from the view
+			/// </summary>
+			/// <value></value>
+			public DataTable Table { get; }
+
+
+			/// <summary>
+			/// The column index of the <see cref="Table"/> cell that is being activated
+			/// </summary>
+			/// <value></value>
+			public int Col { get; }
+
+			/// <summary>
+			/// The row index of the <see cref="Table"/> cell that is being activated
+			/// </summary>
+			/// <value></value>
+			public int Row { get; }
+
+			/// <summary>
+			/// Creates a new instance of arguments describing a cell being activated in <see cref="TableView"/>
+			/// </summary>
+			/// <param name="t"></param>
+			/// <param name="col"></param>
+			/// <param name="row"></param>
+			public CellActivatedEventArgs (DataTable t, int col, int row)
+			{
+				Table = t;
+				Col = col;
+				Row = row;
+			}
+		}
+
 		private int columnOffset;
 		private int rowOffset;
 		private int selectedRow;
@@ -1305,44 +1342,6 @@ namespace Terminal.Gui {
 		{
 			Origin = origin;
 			Rect = rect;
-		}
-	}
-	
-	/// <summary>
-	///  Defines the event arguments for <see cref="TableView.CellActivated"/> event
-	/// </summary>
-	public class CellActivatedEventArgs : EventArgs
-	{
-		/// <summary>
-		/// The current table to which the new indexes refer.  May be null e.g. if selection change is the result of clearing the table from the view
-		/// </summary>
-		/// <value></value>
-		public DataTable Table {get;}
-
-
-		/// <summary>
-		/// The column index of the <see cref="Table"/> cell that is being activated
-		/// </summary>
-		/// <value></value>
-		public int Col {get;}
-		
-		/// <summary>
-		/// The row index of the <see cref="Table"/> cell that is being activated
-		/// </summary>
-		/// <value></value>
-		public int Row {get;}
-
-			/// <summary>
-			/// Creates a new instance of arguments describing a cell being activated in <see cref="TableView"/>
-			/// </summary>
-			/// <param name="t"></param>
-			/// <param name="col"></param>
-			/// <param name="row"></param>
-			public CellActivatedEventArgs(DataTable t, int col, int row)
-		{
-			Table = t;
-			Col = col;
-			Row = row;
 		}
 	}
 }

--- a/UICatalog/Scenarios/CsvEditor.cs
+++ b/UICatalog/Scenarios/CsvEditor.cs
@@ -504,7 +504,7 @@ namespace UICatalog.Scenarios {
 			enteredText = okPressed? tf.Text.ToString() : null;
 			return okPressed;
 		}
-		private void EditCurrentCell (CellActivatedEventArgs e)
+		private void EditCurrentCell (TableView.CellActivatedEventArgs e)
 		{
 			if(e.Table == null)
 				return;

--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -226,13 +226,15 @@ namespace UICatalog {
 						"File already exists. Overwrite any way?", "No", "Ok") == 1) {
 						return SaveFile (sd.FileName.ToString (), sd.FilePath.ToString ());
 					} else {
-						return _saved = false;
+						_saved = false;
+						return _saved;
 					}
 				} else {
 					return SaveFile (sd.FileName.ToString (), sd.FilePath.ToString ());
 				}
 			} else {
-				return _saved = false;
+				_saved = false;
+				return _saved;
 			}
 		}
 

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -273,7 +273,7 @@ namespace UICatalog.Scenarios {
 			tableView.Table = BuildSimpleDataTable(big ? 30 : 5, big ? 1000 : 5);
 		}
 
-		private void EditCurrentCell (CellActivatedEventArgs e)
+		private void EditCurrentCell (TableView.CellActivatedEventArgs e)
 		{
 			if(e.Table == null)
 				return;

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -19,26 +19,51 @@ namespace Terminal.Gui.Core {
 		[Fact]
 		public void Init_Shutdown_Cleans_Up ()
 		{
-			Assert.Null (Application.Current);
-			Assert.Null (Application.Top);
-			Assert.Null (Application.MainLoop);
-			Assert.Null (Application.Driver);
+			// Verify inital state is per spec
+			Pre_Init_State ();
 
 			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
-			Assert.NotNull (Application.Current);
-			Assert.NotNull (Application.Top);
-			Assert.NotNull (Application.MainLoop);
-			Assert.NotNull (Application.Driver);
+
+			// Verify post-Init state is correct
+			Post_Init_State ();
 
 			// MockDriver is always 80x25
 			Assert.Equal (80, Application.Driver.Cols);
 			Assert.Equal (25, Application.Driver.Rows);
 
 			Application.Shutdown ();
-			Assert.Null (Application.Current);
-			Assert.Null (Application.Top);
-			Assert.Null (Application.MainLoop);
+
+			// Verify state is back to initial
+			Pre_Init_State ();
+
+		}
+
+		void Pre_Init_State ()
+		{
 			Assert.Null (Application.Driver);
+			Assert.Null (Application.Top);
+			Assert.Null (Application.Current);
+			Assert.Throws<ArgumentNullException> (() => Application.HeightAsBuffer == true);
+			Assert.False (Application.AlwaysSetPosition);
+			Assert.Null (Application.MainLoop);
+			Assert.Null (Application.Iteration);
+			Assert.False (Application.UseSystemConsole);
+			Assert.Null (Application.RootMouseEvent);
+			Assert.Null (Application.Resized);
+		}
+
+		void Post_Init_State ()
+		{
+			Assert.NotNull (Application.Driver);
+			Assert.NotNull (Application.Top);
+			Assert.NotNull (Application.Current);
+			Assert.False (Application.HeightAsBuffer);
+			Assert.False (Application.AlwaysSetPosition);
+			Assert.NotNull (Application.MainLoop);
+			Assert.Null (Application.Iteration);
+			Assert.False (Application.UseSystemConsole);
+			Assert.Null (Application.RootMouseEvent);
+			Assert.Null (Application.Resized);
 		}
 
 		[Fact]

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1,16 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Terminal.Gui;
 using Xunit;
 
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
-
-// Since Application is a singleton we can't run tests in parallel
-[assembly: CollectionBehavior (DisableTestParallelization = true)]
 
 namespace Terminal.Gui.Core {
 	public class ApplicationTests {

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -12,7 +12,7 @@ using Console = Terminal.Gui.FakeConsole;
 // Since Application is a singleton we can't run tests in parallel
 [assembly: CollectionBehavior (DisableTestParallelization = true)]
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Core {
 	public class ApplicationTests {
 		public ApplicationTests ()
 		{

--- a/UnitTests/AssemblyInfo.cs
+++ b/UnitTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using Xunit;
+
+// Since Application is a singleton we can't run tests in parallel
+[assembly: CollectionBehavior (DisableTestParallelization = true)]

--- a/UnitTests/ConsoleDriverTests.cs
+++ b/UnitTests/ConsoleDriverTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.ConsoleDrivers {
 	public class ConsoleDriverTests {
 		[Fact]
 		public void Init_Inits ()

--- a/UnitTests/DimTests.cs
+++ b/UnitTests/DimTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui.Types {
+namespace Terminal.Gui.Core {
 	public class DimTests {
 		public DimTests ()
 		{

--- a/UnitTests/DimTests.cs
+++ b/UnitTests/DimTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Types {
 	public class DimTests {
 		public DimTests ()
 		{

--- a/UnitTests/MainLoopTests.cs
+++ b/UnitTests/MainLoopTests.cs
@@ -12,7 +12,7 @@ using Xunit.Sdk;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Core {
 	public class MainLoopTests {
 
 		[Fact]

--- a/UnitTests/PointTests.cs
+++ b/UnitTests/PointTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Types {
 	public class PointTests {
 		[Fact]
 		public void Point_New ()
@@ -20,7 +20,7 @@ namespace Terminal.Gui {
 		}
 
 		[Fact]
-		public void Point__SetsValue ()
+		public void Point_SetsValue ()
 		{
 			var point = new Point () {
 				X = 0,

--- a/UnitTests/PosTests.cs
+++ b/UnitTests/PosTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Core {
 	public class PosTests {
 		[Fact]
 		public void New_Works ()

--- a/UnitTests/RectTests.cs
+++ b/UnitTests/RectTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Types {
 	public class RectTests {
 		[Fact]
 		public void Rect_New ()
@@ -33,7 +33,7 @@ namespace Terminal.Gui {
 		}
 
 		[Fact]
-		public void Rect__SetsValue ()
+		public void Rect_SetsValue ()
 		{
 			var rect = new Rect () {
 				X = 0,

--- a/UnitTests/ResponderTests.cs
+++ b/UnitTests/ResponderTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Core {
 	public class ResponderTests {
 		[Fact]
 		public void New_Initializes ()

--- a/UnitTests/ScenarioTests.cs
+++ b/UnitTests/ScenarioTests.cs
@@ -43,10 +43,14 @@ namespace Terminal.Gui {
 			Assert.NotEmpty (scenarioClasses);
 
 			foreach (var scenarioClass in scenarioClasses) {
+
 				// Setup some fake keypresses 
 				// Passing empty string will cause just a ctrl-q to be fired
 				Console.MockKeyPresses.Clear ();
 				int stackSize = CreateInput ("");
+
+				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+
 				int iterations = 0;
 				Application.Iteration = () => {
 					iterations++;
@@ -55,7 +59,6 @@ namespace Terminal.Gui {
 						Application.RequestStop ();
 					}
 				};
-				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 				var ms = 1000;
 				var abortCount = 0;
@@ -99,6 +102,8 @@ namespace Terminal.Gui {
 			// Passing empty string will cause just a ctrl-q to be fired
 			int stackSize = CreateInput ("");
 
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+
 			int iterations = 0;
 			Application.Iteration = () => {
 				iterations++;
@@ -107,7 +112,6 @@ namespace Terminal.Gui {
 					Application.RequestStop ();
 				}
 			};
-			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
 			var ms = 1000;
 			var abortCount = 0;

--- a/UnitTests/ScrollBarViewTests.cs
+++ b/UnitTests/ScrollBarViewTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Views {
 	public class ScrollBarViewTests {
 		public class HostView : View {
 			public int Top { get; set; }

--- a/UnitTests/SizeTests.cs
+++ b/UnitTests/SizeTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Types {
 	public class SizeTests {
 		[Fact]
 		public void Size_New ()
@@ -30,7 +30,7 @@ namespace Terminal.Gui {
 		}
 
 		[Fact]
-		public void Size__SetsValue ()
+		public void Size_SetsValue ()
 		{
 			var size = new Size () {
 				Width = 0,

--- a/UnitTests/TabViewTests.cs
+++ b/UnitTests/TabViewTests.cs
@@ -7,7 +7,7 @@ using Terminal.Gui;
 using Xunit;
 using System.Globalization;
 
-namespace UnitTests {
+namespace Terminal.Gui.Views {
 	public class TabViewTests {
 		private TabView GetTabView ()
 		{

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -7,7 +7,7 @@ using Terminal.Gui;
 using Xunit;
 using System.Globalization;
 
-namespace UnitTests {
+namespace Terminal.Gui.Views {
 	public class TableViewTests 
 	{
 

--- a/UnitTests/TextFieldTests.cs
+++ b/UnitTests/TextFieldTests.cs
@@ -1,6 +1,6 @@
 ﻿using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Views {
 	public class TextFieldTests {
 		private TextField _textField;
 

--- a/UnitTests/TextFormatterTests.cs
+++ b/UnitTests/TextFormatterTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 // Alais Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Core {
 	public class TextFormatterTests {
 
 		[Fact]

--- a/UnitTests/TextViewTests.cs
+++ b/UnitTests/TextViewTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Xunit;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Views {
 	public class TextViewTests {
 		private TextView _textView;
 

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Terminal.Gui;
 using Xunit;
 
-namespace UnitTests {
+namespace Terminal.Gui.Views {
 	public class TreeViewTests {
 		#region Test Setup Methods
 		class Factory {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <UseDataCollector/>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <UseDataCollector/>
+    <UseDataCollector />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="ReportGenerator" Version="4.8.7" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -33,4 +33,25 @@
     <ProjectReference Include="..\UICatalog\UICatalog.csproj" />
   </ItemGroup>
 
+  <PropertyGroup Label="FineCodeCoverage">
+    <Enabled>
+      True
+    </Enabled>
+    <Exclude>
+      [UICatalog]*
+    </Exclude>
+    <Include>
+    </Include>
+    <ExcludeByFile>
+      <!--**/Migrations/*
+      **/Hacks/*.cs-->
+    </ExcludeByFile>
+    <ExcludeByAttribute>
+      <!--MyCustomExcludeFromCodeCoverage-->
+    </ExcludeByAttribute>
+    <IncludeTestAssembly>
+      False
+    </IncludeTestAssembly>
+  </PropertyGroup>
+  
 </Project>

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -924,100 +924,100 @@ namespace Terminal.Gui.Views {
 			Application.Shutdown ();
 		}
 
-		//[Fact]
-		//public void Multi_Thread_Toplevels ()
-		//{
-		//	Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+		[Fact]
+		public void Multi_Thread_Toplevels ()
+		{
+			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
-		//	var t = Application.Top;
-		//	var w = new Window ();
-		//	t.Add (w);
+			var t = Application.Top;
+			var w = new Window ();
+			t.Add (w);
 
-		//	int count = 0, count1 = 0, count2 = 0;
-		//	bool log = false, log1 = false, log2 = false;
-		//	bool fromTopStillKnowFirstIsRunning = false;
-		//	bool fromTopStillKnowSecondIsRunning = false;
-		//	bool fromFirstStillKnowSecondIsRunning = false;
+			int count = 0, count1 = 0, count2 = 0;
+			bool log = false, log1 = false, log2 = false;
+			bool fromTopStillKnowFirstIsRunning = false;
+			bool fromTopStillKnowSecondIsRunning = false;
+			bool fromFirstStillKnowSecondIsRunning = false;
 
-		//	Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-		//		count++;
-		//		if (count1 == 5) {
-		//			log1 = true;
-		//		}
-		//		if (count1 > 13 && count < 15) {
-		//			fromTopStillKnowFirstIsRunning = true;
-		//		}
-		//		if (count2 > 6 && count2 < 8) {
-		//			fromTopStillKnowSecondIsRunning = true;
-		//		}
-		//		if (count == 30) {
-		//			Assert.Equal (30, count);
-		//			Assert.Equal (20, count1);
-		//			Assert.Equal (10, count2);
+			Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+				count++;
+				if (count1 == 5) {
+					log1 = true;
+				}
+				if (count1 == 14 && count2 == 10 && count == 15) { // count2 is already stopped
+					fromTopStillKnowFirstIsRunning = true;
+				}
+				if (count1 == 7 && count2 == 7 && count == 8) {
+					fromTopStillKnowSecondIsRunning = true;
+				}
+				if (count == 30) {
+					Assert.Equal (30, count);
+					Assert.Equal (20, count1);
+					Assert.Equal (10, count2);
 
-		//			Assert.True (log);
-		//			Assert.True (log1);
-		//			Assert.True (log2);
+					Assert.True (log);
+					Assert.True (log1);
+					Assert.True (log2);
 
-		//			Assert.True (fromTopStillKnowFirstIsRunning);
-		//			Assert.True (fromTopStillKnowSecondIsRunning);
-		//			Assert.True (fromFirstStillKnowSecondIsRunning);
+					Assert.True (fromTopStillKnowFirstIsRunning);
+					Assert.True (fromTopStillKnowSecondIsRunning);
+					Assert.True (fromFirstStillKnowSecondIsRunning);
 
-		//			Application.RequestStop ();
-		//			return false;
-		//		}
-		//		return true;
-		//	});
+					Application.RequestStop ();
+					return false;
+				}
+				return true;
+			});
 
-		//	t.Ready += FirstDialogToplevel;
+			t.Ready += FirstDialogToplevel;
 
-		//	void FirstDialogToplevel ()
-		//	{
-		//		var od = new OpenDialog ();
-		//		od.Ready += SecoundDialogToplevel;
+			void FirstDialogToplevel ()
+			{
+				var od = new OpenDialog ();
+				od.Ready += SecoundDialogToplevel;
 
-		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-		//			count1++;
-		//			if (count2 == 5) {
-		//				log2 = true;
-		//			}
-		//			if (count2 > 3 && count2 < 5) {
-		//				fromFirstStillKnowSecondIsRunning = true;
-		//			}
-		//			if (count1 == 20) {
-		//				Assert.Equal (20, count1);
-		//				Application.RequestStop ();
-		//				return false;
-		//			}
-		//			return true;
-		//		});
+				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+					count1++;
+					if (count2 == 5) {
+						log2 = true;
+					}
+					if (count2 == 4 && count1 == 5 && count == 5) {
+						fromFirstStillKnowSecondIsRunning = true;
+					}
+					if (count1 == 20) {
+						Assert.Equal (20, count1);
+						Application.RequestStop ();
+						return false;
+					}
+					return true;
+				});
 
-		//		Application.Run (od);
-		//	}
+				Application.Run (od);
+			}
 
-		//	void SecoundDialogToplevel ()
-		//	{
-		//		var d = new Dialog ();
+			void SecoundDialogToplevel ()
+			{
+				var d = new Dialog ();
 
-		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-		//			count2++;
-		//			if (count < 30) {
-		//				log = true;
-		//			}
-		//			if (count2 == 10) {
-		//				Assert.Equal (10, count2);
-		//				Application.RequestStop ();
-		//				return false;
-		//			}
-		//			return true;
-		//		});
+				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+					count2++;
+					if (count < 30) {
+						log = true;
+					}
+					if (count2 == 10) {
+						Assert.Equal (10, count2);
+						Application.RequestStop ();
+						return false;
+					}
+					return true;
+				});
 
-		//		Application.Run (d);
-		//	}
+				Application.Run (d);
+			}
 
-		//	Application.Run ();
-		//	Application.Shutdown ();
-		//}
+			Application.Run ();
+			Application.Shutdown ();
+		}
 
 		[Fact]
 		public void View_Difference_Between_An_Object_Initializer_And_A_Constructor ()

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -924,100 +924,100 @@ namespace Terminal.Gui.Views {
 			Application.Shutdown ();
 		}
 
-		[Fact]
-		public void Multi_Thread_Toplevels ()
-		{
-			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+		//[Fact]
+		//public void Multi_Thread_Toplevels ()
+		//{
+		//	Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
-			var t = Application.Top;
-			var w = new Window ();
-			t.Add (w);
+		//	var t = Application.Top;
+		//	var w = new Window ();
+		//	t.Add (w);
 
-			int count = 0, count1 = 0, count2 = 0;
-			bool log = false, log1 = false, log2 = false;
-			bool fromTopStillKnowFirstIsRunning = false;
-			bool fromTopStillKnowSecondIsRunning = false;
-			bool fromFirstStillKnowSecondIsRunning = false;
+		//	int count = 0, count1 = 0, count2 = 0;
+		//	bool log = false, log1 = false, log2 = false;
+		//	bool fromTopStillKnowFirstIsRunning = false;
+		//	bool fromTopStillKnowSecondIsRunning = false;
+		//	bool fromFirstStillKnowSecondIsRunning = false;
 
-			Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-				count++;
-				if (count1 == 5) {
-					log1 = true;
-				}
-				if (count1 > 13 && count < 15) {
-					fromTopStillKnowFirstIsRunning = true;
-				}
-				if (count2 > 6 && count2 < 8) {
-					fromTopStillKnowSecondIsRunning = true;
-				}
-				if (count == 30) {
-					Assert.Equal (30, count);
-					Assert.Equal (20, count1);
-					Assert.Equal (10, count2);
+		//	Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//		count++;
+		//		if (count1 == 5) {
+		//			log1 = true;
+		//		}
+		//		if (count1 > 13 && count < 15) {
+		//			fromTopStillKnowFirstIsRunning = true;
+		//		}
+		//		if (count2 > 6 && count2 < 8) {
+		//			fromTopStillKnowSecondIsRunning = true;
+		//		}
+		//		if (count == 30) {
+		//			Assert.Equal (30, count);
+		//			Assert.Equal (20, count1);
+		//			Assert.Equal (10, count2);
 
-					Assert.True (log);
-					Assert.True (log1);
-					Assert.True (log2);
+		//			Assert.True (log);
+		//			Assert.True (log1);
+		//			Assert.True (log2);
 
-					Assert.True (fromTopStillKnowFirstIsRunning);
-					Assert.True (fromTopStillKnowSecondIsRunning);
-					Assert.True (fromFirstStillKnowSecondIsRunning);
+		//			Assert.True (fromTopStillKnowFirstIsRunning);
+		//			Assert.True (fromTopStillKnowSecondIsRunning);
+		//			Assert.True (fromFirstStillKnowSecondIsRunning);
 
-					Application.RequestStop ();
-					return false;
-				}
-				return true;
-			});
+		//			Application.RequestStop ();
+		//			return false;
+		//		}
+		//		return true;
+		//	});
 
-			t.Ready += FirstDialogToplevel;
+		//	t.Ready += FirstDialogToplevel;
 
-			void FirstDialogToplevel ()
-			{
-				var od = new OpenDialog ();
-				od.Ready += SecoundDialogToplevel;
+		//	void FirstDialogToplevel ()
+		//	{
+		//		var od = new OpenDialog ();
+		//		od.Ready += SecoundDialogToplevel;
 
-				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-					count1++;
-					if (count2 == 5) {
-						log2 = true;
-					}
-					if (count2 > 3 && count2 < 5) {
-						fromFirstStillKnowSecondIsRunning = true;
-					}
-					if (count1 == 20) {
-						Assert.Equal (20, count1);
-						Application.RequestStop ();
-						return false;
-					}
-					return true;
-				});
+		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//			count1++;
+		//			if (count2 == 5) {
+		//				log2 = true;
+		//			}
+		//			if (count2 > 3 && count2 < 5) {
+		//				fromFirstStillKnowSecondIsRunning = true;
+		//			}
+		//			if (count1 == 20) {
+		//				Assert.Equal (20, count1);
+		//				Application.RequestStop ();
+		//				return false;
+		//			}
+		//			return true;
+		//		});
 
-				Application.Run (od);
-			}
+		//		Application.Run (od);
+		//	}
 
-			void SecoundDialogToplevel ()
-			{
-				var d = new Dialog ();
+		//	void SecoundDialogToplevel ()
+		//	{
+		//		var d = new Dialog ();
 
-				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-					count2++;
-					if (count < 30) {
-						log = true;
-					}
-					if (count2 == 10) {
-						Assert.Equal (10, count2);
-						Application.RequestStop ();
-						return false;
-					}
-					return true;
-				});
+		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//			count2++;
+		//			if (count < 30) {
+		//				log = true;
+		//			}
+		//			if (count2 == 10) {
+		//				Assert.Equal (10, count2);
+		//				Application.RequestStop ();
+		//				return false;
+		//			}
+		//			return true;
+		//		});
 
-				Application.Run (d);
-			}
+		//		Application.Run (d);
+		//	}
 
-			Application.Run ();
-			Application.Shutdown ();
-		}
+		//	Application.Run ();
+		//	Application.Shutdown ();
+		//}
 
 		[Fact]
 		public void View_Difference_Between_An_Object_Initializer_And_A_Constructor ()

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 // Alias Console to MockConsole so we don't accidentally use Console
 using Console = Terminal.Gui.FakeConsole;
 
-namespace Terminal.Gui {
+namespace Terminal.Gui.Views {
 	public class ViewTests {
 		[Fact]
 		public void New_Initializes ()

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -924,100 +924,101 @@ namespace Terminal.Gui.Views {
 			Application.Shutdown ();
 		}
 
-		[Fact]
-		public void Multi_Thread_Toplevels ()
-		{
-			Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+		// See https://github.com/migueldeicaza/gui.cs/issues/1238
+		//[Fact]
+		//public void Multi_Thread_Toplevels ()
+		//{
+		//	Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
-			var t = Application.Top;
-			var w = new Window ();
-			t.Add (w);
+		//	var t = Application.Top;
+		//	var w = new Window ();
+		//	t.Add (w);
 
-			int count = 0, count1 = 0, count2 = 0;
-			bool log = false, log1 = false, log2 = false;
-			bool fromTopStillKnowFirstIsRunning = false;
-			bool fromTopStillKnowSecondIsRunning = false;
-			bool fromFirstStillKnowSecondIsRunning = false;
+		//	int count = 0, count1 = 0, count2 = 0;
+		//	bool log = false, log1 = false, log2 = false;
+		//	bool fromTopStillKnowFirstIsRunning = false;
+		//	bool fromTopStillKnowSecondIsRunning = false;
+		//	bool fromFirstStillKnowSecondIsRunning = false;
 
-			Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-				count++;
-				if (count1 == 5) {
-					log1 = true;
-				}
-				if (count1 > 13 && count < 15) {
-					fromTopStillKnowFirstIsRunning = true;
-				}
-				if (count2 > 6 && count2 < 8) {
-					fromTopStillKnowSecondIsRunning = true;
-				}
-				if (count == 30) {
-					Assert.Equal (30, count);
-					Assert.Equal (20, count1);
-					Assert.Equal (10, count2);
+		//	Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//		count++;
+		//		if (count1 == 5) {
+		//			log1 = true;
+		//		}
+		//		if (count1 > 13 && count < 15) {
+		//			fromTopStillKnowFirstIsRunning = true;
+		//		}
+		//		if (count2 > 6 && count2 < 8) {
+		//			fromTopStillKnowSecondIsRunning = true;
+		//		}
+		//		if (count == 30) {
+		//			Assert.Equal (30, count);
+		//			Assert.Equal (20, count1);
+		//			Assert.Equal (10, count2);
 
-					Assert.True (log);
-					Assert.True (log1);
-					Assert.True (log2);
+		//			Assert.True (log);
+		//			Assert.True (log1);
+		//			Assert.True (log2);
 
-					Assert.True (fromTopStillKnowFirstIsRunning);
-					Assert.True (fromTopStillKnowSecondIsRunning);
-					Assert.True (fromFirstStillKnowSecondIsRunning);
+		//			Assert.True (fromTopStillKnowFirstIsRunning);
+		//			Assert.True (fromTopStillKnowSecondIsRunning);
+		//			Assert.True (fromFirstStillKnowSecondIsRunning);
 
-					Application.RequestStop ();
-					return false;
-				}
-				return true;
-			});
+		//			Application.RequestStop ();
+		//			return false;
+		//		}
+		//		return true;
+		//	});
 
-			t.Ready += FirstDialogToplevel;
+		//	t.Ready += FirstDialogToplevel;
 
-			void FirstDialogToplevel ()
-			{
-				var od = new OpenDialog();
-				od.Ready += SecoundDialogToplevel;
+		//	void FirstDialogToplevel ()
+		//	{
+		//		var od = new OpenDialog();
+		//		od.Ready += SecoundDialogToplevel;
 
-				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-					count1++;
-					if (count2 == 5) {
-						log2 = true;
-					}
-					if (count2 > 3 && count2 < 5) {
-						fromFirstStillKnowSecondIsRunning = true;
-					}
-					if (count1 == 20) {
-						Assert.Equal (20, count1);
-						Application.RequestStop ();
-						return false;
-					}
-					return true;
-				});
+		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//			count1++;
+		//			if (count2 == 5) {
+		//				log2 = true;
+		//			}
+		//			if (count2 > 3 && count2 < 5) {
+		//				fromFirstStillKnowSecondIsRunning = true;
+		//			}
+		//			if (count1 == 20) {
+		//				Assert.Equal (20, count1);
+		//				Application.RequestStop ();
+		//				return false;
+		//			}
+		//			return true;
+		//		});
 
-				Application.Run (od);
-			}
+		//		Application.Run (od);
+		//	}
 
-			void SecoundDialogToplevel ()
-			{
-				var d = new Dialog ();
+		//	void SecoundDialogToplevel ()
+		//	{
+		//		var d = new Dialog ();
 
-				Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
-					count2++;
-					if (count < 30) {
-						log = true;
-					}
-					if (count2 == 10) {
-						Assert.Equal (10, count2);
-						Application.RequestStop ();
-						return false;
-					}
-					return true;
-				});
+		//		Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (100), (_) => {
+		//			count2++;
+		//			if (count < 30) {
+		//				log = true;
+		//			}
+		//			if (count2 == 10) {
+		//				Assert.Equal (10, count2);
+		//				Application.RequestStop ();
+		//				return false;
+		//			}
+		//			return true;
+		//		});
 
-				Application.Run (d);
-			}
+		//		Application.Run (d);
+		//	}
 
-			Application.Run ();
-			Application.Shutdown ();
-		}
+		//	Application.Run ();
+		//	Application.Shutdown ();
+		//}
 
 		[Fact]
 		public void View_Difference_Between_An_Object_Initializer_And_A_Constructor ()

--- a/UnitTests/coverlet.runsettings
+++ b/UnitTests/coverlet.runsettings
@@ -5,8 +5,8 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>opencover</Format>          
-          <Exclude>[coverlet.*.tests?]*,[*]Coverlet.Core*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
-          <Include>[coverlet.*]*,[*]Coverlet.Core*</Include> <!-- [Assembly-Filter]Type-Filter -->
+          <Exclude>[UnitTests]*,[UICatalog]*,[coverlet.*.tests?]*,[*]Coverlet.Core*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+          <Include></Include> <!-- [Assembly-Filter]Type-Filter -->
           <ExcludeByAttribute></ExcludeByAttribute>
           <ExcludeByFile></ExcludeByFile> <!-- Globbing filter -->
           <IncludeDirectory></IncludeDirectory>

--- a/UnitTests/coverlet.runsettings
+++ b/UnitTests/coverlet.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover</Format>          
+          <Exclude>[coverlet.*.tests?]*,[*]Coverlet.Core*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+          <Include>[coverlet.*]*,[*]Coverlet.Core*</Include> <!-- [Assembly-Filter]Type-Filter -->
+          <ExcludeByAttribute></ExcludeByAttribute>
+          <ExcludeByFile></ExcludeByFile> <!-- Globbing filter -->
+          <IncludeDirectory></IncludeDirectory>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <SkipAutoProps>true</SkipAutoProps>
+          <DeterministicReport>false</DeterministicReport>
+          <ResultsDirectory>TestResults/</ResultsDirectory>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
This PR adds

- support for viewing code coverage results with Fine Code Coverage in VS.
- a badge to README.md showing CC results (not fully working yet)
- additional protections in `Application` to ensure, as a singleton, it is deterministic as long as any call to `Init` is bracketed by a call to `Shutdown`

E.g:
![image](https://user-images.githubusercontent.com/585482/115467394-4bba9080-a1e6-11eb-9c0a-735f1f8fc2d1.png)

