### PR TITLE
Simplified Run_All_Scenarios test

### DIFF
--- a/UnitTests/ScenarioTests.cs
+++ b/UnitTests/ScenarioTests.cs
@@ -37,10 +37,14 @@ namespace Terminal.Gui {
 			return FakeConsole.MockKeyPresses.Count;
 		}
 
+
 		/// <summary>
+		/// <para>
 		/// This runs through all Scenarios defined in UI Catalog, calling Init, Setup, and Run.
-		/// It puts a Ctrl-Q in the input queue so the Scenario immediately exits. 
-		/// Should find any egregious regressions.
+		/// </para>
+		/// <para>
+		/// Should find any Scenarios which crash on load or do not respond to <see cref="Application.RequestStop()"/>.
+		/// </para>
 		/// </summary>
 		[Fact]
 		public void Run_All_Scenarios ()
@@ -48,65 +52,25 @@ namespace Terminal.Gui {
 			List<Type> scenarioClasses = Scenario.GetDerivedClasses<Scenario> ();
 			Assert.NotEmpty (scenarioClasses);
 
-			lock (FakeConsole.MockKeyPresses) {
+			foreach (var scenarioClass in scenarioClasses) {
 
-				foreach (var scenarioClass in scenarioClasses) {
+				output.WriteLine ($"Running Scenario '{scenarioClass.Name}'");
 
-					// Setup some fake keypresses 
-					// Passing empty string will cause just a ctrl-q to be fired
-					FakeConsole.MockKeyPresses.Clear ();
-					int stackSize = CreateInput ("");
+				Func<MainLoop, bool> closeCallback = (MainLoop loop) => {
+					Application.RequestStop ();
+					return false;
+				};
 
-					Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
+				var scenario = (Scenario)Activator.CreateInstance (scenarioClass);
+				Application.Init (new FakeDriver (), new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 
-					int iterations = 0;
-					Application.Iteration = () => {
-						iterations++;
-						// Stop if we run out of control...
-						if (iterations > 10) {
-							Application.RequestStop ();
-						}
-					};
+				// Close after a short period of time
+				var token = Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (200), closeCallback);
 
-					int ms;
-					if (scenarioClass.Name == "CharacterMap") {
-						ms = 2000;
-					} else {
-						ms = 1000;
-					}
-					var abortCount = 0;
-					Func<MainLoop, bool> abortCallback = (MainLoop loop) => {
-						abortCount++;
-						Application.RequestStop ();
-						return false;
-					};
-					var token = Application.MainLoop.AddTimeout (TimeSpan.FromMilliseconds (ms), abortCallback);
-
-					var scenario = (Scenario)Activator.CreateInstance (scenarioClass);
-					scenario.Init (Application.Top, Colors.Base);
-					scenario.Setup ();
-					// There is no need to call Application.Begin because Init already creates the Application.Top
-					// If Application.RunState is used then the Application.RunLoop must also be used instead Application.Run.
-					//var rs = Application.Begin (Application.Top);
-					scenario.Run ();
-
-					//Application.End (rs);
-
-					// Shutdown must be called to safely clean up Application if Init has been called
-					Application.Shutdown ();
-
-					if (abortCount != 0) {
-						output.WriteLine ($"Scenario {scenarioClass} had abort count of {abortCount}");
-					}
-					if (iterations > 1) {
-						output.WriteLine ($"Scenario {scenarioClass} had iterations count of {iterations}");
-					}
-
-					Assert.Equal (0, abortCount);
-					// # of key up events should match # of iterations
-					Assert.Equal (1, iterations);
-					Assert.Equal (stackSize, iterations);
-				}
+				scenario.Init (Application.Top, Colors.Base);
+				scenario.Setup ();
+				scenario.Run ();
+				Application.Shutdown ();
 			}
 #if DEBUG_IDISPOSABLE
 			foreach (var inst in Responder.Instances) {


### PR DESCRIPTION
Fixes #1712

This PR changes the test to use `FakeDriver` and simply Init, Setup, Run each scenario.  The callback closes the scenario after 200ms.

I think this achieves the goal of the test which is to confirm that scenarios do not crash on load?

