### PR TITLE
Wizard: Fixed cancel logic. Title now shows for non-modal.

### DIFF
--- a/UICatalog/Scenarios/WizardAsView.cs
+++ b/UICatalog/Scenarios/WizardAsView.cs
@@ -7,7 +7,7 @@ using Terminal.Gui;
 
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "WizardAsView", Description: "Shows using the Wizard class in an non-modal way")]
-	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("Wizards")]
 	public class WizardAsView : Scenario {
 
 		public override void Init (Toplevel top, ColorScheme colorScheme)
@@ -51,6 +51,14 @@ namespace UICatalog.Scenarios {
 				Application.RequestStop ();
 			};
 
+			wizard.Cancelled += (args) => {
+				var btn = MessageBox.Query ("Setup Wizard", "Are you sure you want to cancel?", "Yes", "No");
+				args.Cancel = btn == 1;
+				if (btn == 0) {
+					Application.RequestStop ();
+				}
+			};
+
 			// Add 1st step
 			var firstStep = new Wizard.WizardStep ("End User License Agreement");
 			wizard.AddStep (firstStep);
@@ -83,7 +91,7 @@ namespace UICatalog.Scenarios {
 			// Add last step
 			var lastStep = new Wizard.WizardStep ("The last step");
 			wizard.AddStep (lastStep);
-			lastStep.HelpText = "The wizard is complete!\n\nPress the Finish button to continue.\n\nPressing ESC will cancel the wizard.";
+			lastStep.HelpText = "The wizard is complete!\n\nPress the Finish button to continue.\n\nPressing Esc will cancel.";
 
 			// When run as a modal, Wizard gets a Loading event where it sets the
 			// Current Step. But when running non-modal it must be done manually.

--- a/UICatalog/Scenarios/Wizards.cs
+++ b/UICatalog/Scenarios/Wizards.cs
@@ -7,7 +7,7 @@ using Terminal.Gui;
 
 namespace UICatalog.Scenarios {
 	[ScenarioMetadata (Name: "Wizards", Description: "Demonstrates the Wizard class")]
-	[ScenarioCategory ("Dialogs")]
+	[ScenarioCategory ("Dialogs"), ScenarioCategory ("Top Level Windows"), ScenarioCategory ("Wizards")]
 	public class Wizards : Scenario {
 		public override void Setup ()
 		{
@@ -65,7 +65,7 @@ namespace UICatalog.Scenarios {
 				AutoSize = false
 			};
 			frame.Add (label);
-			var titleEdit = new TextField ("Title") {
+			var titleEdit = new TextField ("Gandolf") {
 				X = Pos.Right (label) + 1,
 				Y = Pos.Top (label),
 				Width = Dim.Fill (),


### PR DESCRIPTION
This PR fixes the Esc/cancel logic for Wizard. Esc now works consistently between the model and non-modal use cases. In the case of non-modal, the Cancelled event works as expected.

Also fixed the fact the WizardStep title wasn't showing in the non-modal case.

Cleaned up all the API docs too.