### PR TITLE
Fixes the ProcessHotKey event.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1730,15 +1730,12 @@ namespace Terminal.Gui {
 			}
 
 			KeyEventEventArgs args = new KeyEventEventArgs (keyEvent);
-			KeyPress?.Invoke (args);
-			if (args.Handled)
-				return true;
-			if (Focused?.Enabled == true) {
-				Focused?.KeyPress?.Invoke (args);
+			if (MostFocused?.Enabled == true) {
+				MostFocused?.KeyPress?.Invoke (args);
 				if (args.Handled)
 					return true;
 			}
-			if (Focused?.Enabled == true && Focused?.ProcessKey (keyEvent) == true)
+			if (MostFocused?.Enabled == true && MostFocused?.ProcessKey (keyEvent) == true)
 				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;
@@ -1759,12 +1756,12 @@ namespace Terminal.Gui {
 			KeyPress?.Invoke (args);
 			if (args.Handled)
 				return true;
-			if (Focused?.Enabled == true) {
-				Focused?.KeyPress?.Invoke (args);
+			if (MostFocused?.Enabled == true) {
+				MostFocused?.KeyPress?.Invoke (args);
 				if (args.Handled)
 					return true;
 			}
-			if (Focused?.Enabled == true && Focused?.ProcessKey (keyEvent) == true)
+			if (MostFocused?.Enabled == true && MostFocused?.ProcessKey (keyEvent) == true)
 				return true;
 			if (subviews == null || subviews.Count == 0)
 				return false;

--- a/UnitTests/ConsoleDriverTests.cs
+++ b/UnitTests/ConsoleDriverTests.cs
@@ -430,7 +430,7 @@ namespace Terminal.Gui.ConsoleDrivers {
 			var okClicked = false;
 			var closing = false;
 			var cursorRight = false;
-			var cancelHasFocus = false;
+			var endingKeyPress = false;
 			var closed = false;
 
 			var top = Application.Top;
@@ -464,9 +464,7 @@ namespace Terminal.Gui.ConsoleDrivers {
 					if (!cursorRight) {
 						cursorRight = true;
 					} else if (ok.HasFocus) {
-						e.Handled = true;
-					} else {
-						cancelHasFocus = true;
+						e.Handled = endingKeyPress = true;
 					}
 				}
 			};
@@ -497,7 +495,7 @@ namespace Terminal.Gui.ConsoleDrivers {
 			Assert.True (okClicked);
 			Assert.True (closing);
 			Assert.True (cursorRight);
-			Assert.True (cancelHasFocus);
+			Assert.True (endingKeyPress);
 			Assert.True (closed);
 			Assert.Empty (FakeConsole.MockKeyPresses);
 		}


### PR DESCRIPTION
Running the unit test without the fix will fail.

Fixes #1613.