### PR TITLE
Makes it easier to use a local NStack.Core package

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -6,10 +6,16 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;DEBUG_IDISPOSABLE</DefineConstants>
   </PropertyGroup>
+  
+  <PropertyGroup>
+  <!-- Uncomment this to have dotnet restore pull NStack from a local dir for testing -->
+  <!-- See https://stackoverflow.com/a/44463578/297526 -->
+    <!--<RestoreSources>$(RestoreSources);../../local-packages;https://api.nuget.org/v3/index.json</RestoreSources>-->
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
-    <PackageReference Include="NStack.Core" Version="0.16.0" />
+    <PackageReference Include="NStack.Core" Version="0.*" />
     <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="all" />
     <InternalsVisibleTo Include="UnitTests" />
     <!-- <None Remove="ConsoleDrivers\#ConsoleDriver.cs#" /> -->
@@ -30,9 +36,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <PropertyGroup>
-      <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
-  </PropertyGroup>
-  <PropertyGroup>
+    <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
+
     <!-- See Terminal.Gui/README.md for how version numbering works -->
     <!-- This enables prefixing version tags with v, e.g. v1.0.0 Instead of 1.0.0 -->
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/Terminal.Gui/packages.config
+++ b/Terminal.Gui/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NStack.Core" version="0.14.0" targetFramework="net472" />
-</packages>

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.128
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32427.441
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example", "Example\Example.csproj", "{B0A602CD-E176-449D-8663-64238D54F857}"
 EndProject
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md
+		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
A minor tweak to the project that makes it easy to switch between using a locally built NStack.Core v. the Nuget.org version.