### PR TITLE
Fixes #1777 - Dialog button justification. Adds unit tests.

### DIFF
--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -116,17 +116,100 @@ namespace Terminal.Gui {
 			}
 			return buttons.Select (b => b.Bounds.Width).Sum () + buttons.Count - 1;
 		}
+		/// <summary>
+		/// Determines the horizontal alignment of the Dialog buttons.
+		/// </summary>
+		public enum ButtonAlignments {
+			/// <summary>
+			/// Center-aligns the buttons (the default).
+			/// </summary>
+			Center = 0,
+
+			/// <summary>
+			/// Justifies the buttons
+			/// </summary>
+			Justify,
+
+			/// <summary>
+			/// Left-aligns the buttons
+			/// </summary>
+			Left,
+
+			/// <summary>
+			/// Right-aligns the buttons
+			/// </summary>
+			Right
+		}
+		public ButtonAlignments ButtonAlignment = Dialog.ButtonAlignments.Center;
 
 		void LayoutStartedHandler ()
 		{
-			int buttonsWidth = GetButtonsWidth ();
+			int shiftLeft = 0;
 
-			int shiftLeft = Math.Max ((Bounds.Width - buttonsWidth) / 2 - 2, 0);
-			for (int i = buttons.Count - 1; i >= 0; i--) {
-				Button button = buttons [i];
-				shiftLeft += button.Frame.Width + 1;
-				button.X = Pos.AnchorEnd (shiftLeft);
-				button.Y = Pos.AnchorEnd (1);
+			int buttonsWidth = GetButtonsWidth ();
+			switch (ButtonAlignment) {
+			case ButtonAlignments.Center:
+				// Center Buttons
+				shiftLeft = Math.Max ((Bounds.Width - buttonsWidth) / 2 - 2, 0);
+				for (int i = buttons.Count - 1; i >= 0; i--) {
+					Button button = buttons [i];
+					shiftLeft += button.Frame.Width + 1;
+					button.X = Pos.AnchorEnd (shiftLeft);
+					button.Y = Pos.AnchorEnd (1);
+				}
+				break;
+
+			case ButtonAlignments.Justify:
+				// Justify Buttons
+				if (buttons.Count == 0) break;
+				if (buttons.Count == 1) {
+					buttons [0].X = Pos.Center ();
+					buttons [0].Y = Pos.AnchorEnd (1);
+					break;
+				}
+
+				var prevButton = buttons [0];
+				prevButton.X = 0;
+				prevButton.Y = Pos.AnchorEnd (1);
+				if (buttons.Count > 1) {
+					var shiftRight = (Bounds.Width - buttonsWidth - 1) / (buttons.Count - 1);
+					for (int i = 1; i < buttons.Count; i++) {
+						Button button = buttons [i];
+						button.X = Pos.Right (prevButton) + shiftRight + 1;
+						button.Y = Pos.AnchorEnd (1);
+						prevButton = button;
+					}
+				}
+				// Force last button to right align (due to rounding)
+				var shift = buttons [buttons.Count - 1].Bounds.Width ;
+				buttons [buttons.Count - 1].X = Pos.AnchorEnd (shift);
+				break;
+
+			case ButtonAlignments.Left:
+				// Left Align Buttons
+				prevButton = buttons [0];
+				prevButton.X = 0;
+				prevButton.Y = Pos.AnchorEnd (1);
+				for (int i = 1; i < buttons.Count; i++) {
+					Button button = buttons [i];
+					button.X = Pos.Right (prevButton) + 1;
+					button.Y = Pos.AnchorEnd (1);
+					prevButton = button;
+				}
+				break;
+
+			case ButtonAlignments.Right:
+				// Right align buttons
+				shiftLeft = buttons [buttons.Count - 1].Frame.Width;
+				buttons [buttons.Count - 1].X = Pos.AnchorEnd (shiftLeft);
+				buttons [buttons.Count - 1].Y = Pos.AnchorEnd (1);
+				for (int i = buttons.Count - 2; i >= 0; i--) {
+					Button button = buttons [i];
+					shiftLeft += button.Frame.Width + 1;
+					button.X = Pos.AnchorEnd (shiftLeft);
+					button.Y = Pos.AnchorEnd (1);
+				}
+				break;
 			}
 		}
 
@@ -140,5 +223,6 @@ namespace Terminal.Gui {
 			}
 			return base.ProcessKey (kb);
 		}
