### PR TITLE
WindowsDriver double click mouse bug fix.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -768,9 +768,16 @@ namespace Terminal.Gui {
 				break;
 
 			case WindowsConsole.EventType.Mouse:
-				mouseHandler (ToDriverMouse (inputEvent.MouseEvent));
-				if (isButtonReleased)
-					mouseHandler (ToDriverMouse (inputEvent.MouseEvent));
+				var me = ToDriverMouse (inputEvent.MouseEvent);
+				mouseHandler (me);
+				if (isButtonReleased) {
+					mouseHandler (
+						new MouseEvent () {
+							X = me.X,
+							Y = me.Y,
+							Flags = ProcessButtonClick (inputEvent.MouseEvent)
+						});
+				}
 				break;
 
 			case WindowsConsole.EventType.WindowBufferSize:
@@ -800,7 +807,7 @@ namespace Terminal.Gui {
 
 			//System.Diagnostics.Debug.WriteLine ($"ButtonState: {mouseEvent.ButtonState};EventFlags: {mouseEvent.EventFlags}");
 
-			if (isButtonDoubleClicked) {
+			if (isButtonDoubleClicked || isOneFingerDoubleClicked) {
 				Application.MainLoop.AddIdle (() => {
 					Task.Run (async () => await ProcessButtonDoubleClickedAsync ());
 					return false;
@@ -835,13 +842,11 @@ namespace Terminal.Gui {
 				&& mouseEvent.EventFlags == 0) {
 
 				buttonPressedCount++;
-			} else {
-				buttonPressedCount = 0;
-				isOneFingerDoubleClicked = false;
 			}
 			//System.Diagnostics.Debug.WriteLine ($"isButtonPressed: {isButtonPressed};buttonPressedCount: {buttonPressedCount};lastMouseButtonPressed: {lastMouseButtonPressed}");
+			//System.Diagnostics.Debug.WriteLine ($"isOneFingerDoubleClicked: {isOneFingerDoubleClicked}");
 
-			if (buttonPressedCount == 3 && lastMouseButtonPressed != null
+			if (buttonPressedCount == 1 && lastMouseButtonPressed != null
 				&& lastMouseButtonPressed == WindowsConsole.ButtonState.Button1Pressed
 				|| lastMouseButtonPressed == WindowsConsole.ButtonState.Button2Pressed
 				|| lastMouseButtonPressed == WindowsConsole.ButtonState.Button3Pressed) {
@@ -861,7 +866,7 @@ namespace Terminal.Gui {
 				}
 				isOneFingerDoubleClicked = true;
 
-			} else if (buttonPressedCount == 5 && lastMouseButtonPressed != null && isOneFingerDoubleClicked
+			} else if (buttonPressedCount == 3 && lastMouseButtonPressed != null && isOneFingerDoubleClicked
 				&& lastMouseButtonPressed == WindowsConsole.ButtonState.Button1Pressed
 				|| lastMouseButtonPressed == WindowsConsole.ButtonState.Button2Pressed
 				|| lastMouseButtonPressed == WindowsConsole.ButtonState.Button3Pressed) {
@@ -921,8 +926,8 @@ namespace Terminal.Gui {
 					});
 				}
 
-			} else if ((mouseEvent.EventFlags == 0 || mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved) &&
-				lastMouseButtonPressed != null && !isButtonReleased && !isButtonDoubleClicked) {
+			} else if (lastMouseButtonPressed != null && mouseEvent.EventFlags == 0
+				&& !isButtonReleased && !isButtonDoubleClicked && !isOneFingerDoubleClicked) {
 				switch (lastMouseButtonPressed) {
 				case WindowsConsole.ButtonState.Button1Pressed:
 					mouseFlag = MouseFlags.Button1Released;
@@ -938,27 +943,11 @@ namespace Terminal.Gui {
 				}
 				isButtonPressed = false;
 				isButtonReleased = true;
-			} else if ((mouseEvent.EventFlags == 0 || mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved)
+			} else if (mouseEvent.EventFlags == WindowsConsole.EventFlags.MouseMoved
 				&& !isOneFingerDoubleClicked && isButtonReleased && p == point) {
-				switch (lastMouseButtonPressed) {
-				case WindowsConsole.ButtonState.Button1Pressed:
-					mouseFlag = MouseFlags.Button1Clicked;
-					break;
 
-				case WindowsConsole.ButtonState.Button2Pressed:
-					mouseFlag = MouseFlags.Button2Clicked;
-					break;
+				mouseFlag = ProcessButtonClick (mouseEvent);
 
-				case WindowsConsole.ButtonState.RightmostButtonPressed:
-					mouseFlag = MouseFlags.Button3Clicked;
-					break;
-				}
-				point = new Point () {
-					X = mouseEvent.MousePosition.X,
-					Y = mouseEvent.MousePosition.Y
-				};
-				lastMouseButtonPressed = null;
-				isButtonReleased = false;
 			} else if (mouseEvent.EventFlags.HasFlag (WindowsConsole.EventFlags.DoubleClick)) {
 				switch (mouseEvent.ButtonState) {
 				case WindowsConsole.ButtonState.Button1Pressed:
@@ -1043,10 +1032,37 @@ namespace Terminal.Gui {
 			};
 		}
 
+		MouseFlags ProcessButtonClick (WindowsConsole.MouseEventRecord mouseEvent)
+		{
+			MouseFlags mouseFlag = 0;
+			switch (lastMouseButtonPressed) {
+			case WindowsConsole.ButtonState.Button1Pressed:
+				mouseFlag = MouseFlags.Button1Clicked;
+				break;
+
+			case WindowsConsole.ButtonState.Button2Pressed:
+				mouseFlag = MouseFlags.Button2Clicked;
+				break;
+
+			case WindowsConsole.ButtonState.RightmostButtonPressed:
+				mouseFlag = MouseFlags.Button3Clicked;
+				break;
+			}
+			point = new Point () {
+				X = mouseEvent.MousePosition.X,
+				Y = mouseEvent.MousePosition.Y
+			};
+			lastMouseButtonPressed = null;
+			isButtonReleased = false;
+			return mouseFlag;
+		}
+
 		async Task ProcessButtonDoubleClickedAsync ()
 		{
-			await Task.Delay (200);
+			await Task.Delay (300);
 			isButtonDoubleClicked = false;
+			isOneFingerDoubleClicked = false;
+			buttonPressedCount = 0;
 		}
 
 		async Task ProcessContinuousButtonPressedAsync (WindowsConsole.MouseEventRecord mouseEvent, MouseFlags mouseFlag)


### PR DESCRIPTION
Open the `Buttons` scenario or the `Editor` scenario with a double click through a laptop touchpad and what is focused is the `Windows` and not the `TextField` or the `TextView`.