### PR TITLE
Dispose `FileSystemWatcher` instance before creating another in `FileDialog`

### DIFF
--- a/Terminal.Gui/Windows/FileDialog.cs
+++ b/Terminal.Gui/Windows/FileDialog.cs
@@ -51,6 +51,10 @@ namespace Terminal.Gui {
 			bool valid = false;
 			try {
 				dirInfo = new DirectoryInfo (value == null ? directory.ToString () : value.ToString ());
+
+				// Dispose of the old watcher
+				watcher?.Dispose ();
+
 				watcher = new FileSystemWatcher (dirInfo.FullName);
 				watcher.NotifyFilter = NotifyFilters.Attributes
 				 | NotifyFilters.CreationTime


### PR DESCRIPTION
There was a fix for #1524 which disposed of the `FileSystemWatcher` in the Dispose method of the view `FileDialog`.  However the issue remains because a new `FileSystemWatcher` is allocated every time `internal bool Reload (ustring value = null)` is called.  This means that while browsing around folders there are new instances constantly being allocated and only the last one is tracked.

This PR ensures that before allocating a new `FileSystemWatcher` the old one (if any) is disposed.