### PR TITLE
Fixes #1810. Dialog: Closing event is not fired when ESC is pressed to close dialog

### DIFF
--- a/Terminal.Gui/Windows/Dialog.cs
+++ b/Terminal.Gui/Windows/Dialog.cs
@@ -226,7 +226,7 @@ namespace Terminal.Gui {
 		{
 			switch (kb.Key) {
 			case Key.Esc:
-				Running = false;
+				Application.RequestStop (this);
 				return true;
 			}
 			return base.ProcessKey (kb);


### PR DESCRIPTION
Fixes #1810 