### PR TITLE
Fixes #1577 - Add Support for Colored ListView Items

### DIFF
--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -767,12 +767,15 @@ namespace Terminal.Gui {
 		IList src;
 		BitArray marks;
 		int count, len;
+		Color[] fore, back;
 
 		/// <summary>
 		/// Initializes a new instance of <see cref="ListWrapper"/> given an <see cref="IList"/>
 		/// </summary>
 		/// <param name="source"></param>
-		public ListWrapper (IList source)
+		/// <param name="fore"></param>
+		/// <param name="back"></param>
+		public ListWrapper (IList source, Color[] fore = null, Color[] back = null)
 		{
 			if (source != null) {
 				count = source.Count;
@@ -780,6 +783,16 @@ namespace Terminal.Gui {
 				src = source;
 				len = GetMaxLengthItem ();
 			}
+
+			if (fore.Length == source.Count)
+				this.fore = fore;
+			else
+				throw new ArgumentException ("Size must be the same as source", "fore");
+
+			if (back.Length == source.Count)
+				this.back = back;
+			else
+				throw new ArgumentException ("Size must be the same as source", "back");
 		}
 
 		/// <summary>
@@ -854,6 +867,10 @@ namespace Terminal.Gui {
 			if (t == null) {
 				RenderUstr (driver, ustring.Make (""), col, line, width);
 			} else {
+				if (item != container.SelectedItem) {
+					driver.SetAttribute (new Attribute (fore[item], back[item]));
+				}
+
 				if (t is ustring u) {
 					RenderUstr (driver, u, col, line, width, start);
 				} else if (t is string s) {

--- a/UICatalog/Scenarios/ListViewWithSelection.cs
+++ b/UICatalog/Scenarios/ListViewWithSelection.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Terminal.Gui;
+using Attribute = Terminal.Gui.Attribute;
 
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "List View With Selection", Description: "ListView with columns and selection")]
@@ -53,6 +54,7 @@ namespace UICatalog.Scenarios {
 				AllowsMarking = false,
 				AllowsMultipleSelection = false
 			};
+			_listView.RowRender += ListView_RowRender;
 			Win.Add (_listView);
 
 			var _scrollBar = new ScrollBarView (_listView, true);
@@ -90,6 +92,22 @@ namespace UICatalog.Scenarios {
 			};
 			keepCheckBox.Toggled += (_) => _scrollBar.KeepContentAlwaysInViewport = keepCheckBox.Checked;
 			Win.Add (keepCheckBox);
+		}
+
+		private void ListView_RowRender (ListViewRowEventArgs obj)
+		{
+			if (obj.Row == _listView.SelectedItem) {
+				return;
+			}
+			if (_listView.AllowsMarking && _listView.Source.IsMarked (obj.Row)) {
+				obj.RowAttribute = new Attribute (Color.BrightRed, Color.BrightYellow);
+				return;
+			}
+			if (obj.Row % 2 == 0) {
+				obj.RowAttribute = new Attribute (Color.BrightGreen, Color.Magenta);
+			} else {
+				obj.RowAttribute = new Attribute (Color.BrightMagenta, Color.Green);
+			}
 		}
 
 		private void _customRenderCB_Toggled (bool prev)


### PR DESCRIPTION
We can now choose the color (background and foreground/text) we want to display each item.

You need to set a delegate to `ListView.RowRender(ListViewRowEventArgs obj)`, and set the `Attribute rowAttribute` property of the `obj`.
You can get the index of the row displayed with the `int Row` property of the `obj`.
This event is called for each row displayed.

Fixes #1577