### PR TITLE
Fixes the MenuIem Width for wider runes

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -135,7 +135,7 @@ namespace Terminal.Gui {
 			return CanExecute == null ? true : CanExecute ();
 		}
 
-		internal int Width => Title.RuneCount + Help.RuneCount + 1 + 2 +
+		internal int Width => Title.Sum (x => Rune.ColumnWidth (x)) + Help.Sum (x => Rune.ColumnWidth (x)) + 1 + 2 +
 			(Checked || CheckType.HasFlag (MenuItemCheckStyle.Checked) || CheckType.HasFlag (MenuItemCheckStyle.Radio) ? 2 : 0) +
 			(ShortcutTag.RuneCount > 0 ? ShortcutTag.RuneCount + 2 : 0);
 


### PR DESCRIPTION
Fixes #1665

![imagem](https://user-images.githubusercontent.com/13117724/163674263-32da20a1-2e5a-4c8b-bf6d-1d86370297e2.png)

