### PR TITLE
Fixes nullref on unclean shutdown

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1892,8 +1892,11 @@ namespace Terminal.Gui {
 		void IMainLoopDriver.MainIteration ()
 		{
 			while (resultQueue.Count > 0) {
-				var inputEvent = resultQueue.Dequeue () [0];
-				ProcessInput?.Invoke (inputEvent);
+				var inputRecords = resultQueue.Dequeue ();
+				if (inputRecords != null && inputRecords.Length > 0) {
+					var inputEvent = inputRecords [0];
+					ProcessInput?.Invoke (inputEvent);
+				}
 			}
 			if (winChanged) {
 				winChanged = false;


### PR DESCRIPTION
First of all thanks for this lovely framework! I've been playing around with it for a couple of days now and I'm seriously considering picking it up for my project.

I ran into crashes in the WindowsDriver on my system while playing around with both my own project and the UICatalog example. It only happens when I forcibly close the terminal window. Because the crash happens while the process is being killed, the executable remains locked by Visual Studio, making it difficult to rebuild again after.

The debugger catches the exception, but it gets killed itself soon after. Luckily it was easy enough to see where it went wrong. I'm guessing that the `ReadConsoleInput` function takes a `ThreadAbortException` or something similar and hence returns `null`. But the `WindowsInputHandler` doesn't do a null check and simply enqueues it. Then in another (still running) thread the `null` is dequeued by `MainIteration` and attempts to access the 1st item, causing a `NullReferenceException`.

I've proposed a patch that not only checks for possible `null` but also verifies that length of the array is at least 1. The latter check might be superfluous but closes another possible crash vector. I've also considering doing the null check at the enqueue side of things, but I didn't see any immediate benefit or downside from doing it in either place, so I kept it at the consuming side so that it's also safe from other future producers.

- Visual Studio 2022 (v17.2)
- Windows 11 (v22000.675)
- Windows Terminal (v1.12.10983.0)