### PR TITLE
Resolves: Add GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
 	"name": "Terminal.Gui Codespace",
 	"image": "mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0",
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "pwsh"
+	},
 	"extensions": [
 		"eamodio.gitlens",
 		"ms-dotnettools.csharp",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "Terminal.Gui Codespace",
+	"image": "mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0",
+	"extensions": [
+		"eamodio.gitlens",
+		"ms-dotnettools.csharp",
+		"VisualStudioExptTeam.vscodeintellicode",
+		"ms-vscode.powershell",
+		"cschleiden.vscode-github-actions",
+		"redhat.vscode-yaml",
+		"bierner.markdown-preview-github-styles",
+		"ban.spellright",
+		"jmrog.vscode-nuget-package-manager",
+		"coenraads.bracket-pair-colorizer",
+		"vscode-icons-team.vscode-icons",
+		"editorconfig.editorconfig"
+	],
+	"postCreateCommand": "dotnet restore && dotnet build --configuration Release --no-restore && dotnet test --no-restore --verbosity normal --collect:'XPlat Code Coverage' --settings UnitTests/coverlet.runsettings",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,5 @@
 		"vscode-icons-team.vscode-icons",
 		"editorconfig.editorconfig"
 	],
-	"postCreateCommand": "dotnet restore && dotnet build --configuration Release --no-restore && dotnet test --no-restore --verbosity normal --collect:'XPlat Code Coverage' --settings UnitTests/coverlet.runsettings",
+	"postCreateCommand": "dotnet restore && dotnet build --configuration Release --no-restore && dotnet test --configuration Debug --no-restore --verbosity normal --collect:'XPlat Code Coverage' --settings UnitTests/coverlet.runsettings",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,3 +20,5 @@
 	],
 	"postCreateCommand": "dotnet restore && dotnet build --configuration Release --no-restore && dotnet test --configuration Debug --no-restore --verbosity normal --collect:'XPlat Code Coverage' --settings UnitTests/coverlet.runsettings",
 }
+
+// Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- ready-to-start GitHub Codespaces configuration

- it provides basic tools for:
  - .NET development
  - GitHub support
  - overall more pleasant VS Code experience
  
The configuration consists of:
  
- `"image":` - a declaration of the Docker image that the Codespace container is created from (this is a list of images and code examples that [work with GitHub Codespaces](https://github.com/microsoft/vscode-dev-containers/tree/main/containers))
  - `"mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0"` - the Codespace container runs from an Ubuntu 20.04 image with .NET Core SDK installed (`0.201.7` is the latest .NET Core SDK Docker image tagged version)

- `"settings":` - a list of VS Code settings to be applied automatically after the Codespace container is created (.editorconfig overrides these)
  - `"terminal.integrated.defaultProfile.linux": "pwsh"` - sets the default VS Code terminal to PowerShell Core

- `extensions:` - a list of VS Code extensions that are automatically installed after the Codespace container is created
  - `"eamodio.gitlens"` - provides git information directly inside the code
  - `"ms-dotnettools.csharp"` and `"VisualStudioExptTeam.vscodeintellicode"` - provide basic Visual Studio tooling
  - `"ms-vscode.powershell"` - provides the functionality of Windows PowerShell ISE inside VS Code
  - `"cschleiden.vscode-github-actions"` and `"redhat.vscode-yaml"` - provide YAML and GitHub Actions support
  - `"bierner.markdown-preview-github-styles"` and `"ban.spellright"` - provide assistance with writing GitHub documentation
  - `"jmrog.vscode-nuget-package-manager"` - provides use of the NuGet library through the Command Palette
  - `"coenraads.bracket-pair-colorizer"` - sets different colors for each nested pair of brackets
  - `"vscode-icons-team.vscode-icons"` - provides a huge set of icons for the VS Code explorer
  - `"editorconfig.editorconfig"` - attempts to override user/workspace settings with those in the .editorconfig
  
- `"postCreateCommand"` - is a string of commands separated by `&&` that execute after the container has been built and the source code has been cloned. In this configuration, the commands run are build and test of the application per the CI instructions

Resolves #1337 