### PR TITLE
Fixes #1693 (Charmap wide runes) by upgrading to Nstack.core 0.17

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
-    <PackageReference Include="NStack.Core" Version="0.16.0" />
+    <PackageReference Include="NStack.Core" Version="0.17.0" />
     <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="all" />
     <InternalsVisibleTo Include="UnitTests" />
     <!-- <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" /> -->


### PR DESCRIPTION
Fixes #1693 (Charmap wide runes) by upgrading to Nstack.core 0.17.

(Draft until @migueldeicaza has a chance to release a new NStack.Core (assuming v 0.17) to Nuget).