### PR TITLE
Fixes TextField context menu not showing with the current localization.

### DIFF
--- a/Terminal.Gui/Core/ContextMenu.cs
+++ b/Terminal.Gui/Core/ContextMenu.cs
@@ -132,7 +132,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		public void Hide ()
 		{
-			menuBar.CloseAllMenus ();
+			menuBar.CleanUp ();
 			Dispose ();
 		}
 
@@ -196,5 +196,10 @@ namespace Terminal.Gui {
 		/// if the left or right position are negative.
 		/// </summary>
 		public bool ForceMinimumPosToZero { get; set; } = true;
+
+		/// <summary>
+		/// Gets the <see cref="Gui.MenuBar"/> that is hosting this context menu.
+		/// </summary>
+		public MenuBar MenuBar { get => menuBar; }
 	}
 }

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -7,7 +7,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using NStack;
 using Terminal.Gui.Resources;
 using Rune = System.Rune;
@@ -25,6 +27,7 @@ namespace Terminal.Gui {
 		int selectedStart = -1; // -1 represents there is no text selection.
 		ustring selectedText;
 		HistoryText historyText = new HistoryText ();
+		CultureInfo currentCulture;
 
 		/// <summary>
 		/// Tracks whether the text field should be considered "used", that is, that the user has moved in the entry, so new input should be appended at the cursor position, rather than clearing the entry
@@ -202,15 +205,17 @@ namespace Terminal.Gui {
 			AddKeyBinding (Key.T | Key.CtrlMask, Command.SelectAll);
 			AddKeyBinding (Key.D | Key.CtrlMask | Key.ShiftMask, Command.DeleteAll);
 
+			currentCulture = Thread.CurrentThread.CurrentUICulture;
+
 			ContextMenu = new ContextMenu (this,
 				new MenuBarItem (new MenuItem [] {
-								new MenuItem (Strings.ctxSelectAll, "", () => SelectAll (), null, null, GetKeyFromCommand (Command.SelectAll)),
-								new MenuItem (Strings.ctxDeleteAll, "", () => DeleteAll (), null, null, GetKeyFromCommand (Command.DeleteAll)),
-								new MenuItem (Strings.ctxCopy, "", () => Copy (), null, null, GetKeyFromCommand (Command.Copy)),
-								new MenuItem (Strings.ctxCut, "", () => Cut (), null, null, GetKeyFromCommand (Command.Cut)),
-								new MenuItem (Strings.ctxPaste, "", () => Paste (), null, null, GetKeyFromCommand (Command.Paste)),
-								new MenuItem (Strings.ctxUndo, "", () => UndoChanges (), null, null, GetKeyFromCommand (Command.Undo)),
-								new MenuItem (Strings.ctxRedo, "", () => RedoChanges (), null, null, GetKeyFromCommand (Command.Redo)),
+					new MenuItem (Strings.ctxSelectAll, "", () => SelectAll (), null, null, GetKeyFromCommand (Command.SelectAll)),
+					new MenuItem (Strings.ctxDeleteAll, "", () => DeleteAll (), null, null, GetKeyFromCommand (Command.DeleteAll)),
+					new MenuItem (Strings.ctxCopy, "", () => Copy (), null, null, GetKeyFromCommand (Command.Copy)),
+					new MenuItem (Strings.ctxCut, "", () => Cut (), null, null, GetKeyFromCommand (Command.Cut)),
+					new MenuItem (Strings.ctxPaste, "", () => Paste (), null, null, GetKeyFromCommand (Command.Paste)),
+					new MenuItem (Strings.ctxUndo, "", () => UndoChanges (), null, null, GetKeyFromCommand (Command.Undo)),
+					new MenuItem (Strings.ctxRedo, "", () => RedoChanges (), null, null, GetKeyFromCommand (Command.Redo)),
 				})
 			);
 			ContextMenu.KeyChanged += ContextMenu_KeyChanged;
@@ -921,6 +926,20 @@ namespace Terminal.Gui {
 
 		void ShowContextMenu ()
 		{
+			if (currentCulture != Thread.CurrentThread.CurrentUICulture) {
+
+				currentCulture = Thread.CurrentThread.CurrentUICulture;
+
+				ContextMenu.MenuItens = new MenuBarItem (new MenuItem [] {
+					new MenuItem (Strings.ctxSelectAll, "", () => SelectAll (), null, null, GetKeyFromCommand (Command.SelectAll)),
+					new MenuItem (Strings.ctxDeleteAll, "", () => DeleteAll (), null, null, GetKeyFromCommand (Command.DeleteAll)),
+					new MenuItem (Strings.ctxCopy, "", () => Copy (), null, null, GetKeyFromCommand (Command.Copy)),
+					new MenuItem (Strings.ctxCut, "", () => Cut (), null, null, GetKeyFromCommand (Command.Cut)),
+					new MenuItem (Strings.ctxPaste, "", () => Paste (), null, null, GetKeyFromCommand (Command.Paste)),
+					new MenuItem (Strings.ctxUndo, "", () => UndoChanges (), null, null, GetKeyFromCommand (Command.Undo)),
+					new MenuItem (Strings.ctxRedo, "", () => RedoChanges (), null, null, GetKeyFromCommand (Command.Redo)),
+				});
+			}
 			ContextMenu.Show ();
 		}
 

--- a/Terminal.Gui/Views/TextField.cs
+++ b/Terminal.Gui/Views/TextField.cs
@@ -207,8 +207,15 @@ namespace Terminal.Gui {
 
 			currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-			ContextMenu = new ContextMenu (this,
-				new MenuBarItem (new MenuItem [] {
+			ContextMenu = new ContextMenu (this, BuildContextMenuBarItem ());
+			ContextMenu.KeyChanged += ContextMenu_KeyChanged;
+
+			AddKeyBinding (ContextMenu.Key, Command.Accept);
+		}
+
+		private MenuBarItem BuildContextMenuBarItem ()
+		{
+			return new MenuBarItem (new MenuItem [] {
 					new MenuItem (Strings.ctxSelectAll, "", () => SelectAll (), null, null, GetKeyFromCommand (Command.SelectAll)),
 					new MenuItem (Strings.ctxDeleteAll, "", () => DeleteAll (), null, null, GetKeyFromCommand (Command.DeleteAll)),
 					new MenuItem (Strings.ctxCopy, "", () => Copy (), null, null, GetKeyFromCommand (Command.Copy)),
@@ -216,11 +223,7 @@ namespace Terminal.Gui {
 					new MenuItem (Strings.ctxPaste, "", () => Paste (), null, null, GetKeyFromCommand (Command.Paste)),
 					new MenuItem (Strings.ctxUndo, "", () => UndoChanges (), null, null, GetKeyFromCommand (Command.Undo)),
 					new MenuItem (Strings.ctxRedo, "", () => RedoChanges (), null, null, GetKeyFromCommand (Command.Redo)),
-				})
-			);
-			ContextMenu.KeyChanged += ContextMenu_KeyChanged;
-
-			AddKeyBinding (ContextMenu.Key, Command.Accept);
+				});
 		}
 
 		private void ContextMenu_KeyChanged (Key obj)
@@ -930,15 +933,7 @@ namespace Terminal.Gui {
 
 				currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-				ContextMenu.MenuItens = new MenuBarItem (new MenuItem [] {
-					new MenuItem (Strings.ctxSelectAll, "", () => SelectAll (), null, null, GetKeyFromCommand (Command.SelectAll)),
-					new MenuItem (Strings.ctxDeleteAll, "", () => DeleteAll (), null, null, GetKeyFromCommand (Command.DeleteAll)),
-					new MenuItem (Strings.ctxCopy, "", () => Copy (), null, null, GetKeyFromCommand (Command.Copy)),
-					new MenuItem (Strings.ctxCut, "", () => Cut (), null, null, GetKeyFromCommand (Command.Cut)),
-					new MenuItem (Strings.ctxPaste, "", () => Paste (), null, null, GetKeyFromCommand (Command.Paste)),
-					new MenuItem (Strings.ctxUndo, "", () => UndoChanges (), null, null, GetKeyFromCommand (Command.Undo)),
-					new MenuItem (Strings.ctxRedo, "", () => RedoChanges (), null, null, GetKeyFromCommand (Command.Redo)),
-				});
+				ContextMenu.MenuItens = BuildContextMenuBarItem ();
 			}
 			ContextMenu.Show ();
 		}

--- a/UnitTests/ContextMenuTests.cs
+++ b/UnitTests/ContextMenuTests.cs
@@ -463,5 +463,57 @@ namespace Terminal.Gui.Core {
 			pos = GraphViewTests.AssertDriverContentsWithPosAre (expected, output);
 			Assert.Equal (new Point (1, 0), pos);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void ContextMenu_Is_Closed_If_Another_MenuBar_Is_Open_Or_Vice_Versa ()
+		{
+			var cm = new ContextMenu (10, 5,
+				new MenuBarItem (new MenuItem [] {
+					new MenuItem ("One", "", null),
+					new MenuItem ("Two", "", null)
+				})
+			);
+
+			var menu = new MenuBar (new MenuBarItem [] {
+					new MenuBarItem ("File", "", null),
+					new MenuBarItem ("Edit", "", null)
+				});
+
+			Application.Top.Add (menu);
+
+			Assert.Null (Application.mouseGrabView);
+
+			cm.Show ();
+			Assert.True (ContextMenu.IsShow);
+			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.False (menu.IsMenuOpen);
+			Assert.True (menu.ProcessHotKey (new KeyEvent (Key.F9, new KeyModifiers ())));
+			Assert.False (ContextMenu.IsShow);
+			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.True (menu.IsMenuOpen);
+
+			cm.Show ();
+			Assert.True (ContextMenu.IsShow);
+			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.False (menu.IsMenuOpen);
+			Assert.False (menu.OnKeyDown (new KeyEvent (Key.Null, new KeyModifiers () { Alt = true })));
+			Assert.True (menu.OnKeyUp (new KeyEvent (Key.Null, new KeyModifiers () { Alt = true })));
+			Assert.False (ContextMenu.IsShow);
+			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.True (menu.IsMenuOpen);
+
+			cm.Show ();
+			Assert.True (ContextMenu.IsShow);
+			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.False (menu.IsMenuOpen);
+			Assert.False (menu.MouseEvent (new MouseEvent () { X = 1, Flags = MouseFlags.ReportMousePosition, View = menu }));
+			Assert.True (ContextMenu.IsShow);
+			Assert.Equal (cm.MenuBar, Application.mouseGrabView);
+			Assert.False (menu.IsMenuOpen);
+			Assert.True (menu.MouseEvent (new MouseEvent () { X = 1, Flags = MouseFlags.Button1Clicked, View = menu }));
+			Assert.False (ContextMenu.IsShow);
+			Assert.Equal (menu, Application.mouseGrabView);
+			Assert.True (menu.IsMenuOpen);
+		}
 	}
 }


### PR DESCRIPTION
Due to the latest context menu changes on the `TextField` the localization stopped working, because it was not updating with the current culture. This PR fixes it.