### PR TITLE
Prevents ListView top to be less than zero if source count is zero.

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -559,7 +559,9 @@ namespace Terminal.Gui {
 		{
 			if (source.Count > 0 && selected != source.Count - 1) {
 				selected = source.Count - 1;
-				top = selected;
+				if (top + selected > Frame.Height - 1) {
+					top = selected;
+				}
 				OnSelectedChanged ();
 				SetNeedsDisplay ();
 			}

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -557,7 +557,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public virtual bool MoveEnd ()
 		{
-			if (selected != source.Count - 1) {
+			if (source.Count > 0 && selected != source.Count - 1) {
 				selected = source.Count - 1;
 				top = selected;
 				OnSelectedChanged ();


### PR DESCRIPTION
This avoids an exception on the `Render` method.
To test open the `Mouse` scenario only using the keyboard and press the `End` key and a `System.ArgumentOutOfRangeException` will be triggered.