### PR TITLE
TextValidateField reimplementation without generics

### DIFF
--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -112,35 +112,37 @@ namespace UICatalog {
 			_timeField.TimeChanged += TimeChanged;
 
 			// MaskedTextProvider
-			var netProvider = new Label (".Net MaskedTextProvider [ 999 000 LLL >LLL| AAA aaa ]") {
+			var netProviderLabel = new Label (".Net MaskedTextProvider [ 999 000 LLL >LLL| AAA aaa ]") {
 				X = Pos.Left (dateField),
 				Y = Pos.Bottom (dateField) + 1
 			};
-			Win.Add (netProvider);
+			Win.Add (netProviderLabel);
 
-			var netProviderField = new TextValidateField<NetMaskedTextProvider> ("999 000 LLL >LLL| AAA aaa") {
-				X = Pos.Right (netProvider) + 1,
-				Y = Pos.Y (netProvider),
-				Width = 40,
+			var netProvider = new NetMaskedTextProvider ("--(0000)--");// ("999 000 LLL > LLL | AAA aaa");
+
+			var netProviderField = new TextValidateField (netProvider) {
+				X = Pos.Right (netProviderLabel) + 1,
+				Y = Pos.Y (netProviderLabel),
+				Width = 20,
 				TextAlignment = TextAlignment.Centered
 			};
+
 			Win.Add (netProviderField);
 
 			// TextRegexProvider
 			var regexProvider = new Label ("Gui.cs TextRegexProvider [ ^([0-9]?[0-9]?[0-9]|1000)$ ]") {
-				X = Pos.Left (netProvider),
-				Y = Pos.Bottom (netProvider) + 1
+				X = Pos.Left (netProviderLabel),
+				Y = Pos.Bottom (netProviderLabel) + 1
 			};
 			Win.Add (regexProvider);
 
-			var regexProviderField = new TextValidateField<TextRegexProvider> ("^([0-9]?[0-9]?[0-9]|1000)$") {
+			var provider2 = new TextRegexProvider ("^([0-9]?[0-9]?[0-9]|1000)$") { ValidateOnInput = false };
+			var regexProviderField = new TextValidateField (provider2) {
 				X = Pos.Right (regexProvider) + 1,
 				Y = Pos.Y (regexProvider),
-				Width = 40,
+				Width = 30,
 				TextAlignment = TextAlignment.Centered
 			};
-			// Access the inner Provider to configure.
-			regexProviderField.Provider.ValidateOnInput = false;
 
 			Win.Add (regexProviderField);
 		}

--- a/UICatalog/Scenarios/Text.cs
+++ b/UICatalog/Scenarios/Text.cs
@@ -118,13 +118,11 @@ namespace UICatalog {
 			};
 			Win.Add (netProviderLabel);
 
-			var netProvider = new NetMaskedTextProvider ("--(0000)--");// ("999 000 LLL > LLL | AAA aaa");
+			var netProvider = new NetMaskedTextProvider ("999 000 LLL > LLL | AAA aaa");
 
 			var netProviderField = new TextValidateField (netProvider) {
 				X = Pos.Right (netProviderLabel) + 1,
-				Y = Pos.Y (netProviderLabel),
-				Width = 20,
-				TextAlignment = TextAlignment.Centered
+				Y = Pos.Y (netProviderLabel)
 			};
 
 			Win.Add (netProviderField);

--- a/UnitTests/TextValidateFieldTests.cs
+++ b/UnitTests/TextValidateFieldTests.cs
@@ -15,14 +15,15 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(1___)--", field.Text);
+			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+			Assert.Equal ("--(1   )--", field.Text);
 		}
 
 		[Fact]
@@ -30,14 +31,15 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
 			field.ProcessKey (new KeyEvent (Key.A, new KeyModifiers { }));
 
-			Assert.Equal ("--(____)--", field.Text);
+			Assert.Equal ("--(    )--", field.Text);
+			Assert.Equal ("--(____)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 		}
 
@@ -46,7 +48,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -57,7 +59,8 @@ namespace Terminal.Gui.Views {
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(1___)--", field.Text);
+			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+			Assert.Equal ("--(1   )--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -66,7 +69,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                               *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -74,7 +77,9 @@ namespace Terminal.Gui.Views {
 			field.ProcessKey (new KeyEvent (Key.End, new KeyModifiers { }));
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
-			Assert.Equal ("--(___1)--", field.Text);
+
+			Assert.Equal ("--(___1)--", field.Provider.DisplayText);
+			Assert.Equal ("--(   1)--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -83,7 +88,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                               *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -93,7 +98,8 @@ namespace Terminal.Gui.Views {
 			}
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(___1)--", field.Text);
+			Assert.Equal ("--(___1)--", field.Provider.DisplayText);
+			Assert.Equal ("--(   1)--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -102,7 +108,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            *
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -112,7 +118,8 @@ namespace Terminal.Gui.Views {
 			}
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(1___)--", field.Text);
+			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
+			Assert.Equal ("--(1   )--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -121,21 +128,21 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
-			Assert.Equal ("--(1___)--", field.Text);
+			Assert.Equal ("--(1   )--", field.Text);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D2, new KeyModifiers { }));
-			Assert.Equal ("--(12__)--", field.Text);
+			Assert.Equal ("--(12  )--", field.Text);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D3, new KeyModifiers { }));
-			Assert.Equal ("--(123_)--", field.Text);
+			Assert.Equal ("--(123 )--", field.Text);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D4, new KeyModifiers { }));
@@ -148,25 +155,25 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ** **
 			//                                                         01234567890
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(00-00)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(00-00)--")) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
-			Assert.Equal ("--(1_-__)--", field.Text);
+			Assert.Equal ("--(1_-__)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D2, new KeyModifiers { }));
-			Assert.Equal ("--(12-__)--", field.Text);
+			Assert.Equal ("--(12-__)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D3, new KeyModifiers { }));
-			Assert.Equal ("--(12-3_)--", field.Text);
+			Assert.Equal ("--(12-3_)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.D4, new KeyModifiers { }));
-			Assert.Equal ("--(12-34)--", field.Text);
+			Assert.Equal ("--(12-34)--", field.Provider.DisplayText);
 			Assert.True (field.IsValid);
 		}
 
@@ -176,7 +183,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--", "1234") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -190,12 +197,13 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--", "12345") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "12345" }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
-			Assert.Equal ("--(____)--", field.Text);
+			Assert.Equal ("--(____)--", field.Provider.DisplayText);
+			Assert.Equal ("--(    )--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -204,12 +212,13 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--", "123") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "123" }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
-			Assert.Equal ("--(123_)--", field.Text);
+			Assert.Equal ("--(123_)--", field.Provider.DisplayText);
+			Assert.Equal ("--(123 )--", field.Text);
 			Assert.False (field.IsValid);
 		}
 
