### PR TITLE
Fixes #1402. Only WindowsDriver supports horizontal scroll.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -248,8 +248,8 @@ namespace Terminal.Gui {
 			}
 		}
 
-		Curses.Event? LastMouseButtonPressed;
-		bool IsButtonPressed;
+		Curses.Event? lastMouseButtonPressed;
+		bool isButtonPressed;
 		bool cancelButtonClicked;
 		bool isReportMousePosition;
 		Point point;
@@ -258,31 +258,31 @@ namespace Terminal.Gui {
 		{
 			MouseFlags mouseFlag = MouseFlags.AllEvents;
 
-			if (LastMouseButtonPressed != null && cev.ButtonState != Curses.Event.ReportMousePosition) {
-				LastMouseButtonPressed = null;
-				IsButtonPressed = false;
+			if (lastMouseButtonPressed != null && cev.ButtonState != Curses.Event.ReportMousePosition) {
+				lastMouseButtonPressed = null;
+				isButtonPressed = false;
 			}
 
 
 			if ((cev.ButtonState == Curses.Event.Button1Clicked || cev.ButtonState == Curses.Event.Button2Clicked ||
 				cev.ButtonState == Curses.Event.Button3Clicked) &&
-				LastMouseButtonPressed == null) {
+				lastMouseButtonPressed == null) {
 
-				IsButtonPressed = false;
+				isButtonPressed = false;
 				mouseFlag = ProcessButtonClickedEvent (cev);
 
 			} else if (((cev.ButtonState == Curses.Event.Button1Pressed || cev.ButtonState == Curses.Event.Button2Pressed ||
-				cev.ButtonState == Curses.Event.Button3Pressed) && LastMouseButtonPressed == null) ||
-				IsButtonPressed && cev.ButtonState == Curses.Event.ReportMousePosition) {
+				cev.ButtonState == Curses.Event.Button3Pressed) && lastMouseButtonPressed == null) ||
+				isButtonPressed && cev.ButtonState == Curses.Event.ReportMousePosition) {
 
 				mouseFlag = MapCursesButton (cev.ButtonState);
 				if (cev.ButtonState != Curses.Event.ReportMousePosition)
-					LastMouseButtonPressed = cev.ButtonState;
-				IsButtonPressed = true;
+					lastMouseButtonPressed = cev.ButtonState;
+				isButtonPressed = true;
 				isReportMousePosition = false;
 
 				if (cev.ButtonState == Curses.Event.ReportMousePosition) {
-					mouseFlag = MapCursesButton ((Curses.Event)LastMouseButtonPressed) | MouseFlags.ReportMousePosition;
+					mouseFlag = MapCursesButton ((Curses.Event)lastMouseButtonPressed) | MouseFlags.ReportMousePosition;
 					point = new Point ();
 					cancelButtonClicked = true;
 				} else {
@@ -293,7 +293,10 @@ namespace Terminal.Gui {
 				}
 
 				if ((mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-					ProcessContinuousButtonPressedAsync (cev, mouseFlag).ConfigureAwait (false);
+					Application.MainLoop.AddIdle (() => {
+						Task.Run (async () => await ProcessContinuousButtonPressedAsync (cev, mouseFlag));
+						return false;
+					});
 				}
 
 
@@ -301,7 +304,7 @@ namespace Terminal.Gui {
 				cev.ButtonState == Curses.Event.Button3Released)) {
 
 				mouseFlag = ProcessButtonReleasedEvent (cev);
-				IsButtonPressed = false;
+				isButtonPressed = false;
 
 			} else if (cev.ButtonState == Curses.Event.ButtonWheeledUp) {
 
@@ -320,9 +323,13 @@ namespace Terminal.Gui {
 				mouseFlag = MouseFlags.WheeledRight;
 
 			} else if (cev.ButtonState == Curses.Event.ReportMousePosition) {
-
-				mouseFlag = MouseFlags.ReportMousePosition;
-				isReportMousePosition = true;
+				if (cev.X != point.X || cev.Y != point.Y) {
+					mouseFlag = MouseFlags.ReportMousePosition;
+					isReportMousePosition = true;
+					point = new Point ();
+				} else {
+					mouseFlag = 0;
+				}
 
 			} else {
 				mouseFlag = 0;
@@ -336,11 +343,6 @@ namespace Terminal.Gui {
 
 			mouseFlag = SetControlKeyStates (cev, mouseFlag);
 
-			point = new Point () {
-				X = cev.X,
-				Y = cev.Y
-			};
-
 			return new MouseEvent () {
 				X = cev.X,
 				Y = cev.Y,
@@ -351,24 +353,24 @@ namespace Terminal.Gui {
 
 		MouseFlags ProcessButtonClickedEvent (Curses.MouseEvent cev)
 		{
-			LastMouseButtonPressed = cev.ButtonState;
+			lastMouseButtonPressed = cev.ButtonState;
 			var mf = GetButtonState (cev, true);
 			mouseHandler (ProcessButtonState (cev, mf));
-			if (LastMouseButtonPressed != null && LastMouseButtonPressed == cev.ButtonState) {
+			if (lastMouseButtonPressed != null && lastMouseButtonPressed == cev.ButtonState) {
 				mf = GetButtonState (cev, false);
 				mouseHandler (ProcessButtonState (cev, mf));
-				if (LastMouseButtonPressed != null && LastMouseButtonPressed == cev.ButtonState) {
+				if (lastMouseButtonPressed != null && lastMouseButtonPressed == cev.ButtonState) {
 					mf = MapCursesButton (cev.ButtonState);
 				}
 			}
-			LastMouseButtonPressed = null;
+			lastMouseButtonPressed = null;
 			return mf;
 		}
 
 		MouseFlags ProcessButtonReleasedEvent (Curses.MouseEvent cev)
 		{
 			var mf = MapCursesButton (cev.ButtonState);
-			if (!cancelButtonClicked && LastMouseButtonPressed == null && !isReportMousePosition) {
+			if (!cancelButtonClicked && lastMouseButtonPressed == null && !isReportMousePosition) {
 				mouseHandler (ProcessButtonState (cev, mf));
 				mf = GetButtonState (cev);
 			} else if (isReportMousePosition) {
@@ -380,7 +382,7 @@ namespace Terminal.Gui {
 
 		async Task ProcessContinuousButtonPressedAsync (Curses.MouseEvent cev, MouseFlags mouseFlag)
 		{
-			while (IsButtonPressed && LastMouseButtonPressed != null) {
+			while (isButtonPressed && lastMouseButtonPressed != null) {
 				await Task.Delay (100);
 				var me = new MouseEvent () {
 					X = cev.X,
@@ -391,9 +393,8 @@ namespace Terminal.Gui {
 				var view = Application.wantContinuousButtonPressedView;
 				if (view == null)
 					break;
-				if (IsButtonPressed && LastMouseButtonPressed != null && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
+				if (isButtonPressed && lastMouseButtonPressed != null && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
 					mouseHandler (me);
-					//mainLoop.Driver.Wakeup ();
 				}
 			}
 		}
@@ -434,7 +435,6 @@ namespace Terminal.Gui {
 			case Curses.Event.Button3Released:
 				mf = MouseFlags.Button3Clicked;
 				break;
-
 
 			}
 			return mf;
@@ -518,6 +518,7 @@ namespace Terminal.Gui {
 		{
 			int wch;
 			var code = Curses.get_wch (out wch);
+			//System.Diagnostics.Debug.WriteLine ($"code: {code}; wch: {wch}");
 			if (code == Curses.ERR)
 				return;
 

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -382,6 +382,7 @@ namespace Terminal.Gui {
 
 		async Task ProcessContinuousButtonPressedAsync (Curses.MouseEvent cev, MouseFlags mouseFlag)
 		{
+			await Task.Delay (200);
 			while (isButtonPressed && lastMouseButtonPressed != null) {
 				await Task.Delay (100);
 				var me = new MouseEvent () {
@@ -394,7 +395,7 @@ namespace Terminal.Gui {
 				if (view == null)
 					break;
 				if (isButtonPressed && lastMouseButtonPressed != null && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-					mouseHandler (me);
+					Application.MainLoop.Invoke (() => mouseHandler (me));
 				}
 			}
 		}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -987,6 +987,7 @@ namespace Terminal.Gui {
 
 		async Task ProcessContinuousButtonPressedAsync (WindowsConsole.MouseEventRecord mouseEvent, MouseFlags mouseFlag)
 		{
+			await Task.Delay (200);
 			while (isButtonPressed) {
 				await Task.Delay (100);
 				var me = new MouseEvent () {
@@ -1000,7 +1001,7 @@ namespace Terminal.Gui {
 					break;
 				}
 				if (isButtonPressed && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
-					mouseHandler (me);
+					Application.MainLoop.Invoke (() => mouseHandler (me));
 				}
 			}
 		}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -240,9 +240,7 @@ namespace Terminal.Gui {
 			Button2Pressed = 4,
 			Button3Pressed = 8,
 			Button4Pressed = 16,
-			RightmostButtonPressed = 2,
-			WheeledUp = unchecked((int)0x780000),
-			WheeledDown = unchecked((int)0xFF880000),
+			RightmostButtonPressed = 2
 		}
 
 		[Flags]
@@ -771,7 +769,7 @@ namespace Terminal.Gui {
 
 			case WindowsConsole.EventType.Mouse:
 				mouseHandler (ToDriverMouse (inputEvent.MouseEvent));
-				if (IsButtonReleased)
+				if (isButtonReleased)
 					mouseHandler (ToDriverMouse (inputEvent.MouseEvent));
 				break;
 
@@ -788,19 +786,19 @@ namespace Terminal.Gui {
 			}
 		}
 
-		WindowsConsole.ButtonState? LastMouseButtonPressed = null;
-		bool IsButtonPressed = false;
-		bool IsButtonReleased = false;
-		bool IsButtonDoubleClicked = false;
+		WindowsConsole.ButtonState? lastMouseButtonPressed = null;
+		bool isButtonPressed = false;
+		bool isButtonReleased = false;
+		bool isButtonDoubleClicked = false;
 		Point point;
 
 		MouseEvent ToDriverMouse (WindowsConsole.MouseEventRecord mouseEvent)
 		{
 			MouseFlags mouseFlag = MouseFlags.AllEvents;
 
-			if (IsButtonDoubleClicked) {
+			if (isButtonDoubleClicked) {
 				Application.MainLoop.AddIdle (() => {
-					ProcessButtonDoubleClickedAsync ().ConfigureAwait (false);
+					Task.Run (async () => await ProcessButtonDoubleClickedAsync ());
 					return false;
 				});
 			}
@@ -810,10 +808,10 @@ namespace Terminal.Gui {
 			// be fired with it's bit set to 0. So when the button is up ButtonState will be 0.
 			// To map to the correct driver events we save the last pressed mouse button so we can
 			// map to the correct clicked event.
-			if ((LastMouseButtonPressed != null || IsButtonReleased) && mouseEvent.ButtonState != 0) {
-				LastMouseButtonPressed = null;
-				IsButtonPressed = false;
-				IsButtonReleased = false;
+			if ((lastMouseButtonPressed != null || isButtonReleased) && mouseEvent.ButtonState != 0) {
+				lastMouseButtonPressed = null;
+				isButtonPressed = false;
+				isButtonReleased = false;
 			}
 
 			var p = new Point () {
@@ -821,9 +819,9 @@ namespace Terminal.Gui {
 				Y = mouseEvent.MousePosition.Y
 			};
 
-			if ((mouseEvent.ButtonState != 0 && mouseEvent.EventFlags == 0 && LastMouseButtonPressed == null && !IsButtonDoubleClicked) ||
+			if ((mouseEvent.ButtonState != 0 && mouseEvent.EventFlags == 0 && lastMouseButtonPressed == null && !isButtonDoubleClicked) ||
 				(mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved &&
-				mouseEvent.ButtonState != 0 && !IsButtonReleased && !IsButtonDoubleClicked)) {
+				mouseEvent.ButtonState != 0 && !isButtonReleased && !isButtonDoubleClicked)) {
 				switch (mouseEvent.ButtonState) {
 				case WindowsConsole.ButtonState.Button1Pressed:
 					mouseFlag = MouseFlags.Button1Pressed;
@@ -841,26 +839,27 @@ namespace Terminal.Gui {
 				if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) {
 					mouseFlag |= MouseFlags.ReportMousePosition;
 					point = new Point ();
-					IsButtonReleased = false;
+					isButtonReleased = false;
 				} else {
 					point = new Point () {
 						X = mouseEvent.MousePosition.X,
 						Y = mouseEvent.MousePosition.Y
 					};
 				}
-				LastMouseButtonPressed = mouseEvent.ButtonState;
-				IsButtonPressed = true;
+				lastMouseButtonPressed = mouseEvent.ButtonState;
+				isButtonPressed = true;
 
 				if ((mouseFlag & MouseFlags.ReportMousePosition) == 0) {
 					Application.MainLoop.AddIdle (() => {
-						ProcessContinuousButtonPressedAsync (mouseEvent, mouseFlag).ConfigureAwait (false);
+						Task.Run (async () => await ProcessContinuousButtonPressedAsync (mouseEvent, mouseFlag));
 						return false;
 					});
 				}
 
+
 			} else if ((mouseEvent.EventFlags == 0 || mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) &&
-				LastMouseButtonPressed != null && !IsButtonReleased && !IsButtonDoubleClicked) {
-				switch (LastMouseButtonPressed) {
+				lastMouseButtonPressed != null && !isButtonReleased && !isButtonDoubleClicked) {
+				switch (lastMouseButtonPressed) {
 				case WindowsConsole.ButtonState.Button1Pressed:
 					mouseFlag = MouseFlags.Button1Released;
 					break;
@@ -873,11 +872,11 @@ namespace Terminal.Gui {
 					mouseFlag = MouseFlags.Button3Released;
 					break;
 				}
-				IsButtonPressed = false;
-				IsButtonReleased = true;
+				isButtonPressed = false;
+				isButtonReleased = true;
 			} else if ((mouseEvent.EventFlags == 0 || mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) &&
-				  IsButtonReleased && p == point) {
-				switch (LastMouseButtonPressed) {
+				  isButtonReleased && p == point) {
+				switch (lastMouseButtonPressed) {
 				case WindowsConsole.ButtonState.Button1Pressed:
 					mouseFlag = MouseFlags.Button1Clicked;
 					break;
@@ -894,8 +893,8 @@ namespace Terminal.Gui {
 					X = mouseEvent.MousePosition.X,
 					Y = mouseEvent.MousePosition.Y
 				};
-				LastMouseButtonPressed = null;
-				IsButtonReleased = false;
+				lastMouseButtonPressed = null;
+				isButtonReleased = false;
 			} else if (mouseEvent.EventFlags.HasFlag (WindowsConsole.EventFlags.DoubleClick)) {
 				switch (mouseEvent.ButtonState) {
 				case WindowsConsole.ButtonState.Button1Pressed:
@@ -910,8 +909,8 @@ namespace Terminal.Gui {
 					mouseFlag = MouseFlags.Button3DoubleClicked;
 					break;
 				}
-				IsButtonDoubleClicked = true;
-			} else if (mouseEvent.EventFlags == 0 && mouseEvent.ButtonState != 0 && IsButtonDoubleClicked) {
+				isButtonDoubleClicked = true;
+			} else if (mouseEvent.EventFlags == 0 && mouseEvent.ButtonState != 0 && isButtonDoubleClicked) {
 				switch (mouseEvent.ButtonState) {
 				case WindowsConsole.ButtonState.Button1Pressed:
 					mouseFlag = MouseFlags.Button1TripleClicked;
@@ -925,26 +924,37 @@ namespace Terminal.Gui {
 					mouseFlag = MouseFlags.Button3TripleClicked;
 					break;
 				}
-				IsButtonDoubleClicked = false;
+				isButtonDoubleClicked = false;
 			} else if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseWheeled) {
-				switch (mouseEvent.ButtonState) {
-				case WindowsConsole.ButtonState.WheeledUp:
+				switch ((int)mouseEvent.ButtonState) {
+				case int v when v > 0:
 					mouseFlag = MouseFlags.WheeledUp;
 					break;
 
-				case WindowsConsole.ButtonState.WheeledDown:
+				case int v when v < 0:
 					mouseFlag = MouseFlags.WheeledDown;
 					break;
 				}
 
 			} else if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseWheeled &&
 				mouseEvent.ControlKeyState == WindowsConsole.ControlKeyState.ShiftPressed) {
-				switch (mouseEvent.ButtonState) {
-				case WindowsConsole.ButtonState.WheeledUp:
+				switch ((int)mouseEvent.ButtonState) {
+				case int v when v > 0:
 					mouseFlag = MouseFlags.WheeledLeft;
 					break;
 
-				case WindowsConsole.ButtonState.WheeledDown:
+				case int v when v < 0:
+					mouseFlag = MouseFlags.WheeledRight;
+					break;
+				}
+
+			} else if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseHorizontalWheeled) {
+				switch ((int)mouseEvent.ButtonState) {
+				case int v when v < 0:
+					mouseFlag = MouseFlags.WheeledLeft;
+					break;
+
+				case int v when v > 0:
 					mouseFlag = MouseFlags.WheeledRight;
 					break;
 				}
@@ -972,12 +982,12 @@ namespace Terminal.Gui {
 		async Task ProcessButtonDoubleClickedAsync ()
 		{
 			await Task.Delay (200);
-			IsButtonDoubleClicked = false;
+			isButtonDoubleClicked = false;
 		}
 
 		async Task ProcessContinuousButtonPressedAsync (WindowsConsole.MouseEventRecord mouseEvent, MouseFlags mouseFlag)
 		{
-			while (IsButtonPressed) {
+			while (isButtonPressed) {
 				await Task.Delay (100);
 				var me = new MouseEvent () {
 					X = mouseEvent.MousePosition.X,
@@ -989,7 +999,7 @@ namespace Terminal.Gui {
 				if (view == null) {
 					break;
 				}
-				if (IsButtonPressed && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
+				if (isButtonPressed && (mouseFlag & MouseFlags.ReportMousePosition) == 0) {
 					mouseHandler (me);
 				}
 			}
@@ -1472,8 +1482,7 @@ namespace Terminal.Gui {
 
 			try {
 				ProcessInput (input);
-			} catch (OverflowException) { }
-			finally {
+			} catch (OverflowException) { } finally {
 				keyEvent.bKeyDown = false;
 				input.KeyEvent = keyEvent;
 				ProcessInput (input);
@@ -1526,7 +1535,7 @@ namespace Terminal.Gui {
 		{
 			this.mainLoop = mainLoop;
 			Task.Run (WindowsInputHandler);
-			// Nor working yet.
+			// Not working yet.
 			//Task.Run (CheckWinChange);
 		}
 


### PR DESCRIPTION
Is possible scroll on a touchpad sliding with two fingers in the vertical and horizontal direction.
- `WindowsDriver` now supports horizontal scroll.
- `NetDriver` don't supports horizontal scroll. On `Windows` and `WSL 2` always returns scroll down for left and right scrolling. On a real `Linux` the horizontal is not caught by the `System.Console.ReadKey`.
- `CursesDriver` don't also supports the horizontal scroll, because `UnixMainLoop` don't caught any event.