### PR TITLE
Fix version conflicts caused by PR#1412

### DIFF
--- a/ReactiveExample/ReactiveExample.csproj
+++ b/ReactiveExample/ReactiveExample.csproj
@@ -7,7 +7,7 @@
         <PackageReference Include="Pharmacist.MsBuild" Version="2.0.8" PrivateAssets="all" />
         <PackageReference Include="Pharmacist.Common" Version="2.0.8" />
         <PackageReference Include="Terminal.Gui" Version="1.1.1.*" />
-        <PackageReference Include="ReactiveUI.Fody" Version="14.1.1" />
-        <PackageReference Include="ReactiveUI" Version="14.1.1" />
+        <PackageReference Include="ReactiveUI.Fody" Version="14.2.1" />
+        <PackageReference Include="ReactiveUI" Version="14.2.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump ReactiveUI.Fody from 14.1.1 to 14.2.1. [(PR#1412)](https://github.com/migueldeicaza/gui.cs/pull/1412).
Hope this fix can help you.

Best regards,
sucrose