### PR TITLE
Tree view context

### DIFF
--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -622,7 +622,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="toFind"></param>
 		/// <returns></returns>
-		public int? GetObjectYPosition(T toFind)
+		public int? GetObjectRow(T toFind)
 		{
 			var idx = BuildLineMap ().IndexOf (o => o.Model.Equals (toFind));
 

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -671,6 +671,21 @@ namespace Terminal.Gui {
 			ObjectActivated?.Invoke (e);
 		}
 
+		/// <summary>
+		/// Returns the object in the tree list that is currently visible
+		/// at the provided point.  Returns null if no object is at that location.
+		/// <remarks>
+		/// </remarks>
+		/// If you have screen cordinates then use <see cref="View.ScreenToView(int, int)"/>
+		/// to translate these into the client area of the <see cref="TreeView{T}"/>.
+		/// </summary>
+		/// <param name="point">Point with the <see cref="View.Bounds"/> of the <see cref="TreeView{T}"/></param>
+		/// <returns></returns>
+		public T HitTest (Point point)
+		{
+			return HitTest (point.Y)?.Model;
+		}
+
 		///<inheritdoc/>
 		public override bool MouseEvent (MouseEvent me)
 		{

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -696,17 +696,17 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Returns the object in the tree list that is currently visible
-		/// at the provided col/row.  Returns null if no object is at that location.
+		/// at the provided row.  Returns null if no object is at that location.
 		/// <remarks>
 		/// </remarks>
 		/// If you have screen coordinates then use <see cref="View.ScreenToView(int, int)"/>
 		/// to translate these into the client area of the <see cref="TreeView{T}"/>.
 		/// </summary>
-		/// <param name="point">Point with the <see cref="View.Bounds"/> of the <see cref="TreeView{T}"/></param>
-		/// <returns></returns>
-		public T GetObjectAtPoint (Point point)
+		/// <param name="row">The row of the <see cref="View.Bounds"/> of the <see cref="TreeView{T}"/></param>
+		/// <returns>The object currently displayed on this row or null</returns>
+		public T GetObjectOnRow (int row)
 		{
-			return HitTest (point.Y)?.Model;
+			return HitTest (row)?.Model;
 		}
 
 		///<inheritdoc/>

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -610,6 +610,29 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
+		/// <para>
+		/// Returns the Y coordinate within the <see cref="View.Bounds"/> of the
+		/// tree at which <paramref name="toFind"/> would be displayed or null if
+		/// it is not currently exposed (e.g. its parent is collapsed).
+		/// </para>
+		/// <para>
+		/// Note that the returned value can be negative if the TreeView is scrolled
+		/// down and the <paramref name="toFind"/> object is off the top of the view.
+		/// </para>
+		/// </summary>
+		/// <param name="toFind"></param>
+		/// <returns></returns>
+		public int? IndexOf(T toFind)
+		{
+			var idx = BuildLineMap ().IndexOf (o => o.Model.Equals (toFind));
+
+			if (idx == -1)
+				return null;
+
+			return idx - ScrollOffsetVertical;
+		}
+
+		/// <summary>
 		/// <para>Moves the <see cref="SelectedObject"/> to the next item that begins with <paramref name="character"/></para>
 		/// <para>This method will loop back to the start of the tree if reaching the end without finding a match</para>
 		/// </summary>

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -622,7 +622,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="toFind"></param>
 		/// <returns></returns>
-		public int? IndexOf(T toFind)
+		public int? GetObjectYPosition(T toFind)
 		{
 			var idx = BuildLineMap ().IndexOf (o => o.Model.Equals (toFind));
 
@@ -696,15 +696,15 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Returns the object in the tree list that is currently visible
-		/// at the provided point.  Returns null if no object is at that location.
+		/// at the provided col/row.  Returns null if no object is at that location.
 		/// <remarks>
 		/// </remarks>
-		/// If you have screen cordinates then use <see cref="View.ScreenToView(int, int)"/>
+		/// If you have screen coordinates then use <see cref="View.ScreenToView(int, int)"/>
 		/// to translate these into the client area of the <see cref="TreeView{T}"/>.
 		/// </summary>
 		/// <param name="point">Point with the <see cref="View.Bounds"/> of the <see cref="TreeView{T}"/></param>
 		/// <returns></returns>
-		public T HitTest (Point point)
+		public T GetObjectAtPoint (Point point)
 		{
 			return HitTest (point.Y)?.Model;
 		}

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -78,6 +78,7 @@ namespace UICatalog.Scenarios {
 
 			treeViewFiles.ObjectActivated += TreeViewFiles_ObjectActivated;
 			treeViewFiles.MouseClick += TreeViewFiles_MouseClick;
+			treeViewFiles.KeyPress += TreeViewFiles_KeyPress;
 
 			SetupFileTree ();
 
@@ -87,6 +88,29 @@ namespace UICatalog.Scenarios {
 
 			green = Application.Driver.MakeAttribute (Color.Green, Color.Blue);
 			red = Application.Driver.MakeAttribute (Color.Red, Color.Blue);
+		}
+
+		private void TreeViewFiles_KeyPress (View.KeyEventEventArgs obj)
+		{
+			if(obj.KeyEvent.Key == (Key.R | Key.CtrlMask)) {
+
+				var selected = treeViewFiles.SelectedObject;
+				
+				// nothing is selected
+				if (selected == null)
+					return;
+				
+				var location = treeViewFiles.IndexOf (selected);
+
+				//selected object is offscreen or somehow not found
+				if (location == null || location < 0 || location > treeViewFiles.Frame.Height)
+					return;
+
+				ShowContextMenu (new Point (
+					5 + treeViewFiles.Frame.X,
+					location.Value + treeViewFiles.Frame.Y + 2),
+					selected);
+			}
 		}
 
 		private void TreeViewFiles_MouseClick (View.MouseEventArgs obj)
@@ -100,39 +124,44 @@ namespace UICatalog.Scenarios {
 				if (rightClicked == null)
 					return;
 
-				var menu = new ContextMenu ();
-				menu.Position = new Point(
+				ShowContextMenu (new Point (
 					obj.MouseEvent.X + treeViewFiles.Frame.X,
-					obj.MouseEvent.Y + treeViewFiles.Frame.Y +1);
-
-				menu.MenuItems = new MenuBarItem (new [] { new MenuItem ("Properties",null,()=> {
-					MessageBox.Query($"{rightClicked.Name}({rightClicked.GetType().Name})",Describe(rightClicked),"Ok");
-				}
-					
-				) });
-				menu.Show ();
-
+					obj.MouseEvent.Y + treeViewFiles.Frame.Y + 2),
+					rightClicked);
 			}
 		}
 
-		private string Describe (FileSystemInfo f)
+		private void ShowContextMenu (Point screenPoint, FileSystemInfo forObject)
 		{
-			try {
+			var menu = new ContextMenu ();
+			menu.Position = screenPoint;
 
-				if (f is FileInfo fi) {
-					return "Size:" + fi.Length;
-				}
+			menu.MenuItems = new MenuBarItem (new [] { new MenuItem ("Properties", null, () => ShowPropertiesOf (forObject)) });
+			
+			Application.MainLoop.Invoke(menu.Show);
+		}
 
-				if (f is DirectoryInfo d) {
-					return $@"Parent:{d.Parent}
-Attributes:{d.Attributes}";
-				}
-			} catch (Exception) {
+		private void ShowPropertiesOf (FileSystemInfo fileSystemInfo)
+		{
+			if (fileSystemInfo is FileInfo f) {
+				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
+				sb.AppendLine ($"Path:{f.DirectoryName}");
+				sb.AppendLine ($"Size:{f.Length:N0} bytes");
+				sb.AppendLine ($"Modified:{ f.LastWriteTime}");
+				sb.AppendLine ($"Created:{ f.CreationTime}");
 
-				return "Could not get properties";
+				MessageBox.Query (f.Name, sb.ToString (), "Close");
 			}
 
-			return null;
+			if (fileSystemInfo is DirectoryInfo dir) {
+
+				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
+				sb.AppendLine ($"Path:{dir.Parent?.FullName}");
+				sb.AppendLine ($"Modified:{ dir.LastWriteTime}");
+				sb.AppendLine ($"Created:{ dir.CreationTime}");
+
+				MessageBox.Query (dir.Name, sb.ToString (), "Close");
+			}
 		}
 
 		private void SetupScrollBar ()
@@ -187,25 +216,7 @@ Attributes:{d.Attributes}";
 
 		private void TreeViewFiles_ObjectActivated (ObjectActivatedEventArgs<FileSystemInfo> obj)
 		{
-			if (obj.ActivatedObject is FileInfo f) {
-				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-				sb.AppendLine ($"Path:{f.DirectoryName}");
-				sb.AppendLine ($"Size:{f.Length:N0} bytes");
-				sb.AppendLine ($"Modified:{ f.LastWriteTime}");
-				sb.AppendLine ($"Created:{ f.CreationTime}");
-
-				MessageBox.Query (f.Name, sb.ToString (), "Close");
-			}
-
-			if (obj.ActivatedObject is DirectoryInfo dir) {
-
-				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-				sb.AppendLine ($"Path:{dir.Parent?.FullName}");
-				sb.AppendLine ($"Modified:{ dir.LastWriteTime}");
-				sb.AppendLine ($"Created:{ dir.CreationTime}");
-
-				MessageBox.Query (dir.Name, sb.ToString (), "Close");
-			}
+			ShowPropertiesOf (obj.ActivatedObject);
 		}
 
 		private void ShowLines ()

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -100,7 +100,7 @@ namespace UICatalog.Scenarios {
 				if (selected == null)
 					return;
 				
-				var location = treeViewFiles.GetObjectYPosition (selected);
+				var location = treeViewFiles.GetObjectRow (selected);
 
 				//selected object is offscreen or somehow not found
 				if (location == null || location < 0 || location > treeViewFiles.Frame.Height)

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -118,7 +118,7 @@ namespace UICatalog.Scenarios {
 			// if user right clicks
 			if (obj.MouseEvent.Flags.HasFlag(MouseFlags.Button3Clicked)) {
 
-				var rightClicked = treeViewFiles.GetObjectAtPoint (new Point (obj.MouseEvent.X, obj.MouseEvent.Y));
+				var rightClicked = treeViewFiles.GetObjectOnRow ( obj.MouseEvent.Y);
 
 				// nothing was clicked
 				if (rightClicked == null)

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -100,7 +100,7 @@ namespace UICatalog.Scenarios {
 				if (selected == null)
 					return;
 				
-				var location = treeViewFiles.IndexOf (selected);
+				var location = treeViewFiles.GetObjectYPosition (selected);
 
 				//selected object is offscreen or somehow not found
 				if (location == null || location < 0 || location > treeViewFiles.Frame.Height)
@@ -118,7 +118,7 @@ namespace UICatalog.Scenarios {
 			// if user right clicks
 			if (obj.MouseEvent.Flags.HasFlag(MouseFlags.Button3Clicked)) {
 
-				var rightClicked = treeViewFiles.HitTest (new Point (obj.MouseEvent.X, obj.MouseEvent.Y));
+				var rightClicked = treeViewFiles.GetObjectAtPoint (new Point (obj.MouseEvent.X, obj.MouseEvent.Y));
 
 				// nothing was clicked
 				if (rightClicked == null)

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -77,6 +77,7 @@ namespace UICatalog.Scenarios {
 			};
 
 			treeViewFiles.ObjectActivated += TreeViewFiles_ObjectActivated;
+			treeViewFiles.MouseClick += TreeViewFiles_MouseClick;
 
 			SetupFileTree ();
 
@@ -86,6 +87,52 @@ namespace UICatalog.Scenarios {
 
 			green = Application.Driver.MakeAttribute (Color.Green, Color.Blue);
 			red = Application.Driver.MakeAttribute (Color.Red, Color.Blue);
+		}
+
+		private void TreeViewFiles_MouseClick (View.MouseEventArgs obj)
+		{
+			// if user right clicks
+			if (obj.MouseEvent.Flags.HasFlag(MouseFlags.Button3Clicked)) {
+
+				var rightClicked = treeViewFiles.HitTest (new Point (obj.MouseEvent.X, obj.MouseEvent.Y));
+
+				// nothing was clicked
+				if (rightClicked == null)
+					return;
+
+				var menu = new ContextMenu ();
+				menu.Position = new Point(
+					obj.MouseEvent.X + treeViewFiles.Frame.X,
+					obj.MouseEvent.Y + treeViewFiles.Frame.Y +1);
+
+				menu.MenuItems = new MenuBarItem (new [] { new MenuItem ("Properties",null,()=> {
+					MessageBox.Query($"{rightClicked.Name}({rightClicked.GetType().Name})",Describe(rightClicked),"Ok");
+				}
+					
+				) });
+				menu.Show ();
+
+			}
+		}
+
+		private string Describe (FileSystemInfo f)
+		{
+			try {
+
+				if (f is FileInfo fi) {
+					return "Size:" + fi.Length;
+				}
+
+				if (f is DirectoryInfo d) {
+					return $@"Parent:{d.Parent}
+Attributes:{d.Attributes}";
+				}
+			} catch (Exception) {
+
+				return "Could not get properties";
+			}
+
+			return null;
 		}
 
 		private void SetupScrollBar ()

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -721,7 +721,7 @@ namespace Terminal.Gui.Views {
 
 		}
 		[Fact, AutoInitShutdown]
-		public void TestTreeHitTest ()
+		public void TestGetObjectAtPoint ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };
 
@@ -746,11 +746,11 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Same (n1, tv.HitTest (new Point (0, 0)));
-			Assert.Same (n1_1, tv.HitTest (new Point (0, 1)));
-			Assert.Same (n1_2, tv.HitTest (new Point (0, 2)));
-			Assert.Same (n2, tv.HitTest (new Point (0, 3)));
-			Assert.Null (tv.HitTest (new Point (0, 4)));
+			Assert.Same (n1, tv.GetObjectAtPoint (new Point (0, 0)));
+			Assert.Same (n1_1, tv.GetObjectAtPoint (new Point (0, 1)));
+			Assert.Same (n1_2, tv.GetObjectAtPoint (new Point (0, 2)));
+			Assert.Same (n2, tv.GetObjectAtPoint (new Point (0, 3)));
+			Assert.Null (tv.GetObjectAtPoint (new Point (0, 4)));
 
 			tv.Collapse (n1);
 
@@ -762,15 +762,15 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Same (n1, tv.HitTest (new Point (0, 0)));
-			Assert.Same (n2, tv.HitTest (new Point (0, 1)));
-			Assert.Null (tv.HitTest (new Point (0, 2)));
-			Assert.Null (tv.HitTest (new Point (0, 3)));
-			Assert.Null (tv.HitTest (new Point (0, 4)));
+			Assert.Same (n1, tv.GetObjectAtPoint (new Point (0, 0)));
+			Assert.Same (n2, tv.GetObjectAtPoint (new Point (0, 1)));
+			Assert.Null (tv.GetObjectAtPoint (new Point (0, 2)));
+			Assert.Null (tv.GetObjectAtPoint (new Point (0, 3)));
+			Assert.Null (tv.GetObjectAtPoint (new Point (0, 4)));
 		}
 
 		[Fact, AutoInitShutdown]
-		public void TestTreeIndexOf ()
+		public void TestGetObjectYPosition ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };
 
@@ -795,10 +795,10 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Equal (0, tv.IndexOf (n1));
-			Assert.Equal (1, tv.IndexOf (n1_1));
-			Assert.Equal (2, tv.IndexOf (n1_2));
-			Assert.Equal (3, tv.IndexOf (n2));
+			Assert.Equal (0, tv.GetObjectYPosition (n1));
+			Assert.Equal (1, tv.GetObjectYPosition (n1_1));
+			Assert.Equal (2, tv.GetObjectYPosition (n1_2));
+			Assert.Equal (3, tv.GetObjectYPosition (n2));
 
 			tv.Collapse (n1);
 
@@ -809,10 +809,10 @@ namespace Terminal.Gui.Views {
 @"├+normal
 └─pink
 ", output);
-			Assert.Equal (0, tv.IndexOf (n1));
-			Assert.Null (tv.IndexOf (n1_1));
-			Assert.Null (tv.IndexOf (n1_2));
-			Assert.Equal (1, tv.IndexOf (n2));
+			Assert.Equal (0, tv.GetObjectYPosition (n1));
+			Assert.Null (tv.GetObjectYPosition (n1_1));
+			Assert.Null (tv.GetObjectYPosition (n1_2));
+			Assert.Equal (1, tv.GetObjectYPosition (n2));
 
 
 			// scroll down 1
@@ -824,10 +824,10 @@ namespace Terminal.Gui.Views {
 			GraphViewTests.AssertDriverContentsAre (
 @"└─pink
 ", output);
-			Assert.Equal (-1, tv.IndexOf (n1));
-			Assert.Null (tv.IndexOf (n1_1));
-			Assert.Null (tv.IndexOf (n1_2));
-			Assert.Equal (0, tv.IndexOf (n2));
+			Assert.Equal (-1, tv.GetObjectYPosition (n1));
+			Assert.Null (tv.GetObjectYPosition (n1_1));
+			Assert.Null (tv.GetObjectYPosition (n1_2));
+			Assert.Equal (0, tv.GetObjectYPosition (n2));
 		}
 		[Fact, AutoInitShutdown]
 		public void TestTreeViewColor()

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -770,7 +770,7 @@ namespace Terminal.Gui.Views {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void TestGetObjectYPosition ()
+		public void TestGetObjectRow ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };
 
@@ -795,10 +795,10 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Equal (0, tv.GetObjectYPosition (n1));
-			Assert.Equal (1, tv.GetObjectYPosition (n1_1));
-			Assert.Equal (2, tv.GetObjectYPosition (n1_2));
-			Assert.Equal (3, tv.GetObjectYPosition (n2));
+			Assert.Equal (0, tv.GetObjectRow (n1));
+			Assert.Equal (1, tv.GetObjectRow (n1_1));
+			Assert.Equal (2, tv.GetObjectRow (n1_2));
+			Assert.Equal (3, tv.GetObjectRow (n2));
 
 			tv.Collapse (n1);
 
@@ -809,10 +809,10 @@ namespace Terminal.Gui.Views {
 @"├+normal
 └─pink
 ", output);
-			Assert.Equal (0, tv.GetObjectYPosition (n1));
-			Assert.Null (tv.GetObjectYPosition (n1_1));
-			Assert.Null (tv.GetObjectYPosition (n1_2));
-			Assert.Equal (1, tv.GetObjectYPosition (n2));
+			Assert.Equal (0, tv.GetObjectRow (n1));
+			Assert.Null (tv.GetObjectRow (n1_1));
+			Assert.Null (tv.GetObjectRow (n1_2));
+			Assert.Equal (1, tv.GetObjectRow (n2));
 
 
 			// scroll down 1
@@ -824,10 +824,10 @@ namespace Terminal.Gui.Views {
 			GraphViewTests.AssertDriverContentsAre (
 @"└─pink
 ", output);
-			Assert.Equal (-1, tv.GetObjectYPosition (n1));
-			Assert.Null (tv.GetObjectYPosition (n1_1));
-			Assert.Null (tv.GetObjectYPosition (n1_2));
-			Assert.Equal (0, tv.GetObjectYPosition (n2));
+			Assert.Equal (-1, tv.GetObjectRow (n1));
+			Assert.Null (tv.GetObjectRow (n1_1));
+			Assert.Null (tv.GetObjectRow (n1_2));
+			Assert.Equal (0, tv.GetObjectRow (n2));
 		}
 		[Fact, AutoInitShutdown]
 		public void TestTreeViewColor()

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -720,8 +720,55 @@ namespace Terminal.Gui.Views {
 			Assert.Equal (1, tree.GetChildren (root).Count (child => ReferenceEquals (obj2, child)));
 
 		}
-
 		[Fact, AutoInitShutdown]
+		public void TestTreeHitTest ()
+		{
+			var tv = new TreeView { Width = 20, Height = 10 };
+
+			var n1 = new TreeNode ("normal");
+			var n1_1 = new TreeNode ("pink");
+			var n1_2 = new TreeNode ("normal");
+			n1.Children.Add (n1_1);
+			n1.Children.Add (n1_2);
+
+			var n2 = new TreeNode ("pink");
+			tv.AddObject (n1);
+			tv.AddObject (n2);
+			tv.Expand (n1);
+
+			tv.ColorScheme = new ColorScheme ();
+			tv.Redraw (tv.Bounds);
+
+			GraphViewTests.AssertDriverContentsAre (
+@"├-normal
+│ ├─pink
+│ └─normal
+└─pink
+", output);
+
+			Assert.Same (n1, tv.HitTest (new Point (0, 0)));
+			Assert.Same (n1_1, tv.HitTest (new Point (0, 1)));
+			Assert.Same (n1_2, tv.HitTest (new Point (0, 2)));
+			Assert.Same (n2, tv.HitTest (new Point (0, 3)));
+			Assert.Null (tv.HitTest (new Point (0, 4)));
+
+			tv.Collapse (n1);
+
+			tv.Redraw (tv.Bounds);
+
+
+			GraphViewTests.AssertDriverContentsAre (
+@"├+normal
+└─pink
+", output);
+
+			Assert.Same (n1, tv.HitTest (new Point (0, 0)));
+			Assert.Same (n2, tv.HitTest (new Point (0, 1)));
+			Assert.Null (tv.HitTest (new Point (0, 2)));
+			Assert.Null (tv.HitTest (new Point (0, 3)));
+			Assert.Null (tv.HitTest (new Point (0, 4)));
+		}
+			[Fact, AutoInitShutdown]
 		public void TestTreeViewColor()
 		{
 			var tv = new TreeView{Width = 20,Height = 10};

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -768,7 +768,68 @@ namespace Terminal.Gui.Views {
 			Assert.Null (tv.HitTest (new Point (0, 3)));
 			Assert.Null (tv.HitTest (new Point (0, 4)));
 		}
-			[Fact, AutoInitShutdown]
+
+		[Fact, AutoInitShutdown]
+		public void TestTreeIndexOf ()
+		{
+			var tv = new TreeView { Width = 20, Height = 10 };
+
+			var n1 = new TreeNode ("normal");
+			var n1_1 = new TreeNode ("pink");
+			var n1_2 = new TreeNode ("normal");
+			n1.Children.Add (n1_1);
+			n1.Children.Add (n1_2);
+
+			var n2 = new TreeNode ("pink");
+			tv.AddObject (n1);
+			tv.AddObject (n2);
+			tv.Expand (n1);
+
+			tv.ColorScheme = new ColorScheme ();
+			tv.Redraw (tv.Bounds);
+
+			GraphViewTests.AssertDriverContentsAre (
+@"├-normal
+│ ├─pink
+│ └─normal
+└─pink
+", output);
+
+			Assert.Equal (0, tv.IndexOf (n1));
+			Assert.Equal (1, tv.IndexOf (n1_1));
+			Assert.Equal (2, tv.IndexOf (n1_2));
+			Assert.Equal (3, tv.IndexOf (n2));
+
+			tv.Collapse (n1);
+
+			tv.Redraw (tv.Bounds);
+
+
+			GraphViewTests.AssertDriverContentsAre (
+@"├+normal
+└─pink
+", output);
+			Assert.Equal (0, tv.IndexOf (n1));
+			Assert.Null (tv.IndexOf (n1_1));
+			Assert.Null (tv.IndexOf (n1_2));
+			Assert.Equal (1, tv.IndexOf (n2));
+
+
+			// scroll down 1
+			tv.ScrollOffsetVertical = 1;
+
+			tv.Redraw (tv.Bounds);
+
+
+			GraphViewTests.AssertDriverContentsAre (
+@"└─pink
+", output);
+			Assert.Equal (-1, tv.IndexOf (n1));
+			Assert.Null (tv.IndexOf (n1_1));
+			Assert.Null (tv.IndexOf (n1_2));
+			Assert.Equal (0, tv.IndexOf (n2));
+		}
+		[Fact, AutoInitShutdown]
 		public void TestTreeViewColor()
 		{
 			var tv = new TreeView{Width = 20,Height = 10};

--- a/UnitTests/TreeViewTests.cs
+++ b/UnitTests/TreeViewTests.cs
@@ -721,7 +721,7 @@ namespace Terminal.Gui.Views {
 
 		}
 		[Fact, AutoInitShutdown]
-		public void TestGetObjectAtPoint ()
+		public void TestGetObjectOnRow ()
 		{
 			var tv = new TreeView { Width = 20, Height = 10 };
 
@@ -746,11 +746,11 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Same (n1, tv.GetObjectAtPoint (new Point (0, 0)));
-			Assert.Same (n1_1, tv.GetObjectAtPoint (new Point (0, 1)));
-			Assert.Same (n1_2, tv.GetObjectAtPoint (new Point (0, 2)));
-			Assert.Same (n2, tv.GetObjectAtPoint (new Point (0, 3)));
-			Assert.Null (tv.GetObjectAtPoint (new Point (0, 4)));
+			Assert.Same (n1, tv.GetObjectOnRow (0));
+			Assert.Same (n1_1, tv.GetObjectOnRow (1));
+			Assert.Same (n1_2, tv.GetObjectOnRow (2));
+			Assert.Same (n2, tv.GetObjectOnRow (3));
+			Assert.Null (tv.GetObjectOnRow (4));
 
 			tv.Collapse (n1);
 
@@ -762,11 +762,11 @@ namespace Terminal.Gui.Views {
 └─pink
 ", output);
 
-			Assert.Same (n1, tv.GetObjectAtPoint (new Point (0, 0)));
-			Assert.Same (n2, tv.GetObjectAtPoint (new Point (0, 1)));
-			Assert.Null (tv.GetObjectAtPoint (new Point (0, 2)));
-			Assert.Null (tv.GetObjectAtPoint (new Point (0, 3)));
-			Assert.Null (tv.GetObjectAtPoint (new Point (0, 4)));
+			Assert.Same (n1, tv.GetObjectOnRow (0));
+			Assert.Same (n2, tv.GetObjectOnRow (1));
+			Assert.Null (tv.GetObjectOnRow (2));
+			Assert.Null (tv.GetObjectOnRow (3));
+			Assert.Null (tv.GetObjectOnRow (4));
 		}
 
 		[Fact, AutoInitShutdown]


### PR DESCRIPTION
This PR adds the following methods to TreeView:

- HitTest
- IndexOf

These combine to allow API users to implement `ContextMenu`  in a simple and elegant fashion:
![contextmenu](https://user-images.githubusercontent.com/31306100/167661483-cb0863d3-254e-4b20-8354-d91ee8919608.gif)

HitTest is important for telling what the user has right clicked in the tree.
IndexOf is important for showing the context menu in a sensible place when using keyboard activation

I have left both X and Y components in HitTest even though only Y is used to ensure that there is a backwards compatibility if we make changes later (e.g. finding a right edge to objects in the tree or reutrning null for clicking branch lines).

IndexOf simply returns the Y.
