### PR TITLE
Fixed RunTimers not checking for key collisions in list when adding to timeouts

### DIFF
--- a/Terminal.Gui/Core/MainLoop.cs
+++ b/Terminal.Gui/Core/MainLoop.cs
@@ -120,10 +120,7 @@ namespace Terminal.Gui {
 		{
 			lock (timeoutsLockToken) {
 				var k = (DateTime.UtcNow + time).Ticks;
-				while (timeouts.ContainsKey (k)) {
-					k = (DateTime.UtcNow + time).Ticks;
-				}
-				timeouts.Add (k, timeout);
+				timeouts.Add (NudgeToUniqueKey(k), timeout);
 			}
 		}
 
@@ -191,11 +188,28 @@ namespace Terminal.Gui {
 						AddTimeout (timeout.Span, timeout);
 				} else {
 					lock (timeoutsLockToken) {
-						timeouts.Add (k, timeout);
+						timeouts.Add (NudgeToUniqueKey(k), timeout);
 					}
 				}
 			}
 			
+		}
+
+		/// <summary>
+		/// Finds the closest number to <paramref name="k"/> that is not
+		/// present in <see cref="timeouts"/> (incrementally).
+		/// </summary>
+		/// <param name="k"></param>
+		/// <returns></returns>
+		private long NudgeToUniqueKey (long k)
+		{
+			lock(timeoutsLockToken) {
+				while (timeouts.ContainsKey (k)) {
+					k++;
+				}
+			}
+
+			return k;
 		}
 
 		void RunIdle ()


### PR DESCRIPTION
So we got the race condition sorted in #1684 but there is another issue with `AddTimeout`.  

There is code in `void AddTimeout (TimeSpan time, Timeout timeout)` which looks for key collisions in the `timeouts` dictionary:

https://github.com/migueldeicaza/gui.cs/blob/2ab69a16d3f4ef082c8e822981f7b01e2d35a9e3/Terminal.Gui/Core/MainLoop.cs#L121-L127

 However there is no check for key collisions in `RunTimers` which has this code only below.

https://github.com/migueldeicaza/gui.cs/blob/2ab69a16d3f4ef082c8e822981f7b01e2d35a9e3/Terminal.Gui/Core/MainLoop.cs#L193-L195

If a new timeout is added at time k by AddTimeout at the same time that RunTimers is iterating and the AddTimeout sneaks in first then RunTimers will fail with 'key already exists' error.  This I think is the issue that @kacperpikacz is getting in #1679.

I have added a new method `NudgeToUniqueKey` which performs this check and should ensure no two timeouts are set for the same time.  

Given it takes @kacperpikacz  ~8 hours of runtime for this error to manifest I don't think there is an easy way to unit test the fix.