### PR TITLE
Explicitly dispose old TreeView instances in UICatalog scenario

### DIFF
--- a/UICatalog/Scenarios/TreeUseCases.cs
+++ b/UICatalog/Scenarios/TreeUseCases.cs
@@ -75,6 +75,7 @@ namespace UICatalog.Scenarios {
 
 			if (currentTree != null) {
 				Win.Remove (currentTree);
+				currentTree.Dispose ();
 			}
 
 
@@ -148,6 +149,7 @@ namespace UICatalog.Scenarios {
 
 			if (currentTree != null) {
 				Win.Remove (currentTree);
+				currentTree.Dispose ();
 			}
 
 
@@ -180,6 +182,7 @@ namespace UICatalog.Scenarios {
 		{
 			if (currentTree != null) {
 				Win.Remove (currentTree);
+				currentTree.Dispose ();
 			}
 
 


### PR DESCRIPTION
Fixes #1742

When swapping out old TreeViews for new there was no call to Dispose.  This resulted in the Scenario post run check failing `Debug.Assert (inst.WasDisposed);`.