### PR TITLE
Fixes CursesDriver mouse and reset issue.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -298,6 +298,7 @@ namespace Terminal.Gui {
 					mouseFlag = MouseFlags.Button3DoubleClicked;
 					break;
 				}
+				cancelButtonClicked = true;
 
 			} else if (buttonPressedCount == 3
 			       && (cev.ButtonState == Curses.Event.Button1Pressed
@@ -328,7 +329,7 @@ namespace Terminal.Gui {
 
 			} else if (((cev.ButtonState == Curses.Event.Button1Pressed || cev.ButtonState == Curses.Event.Button2Pressed ||
 				cev.ButtonState == Curses.Event.Button3Pressed) && lastMouseButtonPressed == null) ||
-				isButtonPressed && cev.ButtonState == Curses.Event.ReportMousePosition) {
+				isButtonPressed && lastMouseButtonPressed != null && cev.ButtonState == Curses.Event.ReportMousePosition) {
 
 				mouseFlag = MapCursesButton (cev.ButtonState);
 				if (cev.ButtonState != Curses.Event.ReportMousePosition)
@@ -419,6 +420,7 @@ namespace Terminal.Gui {
 				}
 			}
 			lastMouseButtonPressed = null;
+			isButtonPressed = false;
 			return mf;
 		}
 
@@ -782,6 +784,9 @@ namespace Terminal.Gui {
 			} catch (Exception e) {
 				Console.WriteLine ("Curses failed to initialize, the exception is: " + e);
 			}
+
+			// Ensures that all procedures are performed at some previous closing.
+			Curses.doupdate ();
 
 			// 
 			// We are setting Invisible as default so we could ignore XTerm DECSUSR setting

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/binding.cs
@@ -103,6 +103,9 @@ namespace Unix.Terminal {
 			setlocale (LC_ALL, "");
 			FindNCurses ();
 
+			// Prevents the terminal from being locked after exiting.
+			reset_shell_mode ();
+
 			main_window = new Window (methods.initscr ());
 			try {
 				console_sharp_get_dims (out lines, out cols);
@@ -310,6 +313,14 @@ namespace Unix.Terminal {
 		static public bool is_term_resized (int lines, int columns) => methods.is_term_resized (lines, columns);
 		static public int resize_term (int lines, int columns) => methods.resize_term (lines, columns);
 		static public int resizeterm (int lines, int columns) => methods.resizeterm (lines, columns);
+		static public void use_env (bool f) => methods.use_env (f);
+		static public int flushinp () => methods.flushinp ();
+		static public int def_prog_mode () => methods.def_prog_mode ();
+		static public int def_shell_mode () => methods.def_shell_mode ();
+		static public int reset_prog_mode () => methods.reset_prog_mode ();
+		static public int reset_shell_mode () => methods.reset_shell_mode ();
+		static public int savetty () => methods.savetty ();
+		static public int resetty () => methods.resetty ();
 	}
 
 #pragma warning disable RCS1102 // Make class static.
@@ -375,6 +386,14 @@ namespace Unix.Terminal {
 		public delegate bool is_term_resized (int lines, int columns);
 		public delegate int resize_term (int lines, int columns);
 		public delegate int resizeterm (int lines, int columns);
+		public delegate void use_env (bool f);
+		public delegate int flushinp ();
+		public delegate int def_prog_mode ();
+		public delegate int def_shell_mode ();
+		public delegate int reset_prog_mode ();
+		public delegate int reset_shell_mode ();
+		public delegate int savetty ();
+		public delegate int resetty ();
 	}
 
 	internal class NativeMethods {
@@ -438,6 +457,14 @@ namespace Unix.Terminal {
 		public readonly Delegates.is_term_resized is_term_resized;
 		public readonly Delegates.resize_term resize_term;
 		public readonly Delegates.resizeterm resizeterm;
+		public readonly Delegates.use_env use_env;
+		public readonly Delegates.flushinp flushinp;
+		public readonly Delegates.def_prog_mode def_prog_mode;
+		public readonly Delegates.def_shell_mode def_shell_mode;
+		public readonly Delegates.reset_prog_mode reset_prog_mode;
+		public readonly Delegates.reset_shell_mode reset_shell_mode;
+		public readonly Delegates.savetty savetty;
+		public readonly Delegates.resetty resetty;
 		public UnmanagedLibrary UnmanagedLibrary;
 
 		public NativeMethods (UnmanagedLibrary lib)
@@ -503,6 +530,14 @@ namespace Unix.Terminal {
 			is_term_resized = lib.GetNativeMethodDelegate<Delegates.is_term_resized> ("is_term_resized");
 			resize_term = lib.GetNativeMethodDelegate<Delegates.resize_term> ("resize_term");
 			resizeterm = lib.GetNativeMethodDelegate<Delegates.resizeterm> ("resizeterm");
+			use_env = lib.GetNativeMethodDelegate<Delegates.use_env> ("use_env");
+			flushinp = lib.GetNativeMethodDelegate<Delegates.flushinp> ("flushinp");
+			def_prog_mode = lib.GetNativeMethodDelegate<Delegates.def_prog_mode> ("def_prog_mode");
+			def_shell_mode = lib.GetNativeMethodDelegate<Delegates.def_shell_mode> ("def_shell_mode");
+			reset_prog_mode = lib.GetNativeMethodDelegate<Delegates.reset_prog_mode> ("reset_prog_mode");
+			reset_shell_mode = lib.GetNativeMethodDelegate<Delegates.reset_shell_mode> ("reset_shell_mode");
+			savetty = lib.GetNativeMethodDelegate<Delegates.savetty> ("savetty");
+			resetty = lib.GetNativeMethodDelegate<Delegates.resetty> ("resetty");
 		}
 	}
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member


### PR DESCRIPTION
### This PR fixes the following issues:

1. Open the `Editor` scenario and do a double or triple click on some text. The text will not selecting because there is a bug on a double or triple click, that is causing an extra click event and, thus, deselecting the text.
2. Only with `WSL`, open the `Mouse` scenario and moving the mouse you will see the `ReportMousePosition` event. Now press `Esc` to exit and open the `Mouse` scenario again. You won't see the `ReportMousePosition` again. On a real `Linux` this doesn't happen.
3. As discussed here https://github.com/migueldeicaza/gui.cs/issues/945#issuecomment-708669985, running on `CursesDriver`, when exiting the application, the terminal isn't restored, forcing to typing "`reset`" to restore. This was one of the most hard issue I had to fix, although the solution be so easy.

Fixes #1428