### PR TITLE
Fixed TableView when redrawing a System.DataTable that has no columns

### DIFF
--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -621,7 +621,7 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public override bool ProcessKey (KeyEvent keyEvent)
 		{
-			if (Table == null) {
+			if (Table == null || Table.Columns.Count <= 0) {
 				PositionCursor ();
 				return false;
 			}
@@ -865,7 +865,7 @@ namespace Terminal.Gui {
 				SetFocus ();
 			}
 
-			if (Table == null) {
+			if (Table == null || Table.Columns.Count <= 0) {
 				return false;
 			}
 
@@ -925,7 +925,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public Point? ScreenToCell (int clientX, int clientY)
 		{
-			if (Table == null)
+			if (Table == null || Table.Columns.Count <= 0)
 				return null;
 
 			var viewPort = CalculateViewport (Bounds);
@@ -956,7 +956,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		public Point? CellToScreen (int tableColumn, int tableRow)
 		{
-			if (Table == null)
+			if (Table == null || Table.Columns.Count <= 0)
 				return null;
 
 			var viewPort = CalculateViewport (Bounds);
@@ -1118,7 +1118,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private IEnumerable<ColumnToRender> CalculateViewport (Rect bounds, int padding = 1)
 		{
-			if (Table == null)
+			if (Table == null || Table.Columns.Count <= 0)
 				yield break;
 
 			int usedSpace = 0;

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -75,6 +75,23 @@ namespace Terminal.Gui.Views {
 		}
 
 		[Fact]
+		[AutoInitShutdown]
+		public void Redraw_EmptyTable ()
+		{
+			var tableView = new TableView ();
+			tableView.ColorScheme = new ColorScheme();
+			tableView.Bounds = new Rect (0, 0, 25, 10);
+
+			// Set a table with 1 column
+			tableView.Table = BuildTable (1, 50);
+			tableView.Redraw(tableView.Bounds);
+
+			tableView.Table.Columns.Remove(tableView.Table.Columns[0]);
+			tableView.Redraw(tableView.Bounds);
+		}
+
+
+		[Fact]
 		public void SelectedCellChanged_NotFiredForSameValue ()
 		{
 			var tableView = new TableView () {


### PR DESCRIPTION
A table with no columns is now treated like no table at all (i.e. when `Table` is null).  This fixes a 'Sequence Contains no elements' Exception that would otherwise be thrown when redrawing (see unit test without this fix).