### PR TITLE
Fixed Axis.Text being a field while every other class member is a property

### DIFF
--- a/Terminal.Gui/Core/Graphs/Axis.cs
+++ b/Terminal.Gui/Core/Graphs/Axis.cs
@@ -45,7 +45,7 @@ namespace Terminal.Gui.Graphs {
 		/// Displayed below/to left of labels (see <see cref="Orientation"/>).
 		/// If text is not visible, check <see cref="GraphView.MarginBottom"/> / <see cref="GraphView.MarginLeft"/>
 		/// </summary>
-		public string Text;
+		public string Text { get; set; }
 
 		/// <summary>
 		/// The minimum axis point to show.  Defaults to null (no minimum)


### PR DESCRIPTION
Noticed this while working on the designer code.  All other user settable values are properties not fields.  So changing this adds consistency as well as allowing for future changes to the backend (i.e. changing the get;set; logic later on).

Fixing this is non breaking except maybe in some corner case of Reflection use.  