### PR TITLE
Fixes #1396. Using the Loaded event instead the Ready event.

### DIFF
--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -273,20 +273,31 @@ namespace UICatalog {
 			_top.Add (_rightPane);
 			_top.Add (_statusBar);
 
-			_top.Loaded += () => {
+			void TopHandler () {
 				if (_runningScenario != null) {
 					_runningScenario = null;
 					_isFirstRunning = false;
 				}
-			};
-			void ReadyHandler ()
-			{
 				if (!_isFirstRunning) {
 					_rightPane.SetFocus ();
 				}
-				_top.Ready -= ReadyHandler;
+				_top.Loaded -= TopHandler;
 			}
-			_top.Ready += ReadyHandler;
+			_top.Loaded += TopHandler;
+			// The following code was moved to the TopHandler event
+			//  because in the MainLoop.EventsPending (wait)
+			//  from the Application.RunLoop with the WindowsDriver
+			//  the OnReady event is triggered due the Focus event.
+			//  On CursesDriver and NetDriver the focus event won't be triggered
+			//  and if it's possible I don't know how to do it.
+			//void ReadyHandler ()
+			//{
+			//	if (!_isFirstRunning) {
+			//		_rightPane.SetFocus ();
+			//	}
+			//	_top.Ready -= ReadyHandler;
+			//}
+			//_top.Ready += ReadyHandler;
 
 			Application.Run (_top);
 			return _runningScenario;


### PR DESCRIPTION
![uicatalog-cursesdriver-fix](https://user-images.githubusercontent.com/13117724/126986857-d9c208df-ae19-43f1-a372-c983063f3c3a.gif)
![uicatalog-netdriver-fix](https://user-images.githubusercontent.com/13117724/126986863-8d8a6faa-113a-4637-b3d1-37aef3bd09b5.gif)
