### PR TITLE
Add timeout thread safety

### DIFF
--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1333,7 +1333,7 @@ namespace Terminal.Gui.Core {
 			// a lot but all those timeout delegates could end up going slowly on a slow machine perhaps
 			// so the final number of delegatesRun might vary by computer.  So for this assert we say
 			// that it should have run at least 2 seconds worth of delegates
-			Assert.True (delegatesRun >= 100 * 100 * 2);
+			Assert.True (delegatesRun >= numberOfThreads * numberOfTimeoutsPerThread * 2);
 		}
 	}
 }

--- a/UnitTests/ApplicationTests.cs
+++ b/UnitTests/ApplicationTests.cs
@@ -1286,5 +1286,54 @@ namespace Terminal.Gui.Core {
 			var cultures = Application.GetSupportedCultures ();
 			Assert.Equal (cultures.Count, Application.SupportedCultures.Count);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void TestAddManyTimeouts ()
+		{
+			int delegatesRun = 0;
+			int numberOfThreads = 100;
+			int numberOfTimeoutsPerThread = 100;
+
+
+			// start lots of threads
+			for (int i = 0; i < numberOfThreads; i++) {
+				
+				var myi = i;
+
+				Task.Run (() => {
+					Task.Delay (100).Wait ();
+
+					// each thread registers lots of 1s timeouts
+					for(int j=0;j< numberOfTimeoutsPerThread; j++) {
+
+						Application.MainLoop.AddTimeout (TimeSpan.FromSeconds(1), (s) => {
+
+							// each timeout delegate increments delegatesRun count by 1 every second
+							Interlocked.Increment (ref delegatesRun);
+							return true; 
+						});
+					}
+					 
+					// if this is the first Thread created
+					if (myi == 0) {
+
+						// let the timeouts run for a bit
+						Task.Delay (5000).Wait ();
+
+						// then tell the application to quuit
+						Application.MainLoop.Invoke (() => Application.RequestStop ());
+					}
+				});
+			}
+
+			// blocks here until the RequestStop is processed at the end of the test
+			Application.Run ();
+
+			// undershoot a bit to be on the safe side.  The 5000 ms wait allows the timeouts to run
+			// a lot but all those timeout delegates could end up going slowly on a slow machine perhaps
+			// so the final number of delegatesRun might vary by computer.  So for this assert we say
+			// that it should have run at least 2 seconds worth of delegates
+			Assert.True (delegatesRun >= 100 * 100 * 2);
+		}
 	}
 }


### PR DESCRIPTION
Fixes  #1679

I think this should fix the above issue.  There are 2 problems addressed by this PR.  

There was locking on the `timeouts` field (i.e. `lock (timeouts)`).  But since this variable is reassigned to a new list in `RunTimers` the reference changes so locking will not be consistent.  I have fixed this by adding an unchanging object `timeoutsLockToken` and locking on that instead.

RunTimers iterates through a `copy` of `timeouts` but there was no protection of the period in which you take the copy but haven't yet assigned a new list for callers to AddTimeout to add new timeouts to which could result in various errors.  I've added an extra lock around that section.  Initially I put it around the whole `RunTimers` but I think that is excessive and the solution implemented works.

I've added a test which is quite conservative (100 threads x 100 timeout callbacks of 1 second x 5 seconds runtime) which shouldn't stress any machines running it much.



 