### PR TITLE
Fixes #1772. Avoids WindowsDriver flickering when resizing.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -1571,6 +1571,12 @@ namespace Terminal.Gui {
 			if (damageRegion.Left == -1)
 				return;
 
+			if (!HeightAsBuffer) {
+				var windowSize = WinConsole.GetConsoleBufferWindow (out _);
+				if (!windowSize.IsEmpty && (windowSize.Width != Cols || windowSize.Height != Rows))
+					return;
+			}
+
 			var bufferCoords = new WindowsConsole.Coord () {
 				X = (short)Clip.Width,
 				Y = (short)Clip.Height


### PR DESCRIPTION
![windowsdriver-resize-behavior-fix](https://user-images.githubusercontent.com/13117724/172956131-d895eb6e-21cd-47fc-bc2f-769781bd6729.gif)
