### PR TITLE
Fixes #1846. TabView now clips to the draw bounds

### DIFF
--- a/Terminal.Gui/Views/TabView.cs
+++ b/Terminal.Gui/Views/TabView.cs
@@ -193,7 +193,9 @@ namespace Terminal.Gui {
 			if (Tabs.Any ()) {
 				tabsBar.Redraw (tabsBar.Bounds);
 				contentView.SetNeedsDisplay ();
+				var savedClip = contentView.ClipToBounds ();
 				contentView.Redraw (contentView.Bounds);
+				Driver.Clip = savedClip;
 			}
 		}
 
@@ -338,11 +340,11 @@ namespace Terminal.Gui {
 				var tabTextWidth = tab.Text.Sum (c => Rune.ColumnWidth (c));
 
 				string text = tab.Text.ToString ();
-				
+
 				// The maximum number of characters to use for the tab name as specified
 				// by the user (MaxTabTextWidth).  But not more than the width of the view
 				// or we won't even be able to render a single tab!
-				var maxWidth = Math.Max(0,Math.Min(bounds.Width-3, MaxTabTextWidth));
+				var maxWidth = Math.Max (0, Math.Min (bounds.Width - 3, MaxTabTextWidth));
 
 				// if tab view is width <= 3 don't render any tabs
 				if (maxWidth == 0)

--- a/UnitTests/TabViewTests.cs
+++ b/UnitTests/TabViewTests.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 using Xunit.Abstractions;
 
 namespace Terminal.Gui.Views {
-  
+
 	public class TabViewTests {
 		readonly ITestOutputHelper output;
 
@@ -25,7 +25,7 @@ namespace Terminal.Gui.Views {
 
 		private TabView GetTabView (out TabView.Tab tab1, out TabView.Tab tab2, bool initFakeDriver = true)
 		{
-			if(initFakeDriver)
+			if (initFakeDriver)
 				InitFakeDriver ();
 
 			var tv = new TabView ();
@@ -51,7 +51,6 @@ namespace Terminal.Gui.Views {
 
 			Application.Shutdown ();
 		}
-
 
 		[Fact]
 		public void EnsureSelectedTabVisible_NullSelect ()
@@ -92,7 +91,6 @@ namespace Terminal.Gui.Views {
 			Application.Shutdown ();
 		}
 
-
 		[Fact]
 		public void SelectedTabChanged_Called ()
 		{
@@ -119,6 +117,7 @@ namespace Terminal.Gui.Views {
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
 		}
+
 		[Fact]
 		public void RemoveTab_ChangesSelection ()
 		{
@@ -224,8 +223,6 @@ namespace Terminal.Gui.Views {
 			Application.Shutdown ();
 		}
 
-
-
 		[Fact]
 		public void SwitchTabBy_OutOfTabsRange ()
 		{
@@ -242,13 +239,12 @@ namespace Terminal.Gui.Views {
 
 			// Shutdown must be called to safely clean up Application if Init has been called
 			Application.Shutdown ();
-
 		}
 
-		[Fact,AutoInitShutdown]
+		[Fact, AutoInitShutdown]
 		public void TestThinTabView_WithLongNames ()
 		{
-			var tv = GetTabView (out var tab1, out var tab2,false);
+			var tv = GetTabView (out var tab1, out var tab2, false);
 			tv.Width = 10;
 			tv.Height = 5;
 
@@ -306,9 +302,7 @@ namespace Terminal.Gui.Views {
 ◄       └┐
 │hi2     │
 └────────┘", output);
-
 		}
-
 
 		[Fact, AutoInitShutdown]
 		public void TestTabView_Width4 ()
@@ -327,6 +321,7 @@ namespace Terminal.Gui.Views {
 │hi│
 └──┘", output);
 		}
+
 		[Fact, AutoInitShutdown]
 		public void TestTabView_Width3 ()
 		{
@@ -339,9 +334,10 @@ namespace Terminal.Gui.Views {
 
 			GraphViewTests.AssertDriverContentsAre (@"
 ┌─┐
-│hi
+│h│
 └─┘", output);
 		}
+
 		private void InitFakeDriver ()
 		{
 			var driver = new FakeDriver ();


### PR DESCRIPTION
```cs
			GraphViewTests.AssertDriverContentsAre (@"
┌─┐
│h│
└─┘", output);

```