### PR TITLE
TextView CursorLeft/CursorRight change focus when at start/end

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1944,6 +1944,25 @@ namespace Terminal.Gui {
 			int restCount;
 			List<Rune> rest;
 
+			// if the user presses Left (without any control keys) and they are at the start of the text
+			if(kb.Key == Key.CursorLeft && currentColumn == 0 && currentRow == 0) {
+				// do not respond (this lets the key press fall through to navigation system - which usually changes focus backward)
+				return false;
+			}
+
+			// if the user presses Right (without any control keys)
+			if (kb.Key == Key.CursorRight) {
+
+				// determine where the last cursor position in the text is
+				var lastRow = model.Count - 1;
+				var lastCol = model.GetLine (lastRow).Count;
+
+				// if they are at the very end of all the text do not respond (this lets the key press fall through to navigation system - which usually changes focus forward)
+				if (currentColumn == lastCol && currentRow == lastRow) {
+					return false;
+				}
+			}
+
 			// Handle some state here - whether the last command was a kill
 			// operation and the column tracking (up/down)
 			switch (kb.Key) {


### PR DESCRIPTION
This PR makes CursorLeft / CursorRight (without modifier keys) change the focus out of TextView.  It does this by returning false from ProcessKey (i.e. no longer claim to handle CursorLeft when cursor is at 0,0).  If you test it out I think it feels quite natural and improves the usability of the control for both Windows and Linux users without changing any existing functionality (Ctrl+Tab taking you out of control)

This PR relates to #1266 where it is difficult to get focus out of TextView without reaching for the mouse on old/linux terminals (due to control keys not playing nicely with Tab key).

![cursor-textview-focusshift](https://user-images.githubusercontent.com/31306100/116528626-f6f8d300-a8d3-11eb-958e-eb5bba8cd794.gif)

_Interacting with TextView using only the cursor keys (and typing)_