### PR TITLE
Reverts Clear method to use AddRune instead of AddStr.

### DIFF
--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1022,7 +1022,7 @@ namespace Terminal.Gui {
 			for (int line = 0; line < h; line++) {
 				Move (0, line);
 				for (int col = 0; col < w; col++)
-					Driver.AddStr (" ");
+					Driver.AddRune (' ');
 			}
 		}
 

--- a/UnitTests/GraphViewTests.cs
+++ b/UnitTests/GraphViewTests.cs
@@ -207,7 +207,7 @@ namespace Terminal.Gui.Views {
 
 				Assert.Equal (expectedLook, actualLook);
 			}
-			return new Rect (x, y, w > -1 ? w : 0, h > -1 ? h : 0);
+			return new Rect (x > -1 ? x : 0, y > -1 ? y : 0, w > -1 ? w : 0, h > -1 ? h : 0);
 		}
 
 #pragma warning disable xUnit1013 // Public method should be marked as test

--- a/UnitTests/ViewTests.cs
+++ b/UnitTests/ViewTests.cs
@@ -2256,5 +2256,101 @@ Y
 			pos = GraphViewTests.AssertDriverContentsWithFrameAre (expected, output);
 			Assert.Equal (new Rect (1, 1, 21, 14), pos);
 		}
+
+		[Fact, AutoInitShutdown]
+		public void Clear_Can_Use_Driver_AddRune_Or_AddStr_Methods ()
+		{
+			var view = new View () {
+				Width = Dim.Fill (),
+				Height = Dim.Fill ()
+			};
+			view.LayoutComplete += e => {
+				view.DrawFrame (view.Bounds);
+				var savedClip = Application.Driver.Clip;
+				Application.Driver.Clip = new Rect (1, 1, view.Bounds.Width - 2, view.Bounds.Height - 2);
+				for (int row = 0; row < view.Bounds.Height - 2; row++) {
+					Application.Driver.Move (1, row + 1);
+					for (int col = 0; col < view.Bounds.Width - 2; col++) {
+						Application.Driver.AddStr ($"{col}");
+					}
+				}
+				Application.Driver.Clip = savedClip;
+			};
+			Application.Top.Add (view);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+
+			var expected = @"
+┌──────────────────┐
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+└──────────────────┘
+";
+
+			var pos = GraphViewTests.AssertDriverContentsWithFrameAre (expected, output);
+			Assert.Equal (new Rect (0, 0, 20, 10), pos);
+
+			view.Clear ();
+
+			expected = @"
+";
+
+			pos = GraphViewTests.AssertDriverContentsWithFrameAre (expected, output);
+			Assert.Equal (Rect.Empty, pos);
+		}
+
+		[Fact, AutoInitShutdown]
+		public void Clear_Bounds_Can_Use_Driver_AddRune_Or_AddStr_Methods ()
+		{
+			var view = new View () {
+				Width = Dim.Fill (),
+				Height = Dim.Fill ()
+			};
+			view.LayoutComplete += e => {
+				view.DrawFrame (view.Bounds);
+				var savedClip = Application.Driver.Clip;
+				Application.Driver.Clip = new Rect (1, 1, view.Bounds.Width - 2, view.Bounds.Height - 2);
+				for (int row = 0; row < view.Bounds.Height - 2; row++) {
+					Application.Driver.Move (1, row + 1);
+					for (int col = 0; col < view.Bounds.Width - 2; col++) {
+						Application.Driver.AddStr ($"{col}");
+					}
+				}
+				Application.Driver.Clip = savedClip;
+			};
+			Application.Top.Add (view);
+			Application.Begin (Application.Top);
+			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
+
+			var expected = @"
+┌──────────────────┐
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+│012345678910111213│
+└──────────────────┘
+";
+
+			var pos = GraphViewTests.AssertDriverContentsWithFrameAre (expected, output);
+			Assert.Equal (new Rect (0, 0, 20, 10), pos);
+
+			view.Clear (view.Bounds);
+
+			expected = @"
+";
+
+			pos = GraphViewTests.AssertDriverContentsWithFrameAre (expected, output);
+			Assert.Equal (Rect.Empty, pos);
+		}
 	}
 }


### PR DESCRIPTION
When I changed this I made some confusion that `AddRune` wasn't moving the column, but is the place where it's moving really, sorry. Perhaps because in the `NetDriver` it wasn't moving if it's outside of the clip bounds, but that was also fixed.