### PR TITLE
Fixes wide runes not render well on NetDriver.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -1451,13 +1451,13 @@ namespace Terminal.Gui {
 				dirtyLine [row] = false;
 				System.Text.StringBuilder output = new System.Text.StringBuilder ();
 				for (int col = 0; col < cols; col++) {
-					if (contents [row, col, 2] != 1) {
-						continue;
-					}
 					if (Console.WindowHeight > 0 && !SetCursorPosition (col, row)) {
 						return;
 					}
 					for (; col < cols; col++) {
+						if (contents [row, col, 2] != 1) {
+							continue;
+						}
 						var attr = contents [row, col, 1];
 						if (attr != redrawAttr) {
 							output.Append (WriteAttributes (attr));


### PR DESCRIPTION
Fixes #1657

![netdriver-wide-runes-fix](https://user-images.githubusercontent.com/13117724/162338036-3c3c2fd3-9a5c-4176-92df-4452d6559fa2.png)
