### PR TITLE
Disables MinVer on Debug builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ dotnet add package Terminal.Gui
 * Windows, Mac, and Linux - Build and run using the .NET SDK command line tools (`dotnet build` in the root directory). Run `UICatalog` with `dotnet run --project ./UICatalog` or by directly executing `./UICatalog/bin/Debug/net5.0/UICatalog.exe`.
 * Windows - Open `Terminal.Gui.sln` with Visual Studio 2019.
 
+Building in Release requires the [git command line tool](https://git-scm.com/) (a dependency of the [MinVer](https://github.com/adamralph/minver#can-i-disable-minver) build tool)
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/migueldeicaza/gui.cs/blob/master/CONTRIBUTING.md).

--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -16,7 +16,9 @@
     </PackageReference>
     <!-- <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" /> -->
   </ItemGroup>
-
+  <PropertyGroup>
+      <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- See Terminal.Gui/README.md for how version numbering works -->
     <!-- This enables prefixing version tags with v, e.g. v1.0.0 Instead of 1.0.0 -->


### PR DESCRIPTION
Closes #1377 

Building Terminal.Gui requires `git` command line tool as it is used by MinVer.  I have added a note to the README.md to highlight this and also disabled MinVer on debug builds (such as when user types `dotnet run` in UICatalog dir) to improve new user experience.

Running in Release still runs MinVer and hence requires git:

```
thomas@mx:~/gui.cs
$ cd UICatalog/
thomas@mx:~/gui.cs/UICatalog
$ dotnet run
thomas@mx:~/gui.cs/UICatalog
$ dotnet run -c Release
/home/thomas/.nuget/packages/minver/2.5.0/build/MinVer.targets(39,5): error MSB3073: The command "dotnet "/home/thomas/.nuget/packages/minver/2.5.0/build/../minver/MinVer.dll" "/home/thomas/gui.cs/Terminal.Gui" --auto-increment "" --build-metadata "" --default-pre-release-phase "" --minimum-major-minor "" --tag-prefix "v" --verbosity "" --version-override """ exited with code 134. [/home/thomas/gui.cs/Terminal.Gui/Terminal.Gui.csproj]

The build failed. Fix the build errors and run again.
thomas@mx:~/gui.cs/UICatalog
```
_Running UICatalog after uninstalling git_

There is the down side of this PR that when running in Debug (the default for `dotnet run` you don't get the correct version number assigned to the binaries - obviously):

![image](https://user-images.githubusercontent.com/31306100/126078278-736cb287-65ff-477b-95b3-a1ae210eb531.png)
_Version shows as 1.0.0 when it should be 1.1.2-alpha.0.10_
