### PR TITLE
Prevents application crash if OS clipboard is not supported.

### DIFF
--- a/Terminal.Gui/Core/Clipboard/Clipboard.cs
+++ b/Terminal.Gui/Core/Clipboard/Clipboard.cs
@@ -14,14 +14,20 @@ namespace Terminal.Gui {
 		public static ustring Contents {
 			get {
 				try {
-					return Application.Driver.Clipboard.GetClipboardData ();
+					if (IsSupported) {
+						return Application.Driver.Clipboard.GetClipboardData ();
+					} else {
+						return contents;
+					}
 				} catch (Exception) {
 					return contents;
 				}
 			}
 			set {
 				try {
-					Application.Driver.Clipboard.SetClipboardData (value.ToString ());
+					if (IsSupported) {
+						Application.Driver.Clipboard.SetClipboardData (value.ToString ());
+					}
 					contents = value;
 				} catch (Exception) {
 					contents = value;

--- a/UICatalog/Scenarios/Editor.cs
+++ b/UICatalog/Scenarios/Editor.cs
@@ -75,6 +75,7 @@ namespace UICatalog {
 				new StatusItem(Key.F2, "~F2~ Open", () => Open()),
 				new StatusItem(Key.F3, "~F3~ Save", () => Save()),
 				new StatusItem(Key.CtrlMask | Key.Q, "~^Q~ Quit", () => Quit()),
+				new StatusItem(Key.Null, $"OS Clipboard IsSupported : {Clipboard.IsSupported}", null)
 			});
 			Top.Add (statusBar);
 


### PR DESCRIPTION
Can be tested on a real `Linux`, not on `WSL`, if `xclip` isn't installed.