### PR TITLE
Correctly mark the .NET Framework reference assemblies as private.

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -8,16 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="true" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="NStack.Core" Version="0.16.0" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <InternalsVisibleTo Include="UnitTests" />
     <!-- <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" /> -->
-	  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>UnitTests</_Parameter1>
-    </AssemblyAttribute>
   </ItemGroup>
   <PropertyGroup>
       <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>


### PR DESCRIPTION
And use a built-in MSBuild item to apply the `InternalsVisibleToAttribute` (available since at least the .NET 5 SDK which is already required by `global.json`).