### PR TITLE
Fixes #1358. Attribute.Foreground / Attribute.Background now working with CursesDriver

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -137,9 +137,10 @@ namespace Terminal.Gui {
 			return new Attribute (
 				//value: Curses.ColorPair (last_color_pair),
 				value: Curses.ColorPair (v),
-				foreground: (Color)foreground,
-				background: (Color)background);
-
+				//foreground: (Color)foreground,
+				foreground: MapCursesColor (foreground),
+				//background: (Color)background);
+				background: MapCursesColor (background));
 		}
 
 		int [,] colorPairs = new int [16, 16];
@@ -897,10 +898,50 @@ namespace Terminal.Gui {
 			throw new ArgumentException ("Invalid color code");
 		}
 
+		static Color MapCursesColor (int color)
+		{
+			switch (color) {
+			case Curses.COLOR_BLACK:
+				return Color.Black;
+			case Curses.COLOR_BLUE:
+				return Color.Blue;
+			case Curses.COLOR_GREEN:
+				return Color.Green;
+			case Curses.COLOR_CYAN:
+				return Color.Cyan;
+			case Curses.COLOR_RED:
+				return Color.Red;
+			case Curses.COLOR_MAGENTA:
+				return Color.Magenta;
+			case Curses.COLOR_YELLOW:
+				return Color.Brown;
+			case Curses.COLOR_WHITE:
+				return Color.Gray;
+			case Curses.COLOR_GRAY:
+				return Color.DarkGray;
+			case Curses.COLOR_BLUE | Curses.COLOR_GRAY:
+				return Color.BrightBlue;
+			case Curses.COLOR_GREEN | Curses.COLOR_GRAY:
+				return Color.BrightGreen;
+			case Curses.COLOR_CYAN | Curses.COLOR_GRAY:
+				return Color.BrightCyan;
+			case Curses.COLOR_RED | Curses.COLOR_GRAY:
+				return Color.BrightRed;
+			case Curses.COLOR_MAGENTA | Curses.COLOR_GRAY:
+				return Color.BrightMagenta;
+			case Curses.COLOR_YELLOW | Curses.COLOR_GRAY:
+				return Color.BrightYellow;
+			case Curses.COLOR_WHITE | Curses.COLOR_GRAY:
+				return Color.White;
+			}
+			throw new ArgumentException ("Invalid curses color code");
+		}
+
 		public override Attribute MakeAttribute (Color fore, Color back)
 		{
 			var f = MapColor (fore);
-			return MakeColor ((short)(f & 0xffff), (short)MapColor (back)) | ((f & Curses.A_BOLD) != 0 ? Curses.A_BOLD : 0);
+			//return MakeColor ((short)(f & 0xffff), (short)MapColor (back)) | ((f & Curses.A_BOLD) != 0 ? Curses.A_BOLD : 0);
+			return MakeColor ((short)(f & 0xffff), (short)MapColor (back));
 		}
 
 		public override void Suspend ()

--- a/UICatalog/Scenarios/InvertColors.cs
+++ b/UICatalog/Scenarios/InvertColors.cs
@@ -1,4 +1,7 @@
-﻿using Terminal.Gui;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terminal.Gui;
 
 namespace UICatalog {
 	[ScenarioMetadata (Name: "Invert Colors", Description: "Invert the foreground and the background colors.")]
@@ -8,23 +11,38 @@ namespace UICatalog {
 		{
 			Win.ColorScheme = Colors.TopLevel;
 
-			var color = Application.Driver.MakeAttribute (Color.Red, Color.Blue);
+			List<Label> labels = new List<Label> ();
+			var foreColors = Enum.GetValues (typeof (Color)).Cast<Color> ().ToArray ();
+			for (int y = 0; y < foreColors.Length; y++) {
 
-			var label = new Label ("Test") {
-				ColorScheme = new ColorScheme()
-			};
-			label.ColorScheme.Normal = color;
-			Win.Add (label);
+				var fore = foreColors [y];
+				var back = foreColors [(y + 1) % foreColors.Length];
+				var color = Application.Driver.MakeAttribute (fore, back);
+
+				var label = new Label ($"{fore} on {back}") {
+					ColorScheme = new ColorScheme (),
+					Y = y
+				};
+				label.ColorScheme.Normal = color;
+				Win.Add (label);
+				labels.Add (label);
+			}
 
 			var button = new Button ("Invert color!") {
 				X = Pos.Center (),
-				Y = Pos.Center (),
+				Y = foreColors.Length + 1,
 			};
 			button.Clicked += () => {
-				color = Application.Driver.MakeAttribute (color.Background, color.Foreground);
 
-				label.ColorScheme.Normal = color;
-				label.SetNeedsDisplay ();
+				foreach (var label in labels) {
+					var color = label.ColorScheme.Normal;
+					color = Application.Driver.MakeAttribute (color.Background, color.Foreground);
+
+					label.ColorScheme.Normal = color;
+					label.Text = $"{color.Foreground} on {color.Background}";
+					label.SetNeedsDisplay ();
+
+				}
 			};
 			Win.Add (button);
 		}

--- a/UICatalog/Scenarios/InvertColors.cs
+++ b/UICatalog/Scenarios/InvertColors.cs
@@ -1,0 +1,32 @@
+﻿using Terminal.Gui;
+
+namespace UICatalog {
+	[ScenarioMetadata (Name: "Invert Colors", Description: "Invert the foreground and the background colors.")]
+	[ScenarioCategory ("Colors")]
+	class InvertColors : Scenario {
+		public override void Setup ()
+		{
+			Win.ColorScheme = Colors.TopLevel;
+
+			var color = Application.Driver.MakeAttribute (Color.Red, Color.Blue);
+
+			var label = new Label ("Test") {
+				ColorScheme = new ColorScheme()
+			};
+			label.ColorScheme.Normal = color;
+			Win.Add (label);
+
+			var button = new Button ("Invert color!") {
+				X = Pos.Center (),
+				Y = Pos.Center (),
+			};
+			button.Clicked += () => {
+				color = Application.Driver.MakeAttribute (color.Background, color.Foreground);
+
+				label.ColorScheme.Normal = color;
+				label.SetNeedsDisplay ();
+			};
+			Win.Add (button);
+		}
+	}
+}


### PR DESCRIPTION
To allowing some test on some specifics `ConsoleDriver` features, the initialization should be done in the Init method (`ConsoleDriver`) and in the `Setup` (`IMainLoopDriver`), instead in the constructors.