@@ -218,19 +227,19 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--", "1234") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
 
-			Assert.Equal ("--(1234)--", field.Text);
+			Assert.Equal ("--(1234)--", field.Provider.DisplayText);
 			Assert.True (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.Delete, new KeyModifiers { }));
 			field.ProcessKey (new KeyEvent (Key.Delete, new KeyModifiers { }));
 			field.ProcessKey (new KeyEvent (Key.Delete, new KeyModifiers { }));
 
-			Assert.Equal ("--(_234)--", field.Text);
+			Assert.Equal ("--(_234)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.CursorRight, new KeyModifiers { }));
@@ -240,7 +249,7 @@ namespace Terminal.Gui.Views {
 			field.ProcessKey (new KeyEvent (Key.Delete, new KeyModifiers { }));
 			field.ProcessKey (new KeyEvent (Key.Delete, new KeyModifiers { }));
 
-			Assert.Equal ("--(_2_4)--", field.Text);
+			Assert.Equal ("--(_2_4)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 		}
 
@@ -249,7 +258,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--", "1234") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--") { Text = "1234" }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
@@ -258,20 +267,20 @@ namespace Terminal.Gui.Views {
 			field.ProcessKey (new KeyEvent (Key.End, new KeyModifiers { }));
 
 			field.ProcessKey (new KeyEvent (Key.Backspace, new KeyModifiers { }));
-			Assert.Equal ("--(12_4)--", field.Text);
+			Assert.Equal ("--(12_4)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.Backspace, new KeyModifiers { }));
-			Assert.Equal ("--(1__4)--", field.Text);
+			Assert.Equal ("--(1__4)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			field.ProcessKey (new KeyEvent (Key.Backspace, new KeyModifiers { }));
-			Assert.Equal ("--(___4)--", field.Text);
+			Assert.Equal ("--(___4)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
 			// One more
 			field.ProcessKey (new KeyEvent (Key.Backspace, new KeyModifiers { }));
-			Assert.Equal ("--(___4)--", field.Text);
+			Assert.Equal ("--(___4)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 		}
 
@@ -281,7 +290,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Left,
 				Width = 30
 			};
@@ -297,7 +306,7 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Left,
 				Width = 30
 			};
@@ -306,8 +315,9 @@ namespace Terminal.Gui.Views {
 			Assert.Equal ("--(1234)--", field.Text);
 			Assert.True (field.IsValid);
 
-			field.Mask = "--------(00000000)--------";
-			Assert.Equal ("--------(1234____)--------", field.Text);
+			var provider = field.Provider as NetMaskedTextProvider;
+			provider.Mask = "--------(00000000)--------";
+			Assert.Equal ("--------(1234____)--------", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 		}
 
@@ -316,21 +326,21 @@ namespace Terminal.Gui.Views {
 		{
 			//                                                            ****
 			//                                                         0123456789
-			var field = new TextValidateField<NetMaskedTextProvider> ("--(0000)--") {
+			var field = new TextValidateField (new NetMaskedTextProvider ("--(0000)--")) {
 				TextAlignment = TextAlignment.Left,
 				Width = 30
 			};
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(1___)--", field.Text);
+			Assert.Equal ("--(1___)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 
-			field.MouseEvent (new MouseEvent () { X = 25, Flags = MouseFlags.Button1Clicked });
+			field.MouseEvent (new MouseEvent () { X = 25, Flags = MouseFlags.Button1Pressed });
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 
-			Assert.Equal ("--(1__1)--", field.Text);
+			Assert.Equal ("--(1__1)--", field.Provider.DisplayText);
 			Assert.False (field.IsValid);
 		}
 	}
@@ -344,12 +354,9 @@ namespace Terminal.Gui.Views {
 		[Fact]
 		public void Input_Without_Validate_On_Input ()
 		{
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9][0-9][0-9]$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
 				Width = 20
 			};
-
-			// Let you input
-			field.Provider.ValidateOnInput = false;
 
 			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers { }));
 			Assert.Equal ("1", field.Text);
@@ -371,7 +378,7 @@ namespace Terminal.Gui.Views {
 		[Fact]
 		public void Input_With_Validate_On_Input_Set_Text ()
 		{
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9][0-9][0-9]$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
 				Width = 20
 			};
 
@@ -392,21 +399,9 @@ namespace Terminal.Gui.Views {
 		}
 
 		[Fact]
-		public void Empty_Mask_Does_Not_Validate ()
-		{
-			var field = new TextValidateField<TextRegexProvider> () {
-				Width = 20
-			};
-
-			field.ProcessKey (new KeyEvent (Key.D1, new KeyModifiers ()));
-			Assert.Equal ("", field.Text);
-			Assert.False (field.IsValid);
-		}
-
-		[Fact]
 		public void Text_With_All_Charset ()
 		{
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9][0-9][0-9]$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$")) {
 				Width = 20
 			};
 
@@ -432,7 +427,7 @@ namespace Terminal.Gui.Views {
 			}
 
 			try {
-				var field = new TextValidateField<TextRegexProvider> (mask) {
+				var field = new TextValidateField (new TextRegexProvider (mask)) {
 					Width = 20
 				};
 			} catch (RegexParseException ex) {
@@ -447,7 +442,7 @@ namespace Terminal.Gui.Views {
 		{
 			// Range 0 to 1000
 			// Accepts 001 too.
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9]?[0-9]?[0-9]|1000$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9]?[0-9]?[0-9]|1000$")) {
 				Width = 20
 			};
 
@@ -473,11 +468,9 @@ namespace Terminal.Gui.Views {
 		public void End_Key_End_Of_Input ()
 		{
 			// Exactly 5 numbers
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9]{5}$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9]{5}$") { ValidateOnInput = false }) {
 				Width = 20
 			};
-
-			field.Provider.ValidateOnInput = false;
 
 			for (int i = 0; i < 4; i++) {
 				field.ProcessKey (new KeyEvent (Key.D0, new KeyModifiers { }));
@@ -508,11 +501,10 @@ namespace Terminal.Gui.Views {
 		[Fact]
 		public void Right_Key_Stops_At_End_And_Insert ()
 		{
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9][0-9][0-9]$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
-			field.Provider.ValidateOnInput = false;
 
 			field.Text = "123";
 
@@ -533,11 +525,10 @@ namespace Terminal.Gui.Views {
 		[Fact]
 		public void Left_Key_Stops_At_Start_And_Insert ()
 		{
-			var field = new TextValidateField<TextRegexProvider> ("^[0-9][0-9][0-9]$") {
+			var field = new TextValidateField (new TextRegexProvider ("^[0-9][0-9][0-9]$") { ValidateOnInput = false }) {
 				TextAlignment = TextAlignment.Centered,
 				Width = 20
 			};
-			field.Provider.ValidateOnInput = false;
 
 			field.Text = "123";
 


### PR DESCRIPTION
Usage:
```csharp
var netProvider = new NetMaskedTextProvider ("000-0000");

var field = new TextValidateField (netProvider) {
    X = 0,
    Y = 0
};
```
or with the empty constructor.

```csharp
var netProvider = new NetMaskedTextProvider ("000-0000");

var field = new TextValidateField () {
    X = 0,
    Y = 0
};
field.Provider = netProvider;
```
Input value can be passed to the provider and/or to the field.
```csharp
var netProvider = new NetMaskedTextProvider ("000-0000") { Text = "123"};

var field = new TextValidateField () {
    X = 0,
    Y = 0,
    Text = "456" // Not assigned. Needs a provider to work.
};
field.Provider = netProvider;


var netProvider = new NetMaskedTextProvider ("000-0000") { Text = "123"};

var field = new TextValidateField (netProvider) {
    X = 0,
    Y = 0,
    Text = "456" // Assigned over 123
};
```

For the ```NetMaskedTextProvider```, to update the mask, if there is no reference to the provider, a new provider must be assigned, or the field provider must be casted, because providers are ```ITextValidateProvider```, and it dosen't have the mask property.

```csharp
var field = new TextValidateField (new NetMaskedTextProvider ("000-0000") ) {
    X = 0,
    Y = 0
};
var provider = field.Provider as NetMaskedTextProvider;
provider.Mask = "00-00-00";
```

The same thing happens with ```TextRegexProvider```, but with the ```Pattern``` property.

```csharp
var field = new TextValidateField (new TextRegexProvider("^([0-9]?[0-9]?[0-9]|1000)$") ) {
    X = 0,
    Y = 0
};
var provider = field.Provider as TextRegexProvider;
provider.Pattern = "^([0-9]?[0-9]|100)$";
```