### PR TITLE
feature: Don't pull Terminal.Gui from NuGet, use ReactiveMarbles.ObservableEvents

### DIFF
--- a/ReactiveExample/LoginView.cs
+++ b/ReactiveExample/LoginView.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using NStack;
 using ReactiveUI;
 using Terminal.Gui;
+using ReactiveMarbles.ObservableEvents;
 
 namespace ReactiveExample {
 	public class LoginView : Window, IViewFor<LoginViewModel> {

--- a/ReactiveExample/ReactiveExample.csproj
+++ b/ReactiveExample/ReactiveExample.csproj
@@ -4,10 +4,14 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Pharmacist.MsBuild" Version="2.0.8" PrivateAssets="all" />
-        <PackageReference Include="Pharmacist.Common" Version="2.0.8" />
-        <PackageReference Include="Terminal.Gui" Version="1.1.1.*" />
         <PackageReference Include="ReactiveUI.Fody" Version="14.2.1" />
         <PackageReference Include="ReactiveUI" Version="14.2.1" />
+        <PackageReference
+            Include="ReactiveMarbles.ObservableEvents.SourceGenerator"
+            Version="1.1.3"
+            PrivateAssets="all" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Terminal.Gui\Terminal.Gui.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This replaces [Pharmacist](http://github.com/reactiveui/pharmacist) with [ReactiveMarbles.ObservableEvents](https://github.com/reactivemarbles/observableevents) which is a successor for Pharmacist.
Based on https://github.com/migueldeicaza/gui.cs/issues/1132#issuecomment-903699483