### PR TITLE
Use custom resolver for libcoreclr.so also for .NET 6.0

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
@@ -258,7 +258,7 @@ namespace Unix.Terminal {
 		/// </summary>
 		static class CoreCLR
 		{
-#if NET6_0 || NET5_0
+#if NET6_0
 			// Custom resolver to support true single-file apps
 			// (those which run directly from bundle; in-memory).
 			//     -1 on Unix means self-referencing binary (libcoreclr.so)

--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/UnmanagedLibrary.cs
@@ -258,7 +258,7 @@ namespace Unix.Terminal {
 		/// </summary>
 		static class CoreCLR
 		{
-#if NET5_0
+#if NET6_0 || NET5_0
 			// Custom resolver to support true single-file apps
 			// (those which run directly from bundle; in-memory).
 			//     -1 on Unix means self-referencing binary (libcoreclr.so)


### PR DESCRIPTION
Running into the same issue as in #889, I noticed the custom resolver code was not included for .NET 6.0 . This patch fixes the `System.DllNotFoundException` for single-file mode also in .NET 6.0