### PR TITLE
Fixed bug setting ColorScheme on Autocomplete

### DIFF
--- a/Terminal.Gui/Core/Autocomplete.cs
+++ b/Terminal.Gui/Core/Autocomplete.cs
@@ -67,7 +67,7 @@ namespace Terminal.Gui {
 			}
 		 	set
 			{
-				ColorScheme = value;
+				colorScheme = value;
 			}
 		}
 

--- a/UnitTests/AutocompleteTests.cs
+++ b/UnitTests/AutocompleteTests.cs
@@ -25,5 +25,33 @@ namespace UnitTests {
 			Assert.Equal ("Cobble", ac.Suggestions[1]);
 
 		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void TestSettingColorSchemeOnAutocomplete ()
+		{
+			var tv = new TextView ();
+
+			// to begin with we should be using the default menu color scheme
+			Assert.Same (Colors.Menu, tv.Autocomplete.ColorScheme);
+
+			// allocate a new custom scheme
+			tv.Autocomplete.ColorScheme = new ColorScheme () {
+				Normal = Application.Driver.MakeAttribute (Color.Black, Color.Blue),
+				Focus = Application.Driver.MakeAttribute (Color.Black, Color.Cyan),
+			};
+
+			// should be seperate instance
+			Assert.NotSame (Colors.Menu, tv.Autocomplete.ColorScheme);
+
+			// with the values we set on it
+			Assert.Equal (Color.Black, tv.Autocomplete.ColorScheme.Normal.Foreground);
+			Assert.Equal (Color.Blue, tv.Autocomplete.ColorScheme.Normal.Background);
+
+			Assert.Equal (Color.Black, tv.Autocomplete.ColorScheme.Focus.Foreground);
+			Assert.Equal (Color.Cyan, tv.Autocomplete.ColorScheme.Focus.Background);
+
+
+		}
 	}
 }


### PR DESCRIPTION
There is a typo in Autocomplete that results in ColorScheme setter calling itself which causes StackOverflowException.  This PR fixes and adds a test.