### PR TITLE
Adds Data field to MenuItem

### DIFF
--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -43,6 +43,12 @@ namespace Terminal.Gui {
 		ustring title;
 
 		ShortcutHelper shortcutHelper;
+		
+		/// <summary>
+		/// Gets or sets arbitrary data for the menu item.
+		/// </summary>
+		/// <remarks>This property is not used internally.</remarks>
+		public object Data { get; set; }
 
 		/// <summary>
 		/// Initializes a new instance of <see cref="MenuItem"/>


### PR DESCRIPTION
`View` has a field `Data` which API users can add any object/class they want for use later (e.g. in delegates).  This is pretty handy and I've used it quite a bit myself.  MenuItems do not inherit from View and therefore do not have this property.

This PR adds the same field (Data) to the MenuItem class.