### PR TITLE
Added calls to `Application.Shutdown ()` into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ win.Add(
 );
 
 Application.Run();
+Application.Shutdown();
 ```
 
 Alternatively, you can encapsulate the app behavior in a new `Window`-derived class, say `App.cs` containing the code above, and simplify your `Main` method to:
@@ -198,6 +199,7 @@ class Demo {
 	static void Main ()
 	{
 		Application.Run<App> ();
+		Application.Shutdown ();
 	}
 }
 ```

--- a/docfx/articles/overview.md
+++ b/docfx/articles/overview.md
@@ -26,7 +26,8 @@ class Demo {
 
         var n = MessageBox.Query (50, 7, 
             "Question", "Do you like console apps?", "Yes", "No");
-
+            
+		Application.Shutdown ();
         return n;
     }
 }
@@ -62,6 +63,7 @@ class Demo {
         };
         Application.Top.Add (label);
         Application.Run ();
+        Application.Shutdown ();
     }
 }
 ```
@@ -95,6 +97,7 @@ class Demo {
         // Add both menu and win in a single call
         Application.Top.Add (menu, win);
         Application.Run ();
+        Application.Shutdown ();
     }
 }
 ```
@@ -277,6 +280,7 @@ class Demo {
         // Add both menu and win in a single call
         top.Add (win, menu);
         Application.Run (top);
+        Application.Shutdown ();
     }
 }
 ```
@@ -342,6 +346,7 @@ var entry = new TextField () {
 };
 dialog.Add (entry);
 Application.Run (dialog);
+Application.Shutdown ();
 if (okpressed)
     Console.WriteLine ("The user entered: " + entry.Text);
 ```


### PR DESCRIPTION
As highlighted in #1686  most of the docs do not include calls to `Application.Shutdown ();`.  This PR adds shutdown calls to overview and the root README.