### PR TITLE
Fixes #1584 - ComboBox is hiding elements below from being clicked/focused

### DIFF
--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -31,6 +31,8 @@ namespace Terminal.Gui {
 
 				// Only need to refresh list if its been added to a container view
 				if (SuperView != null && SuperView.Subviews.Contains (this)) {
+					SelectedItem = 0;
+					search.Text = "";
 					Search_Changed ("");
 					SetNeedsDisplay ();
 				}
@@ -64,7 +66,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		public event Action<ListViewItemEventArgs> OpenSelectedItem;
 
-        readonly IList searchset = new List<object> ();
+		readonly IList searchset = new List<object> ();
 		ustring text = "";
 		readonly TextField search;
 		readonly ListView listview;
@@ -156,13 +158,30 @@ namespace Terminal.Gui {
 			};
 		}
 
+		bool isShow = false;
+
+		private int selectedItem;
+
 		/// <summary>
 		/// Gets the index of the currently selected item in the <see cref="Source"/>
 		/// </summary>
 		/// <value>The selected item or -1 none selected.</value>
-		public int SelectedItem { private set; get; }
+		public int SelectedItem {
+			get => selectedItem;
+			set {
+				if (selectedItem != value && (value == -1
+					|| (source != null && value > -1 && value < source.Count))) {
 
-		bool isShow = false;
+					selectedItem = value;
+					if (selectedItem != -1) {
+						Text = source.ToList () [selectedItem].ToString ();
+					} else {
+						Text = "";
+					}
+					OnSelectedChanged ();
+				}
+			}
+		}
 
 		///<inheritdoc/>
 		public new ColorScheme ColorScheme {
@@ -398,7 +417,7 @@ namespace Terminal.Gui {
 			this.text = search.Text = text.ToString ();
 			search.CursorPosition = 0;
 			search.TextChanged += Search_Changed;
-			SelectedItem = GetSelectedItemFromSource (this.text);
+			selectedItem = GetSelectedItemFromSource (this.text);
 			OnSelectedChanged ();
 		}
 
@@ -454,7 +473,7 @@ namespace Terminal.Gui {
 
 		private void ResetSearchSet (bool noCopy = false)
 		{
-            searchset.Clear ();
+			searchset.Clear ();
 
 			if (autoHide || noCopy)
 				return;
@@ -498,7 +517,7 @@ namespace Terminal.Gui {
 		/// Consider making public
 		private void ShowList ()
 		{
-            listview.SetSource (searchset);
+			listview.SetSource (searchset);
 			listview.Clear (); // Ensure list shrinks in Dialog as you type
 			listview.Height = CalculatetHeight ();
 			this.SuperView?.BringSubviewToFront (this);

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -406,6 +406,8 @@ namespace Terminal.Gui {
 		{
 			isShow = false;
 			listview.TabStop = false;
+			HideList ();
+
 			if (listview.Source.Count == 0 || (searchset?.Count ?? 0) == 0) {
 				text = "";
 				return;
@@ -513,6 +515,7 @@ namespace Terminal.Gui {
 			Reset (SelectedItem > -1);
 			listview.Clear (rect);
 			listview.TabStop = false;
+			SuperView?.SendSubviewToBack (this);
 			SuperView?.SetNeedsDisplay (rect);
 		}
 

--- a/Terminal.Gui/Views/ComboBox.cs
+++ b/Terminal.Gui/Views/ComboBox.cs
@@ -31,7 +31,7 @@ namespace Terminal.Gui {
 
 				// Only need to refresh list if its been added to a container view
 				if (SuperView != null && SuperView.Subviews.Contains (this)) {
-					SelectedItem = 0;
+					SelectedItem = -1;
 					search.Text = "";
 					Search_Changed ("");
 					SetNeedsDisplay ();
@@ -158,9 +158,8 @@ namespace Terminal.Gui {
 			};
 		}
 
-		bool isShow = false;
-
-		private int selectedItem;
+		private bool isShow = false;
+		private int selectedItem = -1;
 
 		/// <summary>
 		/// Gets the index of the currently selected item in the <see cref="Source"/>
@@ -174,9 +173,9 @@ namespace Terminal.Gui {
 
 					selectedItem = value;
 					if (selectedItem != -1) {
-						Text = source.ToList () [selectedItem].ToString ();
+						SetValue (source.ToList () [selectedItem].ToString (), true);
 					} else {
-						Text = "";
+						SetValue ("", true);
 					}
 					OnSelectedChanged ();
 				}
@@ -263,6 +262,11 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool OnLeave (View view)
 		{
+			if (source?.Count > 0 && selectedItem > -1 && selectedItem < source.Count - 1
+				&& text != source.ToList () [selectedItem].ToString ()) {
+
+				SetValue (source.ToList () [selectedItem].ToString ());
+			}
 			if (autoHide && isShow && view != this && view != search && view != listview) {
 				isShow = false;
 				HideList ();
@@ -411,24 +415,26 @@ namespace Terminal.Gui {
 			}
 		}
 
-		private void SetValue (object text)
+		private void SetValue (object text, bool isFromSelectedItem = false)
 		{
 			search.TextChanged -= Search_Changed;
 			this.text = search.Text = text.ToString ();
 			search.CursorPosition = 0;
 			search.TextChanged += Search_Changed;
-			selectedItem = GetSelectedItemFromSource (this.text);
-			OnSelectedChanged ();
+			if (!isFromSelectedItem) {
+				selectedItem = GetSelectedItemFromSource (this.text);
+				OnSelectedChanged ();
+			}
 		}
 
 		private void Selected ()
 		{
 			isShow = false;
 			listview.TabStop = false;
-			HideList ();
 
 			if (listview.Source.Count == 0 || (searchset?.Count ?? 0) == 0) {
 				text = "";
+				HideList ();
 				return;
 			}
 
@@ -437,6 +443,7 @@ namespace Terminal.Gui {
 			Search_Changed (search.Text);
 			OnOpenSelectedItem ();
 			Reset (keepSearchText: true);
+			HideList ();
 		}
 
 		private int GetSelectedItemFromSource (ustring value)

--- a/UICatalog/Scenarios/ComboBoxIteration.cs
+++ b/UICatalog/Scenarios/ComboBoxIteration.cs
@@ -43,8 +43,10 @@ namespace UICatalog.Scenarios {
 			};
 
 			comboBox.SelectedItemChanged += (ListViewItemEventArgs text) => {
-				lbComboBox.Text = items [comboBox.SelectedItem];
-				listview.SelectedItem = text.Item;
+				if (text.Item != -1) {
+					lbComboBox.Text = text.Value.ToString ();
+					listview.SelectedItem = text.Item;
+				}
 			};
 			Win.Add (lbComboBox, comboBox);
 			Win.Add (new TextField { X = Pos.Right (listview) + 1, Y = Pos.Top (comboBox) + 3, Height = 1, Width = 20 });
@@ -56,6 +58,7 @@ namespace UICatalog.Scenarios {
 				items = new List<string> () { "one", "two" };
 				comboBox.SetSource (items);
 				listview.SetSource (items);
+				listview.SelectedItem = 0;
 			};
 			Win.Add (btnTwo);
 
@@ -67,6 +70,7 @@ namespace UICatalog.Scenarios {
 				items = new List<string> () { "one", "two", "three" };
 				comboBox.SetSource (items);
 				listview.SetSource (items);
+				listview.SelectedItem = 0;
 			};
 			Win.Add (btnThree);
 		}

--- a/UICatalog/Scenarios/ComboBoxIteration.cs
+++ b/UICatalog/Scenarios/ComboBoxIteration.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios {
+	[ScenarioMetadata (Name: "ComboBoxIteration", Description: "ComboBox iteration.")]
+	[ScenarioCategory ("Controls")]
+	public class ComboBoxIteration : Scenario {
+		public override void Setup ()
+		{
+			var items = new List<string> () { "one", "two", "three" };
+
+			var lbListView = new Label () {
+				AutoSize = false,
+				Width = 10,
+				Height = 1
+			};
+			Win.Add (lbListView);
+
+			var listview = new ListView (items) {
+				Y = Pos.Bottom (lbListView) + 1,
+				Width = 10,
+				Height = Dim.Fill (2)
+			};
+			Win.Add (listview);
+
+			var lbComboBox = new Label () {
+				ColorScheme = Colors.TopLevel,
+				X = Pos.Right (lbListView) + 1,
+				Width = Dim.Percent (40)
+			};
+
+			var comboBox = new ComboBox () {
+				X = Pos.Right (listview) + 1,
+				Y = Pos.Bottom (lbListView) + 1,
+				Height = Dim.Fill (2),
+				Width = Dim.Percent (40)
+			};
+			comboBox.SetSource (items);
+
+			listview.SelectedItemChanged += (e) => {
+				lbListView.Text = items [e.Item];
+				comboBox.SelectedItem = e.Item;
+			};
+
+			comboBox.SelectedItemChanged += (ListViewItemEventArgs text) => {
+				lbComboBox.Text = items [comboBox.SelectedItem];
+				listview.SelectedItem = text.Item;
+			};
+			Win.Add (lbComboBox, comboBox);
+			Win.Add (new TextField { X = Pos.Right (listview) + 1, Y = Pos.Top (comboBox) + 3, Height = 1, Width = 20 });
+
+			var btnTwo = new Button ("Two") {
+				X = Pos.Right (comboBox) + 1,
+			};
+			btnTwo.Clicked += () => {
+				items = new List<string> () { "one", "two" };
+				comboBox.SetSource (items);
+				listview.SetSource (items);
+			};
+			Win.Add (btnTwo);
+
+			var btnThree = new Button ("Three") {
+				X = Pos.Right (comboBox) + 1,
+				Y = Pos.Top (comboBox)
+			};
+			btnThree.Clicked += () => {
+				items = new List<string> () { "one", "two", "three" };
+				comboBox.SetSource (items);
+				listview.SetSource (items);
+			};
+			Win.Add (btnThree);
+		}
+	}
+}

--- a/UICatalog/Scenarios/ListsAndCombos.cs
+++ b/UICatalog/Scenarios/ListsAndCombos.cs
@@ -80,7 +80,7 @@ namespace UICatalog.Scenarios {
 			};
 			comboBox.SetSource (items);
 
-			comboBox.SelectedItemChanged += (ListViewItemEventArgs text) => lbComboBox.Text = items[comboBox.SelectedItem];
+			comboBox.SelectedItemChanged += (ListViewItemEventArgs text) => lbComboBox.Text = text.Value.ToString ();
 			Win.Add (lbComboBox, comboBox);
 
 			var scrollBarCbx = new ScrollBarView (comboBox.Subviews [1], true);


### PR DESCRIPTION
The problem in the issue is that controls 'behind' a combo box cannot be focused.  This only manifests after the combo list has been shown with `ShowList ()`.  That method calls `this.SuperView?.BringSubviewToFront (this);`.

This PR updates `HideList ()` to call `SuperView?.SendSubviewToBack (this);` which is the mirror operation to when it is showing.

This fixes the issue when using the mouse to expand and collapse the ComboBox.  I have also added a call to `HideList ()` in the completion handler for the combo box when the user confirms a selection with the mouse or Enter keys.

**Update**
Now also includes making `ComboBox.SelectedItem` setter public (thanks @BDisp )