### PR TITLE
Fixes InvalidOperationException from throwing when removing the label on the LabelsAsLabels scenario.

### DIFF
--- a/UICatalog/Scenarios/LabelsAsButtons.cs
+++ b/UICatalog/Scenarios/LabelsAsButtons.cs
@@ -117,8 +117,14 @@ namespace UICatalog {
 				CanFocus = true,
 			};
 			Win.Add (removeLabel);
-			// This in intresting test case because `moveBtn` and below are laid out relative to this one!
-			removeLabel.Clicked += () => Win.Remove (removeLabel);
+			// This in interesting test case because `moveBtn` and below are laid out relative to this one!
+			removeLabel.Clicked += () => {
+				// Now this throw a InvalidOperationException on the TopologicalSort method as is expected.
+				//Win.Remove (removeLabel);
+
+				removeLabel.Visible = false;
+				Win.SetNeedsDisplay ();
+			};
 
 			var computedFrame = new FrameView ("Computed Layout") {
 				X = 0,


### PR DESCRIPTION
Setting the label visibility as false was the more easy way. The other fix would be removing the `Pos` relation from the other views.