+
 	}
 }

--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -141,11 +141,14 @@ namespace Terminal.Gui {
 			/// </summary>
 			Right
 		}
+
+		private ButtonAlignments buttonAlignment = Dialog.ButtonAlignments.Center;
+
 		/// <summary>
 		/// Determines how the <see cref="Dialog"/> <see cref="Button"/>s are aligned along the 
 		/// bottom of the dialog. 
 		/// </summary>
-		public ButtonAlignments ButtonAlignment = Dialog.ButtonAlignments.Center;
+		public ButtonAlignments ButtonAlignment { get => buttonAlignment; set => buttonAlignment = value; }
 
 		void LayoutStartedHandler ()
 		{

--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -140,6 +140,10 @@ namespace Terminal.Gui {
 			/// </summary>
 			Right
 		}
+		/// <summary>
+		/// Determines how the <see cref="Dialog"/> <see cref="Button"/>s are aligned along the 
+		/// bottom of the dialog. 
+		/// </summary>
 		public ButtonAlignments ButtonAlignment = Dialog.ButtonAlignments.Center;
 
 		void LayoutStartedHandler ()

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -15,7 +15,7 @@ namespace UICatalog.Scenarios {
 				X = Pos.Center (),
 				Y = 1,
 				Width = Dim.Percent (75),
-				Height = 10
+				Height = 15
 			};
 			Win.Add (frame);
 
@@ -92,10 +92,25 @@ namespace UICatalog.Scenarios {
 			};
 			frame.Add (numButtonsEdit);
 
+
+			label = new Label ("Button Style:") {
+				X = 0,
+				Y = Pos.Bottom (label),
+				Width = Dim.Width (label),
+				Height = 1,
+				TextAlignment = Terminal.Gui.TextAlignment.Right,
+			};
+			frame.Add (label);
+			var styleRadioGroup = new RadioGroup (new ustring [] { "Center", "Justify", "Left", "Right" }) {
+				X = Pos.Right (label) + 1,
+				Y = Pos.Top (label),
+			};
+			frame.Add (styleRadioGroup);
+
 			void Top_Loaded ()
 			{
 				frame.Height = Dim.Height (widthEdit) + Dim.Height (heightEdit) + Dim.Height (titleEdit)
-					+ Dim.Height (numButtonsEdit) + 2;
+					+ Dim.Height (numButtonsEdit) + Dim.Height(styleRadioGroup) + 2;
 				Top.Loaded -= Top_Loaded;
 			}
 			Top.Loaded += Top_Loaded;
@@ -145,7 +160,10 @@ namespace UICatalog.Scenarios {
 					// This tests dynamically adding buttons; ensuring the dialog resizes if needed and 
 					// the buttons are laid out correctly
 					var dialog = new Dialog (titleEdit.Text, width, height,
-						buttons.ToArray ());
+						buttons.ToArray ()) {
+						ButtonAlignment = (Dialog.ButtonAlignments)styleRadioGroup.SelectedItem
+					};
+
 					var add = new Button ("Add a button") {
 						X = Pos.Center (),
 						Y = Pos.Center ()

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -148,9 +148,12 @@ namespace UICatalog.Scenarios {
 			};
 			showDialogButton.Clicked += () => {
 				try {
-					int width = int.Parse (widthEdit.Text.ToString ());
-					int height = int.Parse (heightEdit.Text.ToString ());
-					int numButtons = int.Parse (numButtonsEdit.Text.ToString ());
+					int width = 0;
+					int.TryParse (widthEdit.Text.ToString (), out width);
+					int height = 0;
+					int.TryParse (heightEdit.Text.ToString (), out height);
+					int numButtons = 3;
+					int.TryParse (numButtonsEdit.Text.ToString (), out numButtons);
 
 					var buttons = new List<Button> ();
 					var clicked = -1;

--- a/UICatalog/Scenarios/Dialogs.cs
+++ b/UICatalog/Scenarios/Dialogs.cs
@@ -9,13 +9,13 @@ namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Dialogs", Description: "Demonstrates how to the Dialog class")]
 	[ScenarioCategory ("Dialogs")]
 	public class Dialogs : Scenario {
+		static int CODE_POINT = '你'; // We know this is a wide char
 		public override void Setup ()
 		{
 			var frame = new FrameView ("Dialog Options") {
 				X = Pos.Center (),
-				Y = 1,
-				Width = Dim.Percent (75),
-				Height = 15
+				Y = 0,
+				Width = Dim.Percent (75)
 			};
 			Win.Add (frame);
 
@@ -92,12 +92,18 @@ namespace UICatalog.Scenarios {
 			};
 			frame.Add (numButtonsEdit);
 
+			var glyphsNotWords = new CheckBox ($"Add {Char.ConvertFromUtf32(CODE_POINT)} to button text to stress wide char support", false) {
+				X = Pos.Left (numButtonsEdit),
+				Y = Pos.Bottom (label),
+				TextAlignment = Terminal.Gui.TextAlignment.Right,
+			};
+			frame.Add (glyphsNotWords);
+
 
 			label = new Label ("Button Style:") {
 				X = 0,
-				Y = Pos.Bottom (label),
-				Width = Dim.Width (label),
-				Height = 1,
+				Y = Pos.Bottom (glyphsNotWords),
+				AutoSize = true,
 				TextAlignment = Terminal.Gui.TextAlignment.Right,
 			};
 			frame.Add (label);
@@ -110,7 +116,7 @@ namespace UICatalog.Scenarios {
 			void Top_Loaded ()
 			{
 				frame.Height = Dim.Height (widthEdit) + Dim.Height (heightEdit) + Dim.Height (titleEdit)
-					+ Dim.Height (numButtonsEdit) + Dim.Height(styleRadioGroup) + 2;
+					+ Dim.Height (numButtonsEdit) + Dim.Height (styleRadioGroup) + Dim.Height(glyphsNotWords) + 2;
 				Top.Loaded -= Top_Loaded;
 			}
 			Top.Loaded += Top_Loaded;
@@ -127,10 +133,14 @@ namespace UICatalog.Scenarios {
 				Y = Pos.Bottom (frame) + 5,
 				Width = 25,
 				Height = 1,
+
 				ColorScheme = Colors.Error,
 			};
+			// glyphsNotWords
+			// false:var btnText = new [] { "Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine" };
+			// true: var btnText = new [] { "0", "\u2780", "➁", "\u2783", "\u2784", "\u2785", "\u2786", "\u2787", "\u2788", "\u2789" };
+			// \u2781 is ➁ dingbats \ufb70 is	
 
-			//var btnText = new [] { "Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine" };
 			var showDialogButton = new Button ("Show Dialog") {
 				X = Pos.Center (),
 				Y = Pos.Bottom (frame) + 2,
@@ -145,11 +155,16 @@ namespace UICatalog.Scenarios {
 					var buttons = new List<Button> ();
 					var clicked = -1;
 					for (int i = 0; i < numButtons; i++) {
-						var buttonId = i;
-						//var button = new Button (btnText [buttonId % 10],
-						//	is_default: buttonId == 0);
-						var button = new Button (NumberToWords.Convert (buttonId),
-							is_default: buttonId == 0);
+						int buttonId = i;
+						Button button = null;
+						if (glyphsNotWords.Checked) {
+							buttonId = i;
+							button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
+								is_default: buttonId == 0);
+						} else {
+							button = new Button (NumberToWords.Convert (buttonId),
+							       is_default: buttonId == 0);
+						}
 						button.Clicked += () => {
 							clicked = buttonId;
 							Application.RequestStop ();
@@ -170,10 +185,14 @@ namespace UICatalog.Scenarios {
 					};
 					add.Clicked += () => {
 						var buttonId = buttons.Count;
-						//var button = new Button (btnText [buttonId % 10],
-						//	is_default: buttonId == 0);
-						var button = new Button (NumberToWords.Convert (buttonId),
-							is_default: buttonId == 0);
+						Button button;
+						if (glyphsNotWords.Checked) {
+							button = new Button (NumberToWords.Convert (buttonId) + " " + Char.ConvertFromUtf32 (buttonId + CODE_POINT),
+								is_default: buttonId == 0);
+						} else {
+							button = new Button (NumberToWords.Convert (buttonId),
+								is_default: buttonId == 0);
+						}
 						button.Clicked += () => {
 							clicked = buttonId;
 							Application.RequestStop ();

--- a/UnitTests/ConsoleDriverTests.cs
+++ b/UnitTests/ConsoleDriverTests.cs
@@ -576,7 +576,7 @@ namespace Terminal.Gui.ConsoleDrivers {
 ││  Hello World  │ │
 ││               │ │
 ││               │ │
-││     [ Ok ]    │ │
+││    [ Ok ]     │ │
 │└───────────────┘ │
 └──────────────────┘
 ";

--- a/UnitTests/ConsoleDriverTests.cs
+++ b/UnitTests/ConsoleDriverTests.cs
@@ -593,7 +593,7 @@ namespace Terminal.Gui.ConsoleDrivers {
 ││  Hello World  │ │
 ││               │ │
 ││               │ │
-││     [ Ok ]    │ │
+││    [ Ok ]     │ │
 │└───────────────┘ │
 └──────────────────┘
 ";

--- a/UnitTests/DialogTests.cs
+++ b/UnitTests/DialogTests.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Terminal.Gui;
+using Xunit;
+using System.Globalization;
+using Xunit.Abstractions;
+
+namespace Terminal.Gui.Views {
+
+	public class DialogTests {
+		readonly ITestOutputHelper output;
+
+		public DialogTests (ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		private void RunButtonTestDialog (string title, int width, Dialog.ButtonAlignments align, params Button [] btns)
+		{
+			var dlg = new Dialog (title, width, 3, btns) { ButtonAlignment = align };
+			Application.End (Application.Begin (dlg));
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_One ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+			// E.g "|[ ok ]|"
+			var btnText = "ok";
+			var buttonRow = $"{d.VLine}   {d.LeftBracket} {btnText} {d.RightBracket}   {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+
+			d.SetBufferSize (width, 3);
+
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $"{d.VLine}   {d.LeftBracket} {btnText} {d.RightBracket}   {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $"{d.VLine}      {d.LeftBracket} {btnText} {d.RightBracket}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $"{d.VLine}{d.LeftBracket} {btnText} {d.RightBracket}      {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_Two ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+			// E.g "|[ yes ][ no ]|"
+			var btn1Text = "yes";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "no";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+
+			var buttonRow = $@"{d.VLine} {btn1} {btn2} {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $@"{d.VLine}{btn1}   {btn2}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $@"{d.VLine}  {btn1} {btn2}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $@"{d.VLine}{btn1} {btn2}  {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_Three ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+			// E.g "|[ yes ][ no ][ maybe ]|"
+			var btn1Text = "yes";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "no";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+			var btn3Text = "maybe";
+			var btn3 = $"{d.LeftBracket} {btn3Text} {d.RightBracket}";
+
+			var buttonRow = $@"{d.VLine} {btn1} {btn2} {btn3} {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $@"{d.VLine}{btn1}  {btn2}  {btn3}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $@"{d.VLine}  {btn1} {btn2} {btn3}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $@"{d.VLine}{btn1} {btn2} {btn3}  {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_Four ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+
+			// E.g "|[ yes ][ no ][ maybe ]|"
+			var btn1Text = "yes";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "no";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+			var btn3Text = "maybe";
+			var btn3 = $"{d.LeftBracket} {btn3Text} {d.RightBracket}";
+			var btn4Text = "never";
+			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
+
+			var buttonRow = $"{d.VLine} {btn1} {btn2} {btn3} {btn4} {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			// Default - Center
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $"{d.VLine}{btn1}  {btn2}  {btn3} {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $"{d.VLine}  {btn1} {btn2} {btn3} {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}  {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_Four_Wider ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+
+			// E.g "|[ yes ][ no ][ maybe ]|"
+			var btn1Text = "yes";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "no";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+			var btn3Text = "maybe";
+			var btn3 = $"{d.LeftBracket} {btn3Text} {d.RightBracket}";
+			var btn4Text = "never";
+			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
+
+			// Note extra spaces to make dialog even wider
+			//                         123456                           12345
+			var buttonRow = $"{d.VLine}      {btn1} {btn2} {btn3} {btn4}     {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			// Default - Center
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $"{d.VLine}{btn1}     {btn2}     {btn3}    {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $"{d.VLine}           {btn1} {btn2} {btn3} {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}           {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void ButtonAlignment_Four_WideOdd ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+
+			// E.g "|[ yes ][ no ][ maybe ]|"
+			var btn1Text = "really long button 1";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "really long button 2";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+			var btn3Text = "really long button 3";
+			var btn3 = $"{d.LeftBracket} {btn3Text} {d.RightBracket}";
+			var btn4Text = "really long button 44"; // 44 is intentional to make length different than rest
+			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
+
+			// Note extra spaces to make dialog even wider
+			//                         123456                           12345
+			var buttonRow = $"{d.VLine}      {btn1} {btn2} {btn3} {btn4}     {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			// Default - Center
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Justify
+			buttonRow = $"{d.VLine}{btn1}     {btn2}     {btn3}    {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Right
+			buttonRow = $"{d.VLine}           {btn1} {btn2} {btn3} {btn4}{d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Left
+			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}           {d.VLine}";
+			Assert.Equal (width, buttonRow.Length);
+			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+		}
+	}
+}

--- a/UnitTests/DialogTests.cs
+++ b/UnitTests/DialogTests.cs
@@ -7,6 +7,7 @@ using Terminal.Gui;
 using Xunit;
 using System.Globalization;
 using Xunit.Abstractions;
+using NStack;
 
 namespace Terminal.Gui.Views {
 
@@ -208,18 +209,19 @@ namespace Terminal.Gui.Views {
 			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
 			var btn2Text = "no";
 			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
-			var btn3Text = "maybe";
+			var btn3Text = "你你你你你"; // This is a wide char
 			var btn3 = $"{d.LeftBracket} {btn3Text} {d.RightBracket}";
-			var btn4Text = "never";
+			// Requires a Nerd Font
+			var btn4Text = "\uE36E\uE36F\uE370\uE371\uE372\uE373";
 			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
 
 			// Note extra spaces to make dialog even wider
 			//                         123456                           12345
 			var buttonRow = $"{d.VLine}      {btn1} {btn2} {btn3} {btn4}     {d.VLine}";
-			var width = buttonRow.Length;
+			var width = ustring.Make (buttonRow).ConsoleWidth;
 			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
 			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
-			d.SetBufferSize (buttonRow.Length, 3);
+			d.SetBufferSize (width, 3);
 
 			// Default - Center
 			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
@@ -227,19 +229,19 @@ namespace Terminal.Gui.Views {
 
 			// Justify
 			buttonRow = $"{d.VLine}{btn1}     {btn2}     {btn3}    {btn4}{d.VLine}";
-			Assert.Equal (width, buttonRow.Length);
+			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
 			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
 
 			// Right
 			buttonRow = $"{d.VLine}           {btn1} {btn2} {btn3} {btn4}{d.VLine}";
-			Assert.Equal (width, buttonRow.Length);
+			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
 			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
 
 			// Left
 			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}           {d.VLine}";
-			Assert.Equal (width, buttonRow.Length);
+			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
 			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
 		}

--- a/UnitTests/DialogTests.cs
+++ b/UnitTests/DialogTests.cs
@@ -19,10 +19,10 @@ namespace Terminal.Gui.Views {
 			this.output = output;
 		}
 
-		private void RunButtonTestDialog (string title, int width, Dialog.ButtonAlignments align, params Button [] btns)
+		private Application.RunState RunButtonTestDialog (string title, int width, Dialog.ButtonAlignments align, params Button [] btns)
 		{
 			var dlg = new Dialog (title, width, 3, btns) { ButtonAlignment = align };
-			Application.End (Application.Begin (dlg));
+			return Application.Begin (dlg);
 		}
 
 		[Fact]
@@ -41,26 +41,30 @@ namespace Terminal.Gui.Views {
 
 			d.SetBufferSize (width, 3);
 
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
-			buttonRow = $"{d.VLine}   {d.LeftBracket} {btnText} {d.RightBracket}   {d.VLine}";
+			buttonRow = $"{d.VLine}      {d.LeftBracket} {btnText} {d.RightBracket}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btnText));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $"{d.VLine}      {d.LeftBracket} {btnText} {d.RightBracket}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btnText));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $"{d.VLine}{d.LeftBracket} {btnText} {d.RightBracket}      {d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btnText));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 
 		[Fact]
@@ -83,26 +87,30 @@ namespace Terminal.Gui.Views {
 
 			d.SetBufferSize (buttonRow.Length, 3);
 
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
 			buttonRow = $@"{d.VLine}{btn1}   {btn2}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $@"{d.VLine}  {btn1} {btn2}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $@"{d.VLine}{btn1} {btn2}  {d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 
 		[Fact]
@@ -127,26 +135,30 @@ namespace Terminal.Gui.Views {
 
 			d.SetBufferSize (buttonRow.Length, 3);
 
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
 			buttonRow = $@"{d.VLine}{btn1}  {btn2}  {btn3}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $@"{d.VLine}  {btn1} {btn2} {btn3}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $@"{d.VLine}{btn1} {btn2} {btn3}  {d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 
 		[Fact]
@@ -174,26 +186,30 @@ namespace Terminal.Gui.Views {
 			d.SetBufferSize (buttonRow.Length, 3);
 
 			// Default - Center
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
-			buttonRow = $"{d.VLine}{btn1}  {btn2}  {btn3} {btn4}{d.VLine}";
+			buttonRow = $"{d.VLine}{btn1} {btn2}  {btn3}  {btn4}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $"{d.VLine}  {btn1} {btn2} {btn3} {btn4}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}  {d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 
 		[Fact]
@@ -216,34 +232,38 @@ namespace Terminal.Gui.Views {
 			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
 
 			// Note extra spaces to make dialog even wider
-			//                         123456                           12345
-			var buttonRow = $"{d.VLine}      {btn1} {btn2} {btn3} {btn4}     {d.VLine}";
+			//                         12345                           123456
+			var buttonRow = $"{d.VLine}     {btn1} {btn2} {btn3} {btn4}      {d.VLine}";
 			var width = ustring.Make (buttonRow).ConsoleWidth;
 			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
 			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
 			d.SetBufferSize (width, 3);
 
 			// Default - Center
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
-			buttonRow = $"{d.VLine}{btn1}     {btn2}     {btn3}    {btn4}{d.VLine}";
+			buttonRow = $"{d.VLine}{btn1}    {btn2}     {btn3}     {btn4}{d.VLine}";
 			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $"{d.VLine}           {btn1} {btn2} {btn3} {btn4}{d.VLine}";
 			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}           {d.VLine}";
 			Assert.Equal (width, ustring.Make (buttonRow).ConsoleWidth);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 
 		[Fact]
@@ -265,34 +285,154 @@ namespace Terminal.Gui.Views {
 			var btn4 = $"{d.LeftBracket} {btn4Text} {d.RightBracket}";
 
 			// Note extra spaces to make dialog even wider
-			//                         123456                           12345
-			var buttonRow = $"{d.VLine}      {btn1} {btn2} {btn3} {btn4}     {d.VLine}";
+			//                         12345                          123456
+			var buttonRow = $"{d.VLine}     {btn1} {btn2} {btn3} {btn4}      {d.VLine}";
 			var width = buttonRow.Length;
 			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
 			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
 			d.SetBufferSize (buttonRow.Length, 3);
 
 			// Default - Center
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Justify
-			buttonRow = $"{d.VLine}{btn1}     {btn2}     {btn3}    {btn4}{d.VLine}";
+			buttonRow = $"{d.VLine}{btn1}    {btn2}     {btn3}     {btn4}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Justify, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Right
 			buttonRow = $"{d.VLine}           {btn1} {btn2} {btn3} {btn4}{d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Right, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 
 			// Left
 			buttonRow = $"{d.VLine}{btn1} {btn2} {btn3} {btn4}           {d.VLine}";
 			Assert.Equal (width, buttonRow.Length);
-			RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
+			runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Left, new Button (btn1Text), new Button (btn2Text), new Button (btn3Text), new Button (btn4Text));
 			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void Zero_Buttons_Works ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+
+			var buttonRow = $"{d.VLine}        {d.VLine}";
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, null);
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			Application.End (runstate);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void One_Button_Works ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+			var btnText = "ok";
+			var buttonRow = $"{d.VLine}   {d.LeftBracket} {btnText} {d.RightBracket}   {d.VLine}";
+
+			var width = buttonRow.Length;
+			var topRow = $"┌ {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}┐";
+			var bottomRow = $"└{new String (d.HLine.ToString () [0], width - 2)}┘";
+			d.SetBufferSize (buttonRow.Length, 3);
+
+			var runstate = RunButtonTestDialog (title, width, Dialog.ButtonAlignments.Center, new Button (btnText));
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void Add_Button_Works ()
+		{
+			var d = ((FakeDriver)Application.Driver);
+
+			var title = "1234";
+			var btn1Text = "yes";
+			var btn1 = $"{d.LeftBracket} {btn1Text} {d.RightBracket}";
+			var btn2Text = "no";
+			var btn2 = $"{d.LeftBracket} {btn2Text} {d.RightBracket}";
+
+			// We test with one button first, but do this to get the width right for 2
+			var width = $@"{d.VLine} {btn1} {btn2} {d.VLine}".Length;
+			d.SetBufferSize (width, 3);
+
+			var topRow = $"{d.ULCorner} {title} {new String (d.HLine.ToString () [0], width - title.Length - 4)}{d.URCorner}";
+			var bottomRow = $"{d.LLCorner}{new String (d.HLine.ToString () [0], width - 2)}{d.LRCorner}";
+
+			// Default (center)
+			var dlg = new Dialog (title, width, 3, new Button (btn1Text)) { ButtonAlignment = Dialog.ButtonAlignments.Center };
+			var runstate = Application.Begin (dlg);
+			var buttonRow = $"{d.VLine}    {btn1}     {d.VLine}";
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Now add a second button
+			buttonRow = $"{d.VLine} {btn1} {btn2} {d.VLine}";
+			dlg.AddButton (new Button (btn2Text));
+			bool first = false;
+			Application.RunMainLoopIteration (ref runstate, true, ref first);
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
+
+			// Justify
+			dlg = new Dialog (title, width, 3, new Button (btn1Text)) { ButtonAlignment = Dialog.ButtonAlignments.Justify };
+			runstate = Application.Begin (dlg);
+			buttonRow = $"{d.VLine}         {btn1}{d.VLine}";
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Now add a second button
+			buttonRow = $"{d.VLine}{btn1}   {btn2}{d.VLine}";
+			dlg.AddButton (new Button (btn2Text));
+			first = false;
+			Application.RunMainLoopIteration (ref runstate, true, ref first);
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
+
+			// Right
+			dlg = new Dialog (title, width, 3, new Button (btn1Text)) { ButtonAlignment = Dialog.ButtonAlignments.Right };
+			runstate = Application.Begin (dlg);
+			buttonRow = $"{d.VLine}{new String (' ', width - btn1.Length - 2)}{btn1}{d.VLine}";
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Now add a second button
+			buttonRow = $"{d.VLine}  {btn1} {btn2}{d.VLine}";
+			dlg.AddButton (new Button (btn2Text));
+			first = false;
+			Application.RunMainLoopIteration (ref runstate, true, ref first);
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
+
+			// Left
+			dlg = new Dialog (title, width, 3, new Button (btn1Text)) { ButtonAlignment = Dialog.ButtonAlignments.Left };
+			runstate = Application.Begin (dlg);
+			buttonRow = $"{d.VLine}{btn1}{new String (' ', width - btn1.Length - 2)}{d.VLine}";
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+
+			// Now add a second button
+			buttonRow = $"{d.VLine}{btn1} {btn2}  {d.VLine}";
+			dlg.AddButton (new Button (btn2Text));
+			first = false;
+			Application.RunMainLoopIteration (ref runstate, true, ref first);
+			GraphViewTests.AssertDriverContentsWithFrameAre ($"{topRow}\n{buttonRow}\n{bottomRow}", output);
+			Application.End (runstate);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1777 

- Adds `ButtonAlignment` property to `Dialog`. Uses `Dialog.ButtonAlignments` enum
- Center (default), Justify, Left, and Right alignment supported
- Updates UI Catalog scenario to demonstrate
- Adds first Dialog unit tests!

This PR is needed for #124 so that with two dialog buttons the Wizard can have "Back" and "Next" left and right justified.

![1CjWGvP 1](https://user-images.githubusercontent.com/585482/173134005-29dae617-c26c-4aa6-8a46-b89a31aa414c.gif)
