### PR TITLE
Fixes #4136. NetDriver and v2net are rendering badly the Button only in `Windows

### DIFF
--- a/Terminal.Gui/Drivers/NetDriver/NetDriver.cs
+++ b/Terminal.Gui/Drivers/NetDriver/NetDriver.cs
@@ -3,9 +3,6 @@
 // NetDriver.cs: The System.Console-based .NET driver, works on Windows and Unix, but is not particularly efficient.
 //
 
-using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using static Terminal.Gui.Drivers.NetEvents;
 
@@ -232,6 +229,8 @@ internal class NetDriver : ConsoleDriver
     /// <inheritdoc />
     public override MainLoop Init ()
     {
+        Console.OutputEncoding = Encoding.UTF8;
+
         PlatformID p = Environment.OSVersion.Platform;
 
         if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows)

--- a/Terminal.Gui/Drivers/V2/NetOutput.cs
+++ b/Terminal.Gui/Drivers/V2/NetOutput.cs
@@ -22,6 +22,8 @@ public class NetOutput : IConsoleOutput
     {
         Logging.Logger.LogInformation ($"Creating {nameof (NetOutput)}");
 
+        Console.OutputEncoding = Encoding.UTF8;
+
         PlatformID p = Environment.OSVersion.Platform;
 
         if (p == PlatformID.Win32NT || p == PlatformID.Win32S || p == PlatformID.Win32Windows)


### PR DESCRIPTION
## Fixes

- Fixes #4136

## Proposed Changes/Todos

- [x] `Console.OutputEncoding` must be set to `Encoding.UTF8`
- [x] For `conhost.exe` and `cmd.exe` support I recommend the `JetBrainsMono NFM` font

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
