### PR TITLE
Fixes #4143. ReactiveExample throw System.NotSupportedException: 'Index expressions are only supported with constants.'

### DIFF
--- a/Examples/ReactiveExample/LoginView.cs
+++ b/Examples/ReactiveExample/LoginView.cs
@@ -100,7 +100,7 @@ public class LoginView : Window, IViewFor<LoginViewModel>
                 ViewModel
                     .WhenAnyValue (x => x.IsValid)
                     .Select (valid => valid ? SchemeManager.GetScheme ("Base") : SchemeManager.GetScheme ("Error"))
-                    .BindTo (validation, x => x.GetScheme ())
+                    .Subscribe (scheme => validation.SetScheme (scheme))
                     .DisposeWith (_disposable);
             })
             .AddControlAfter<Button> ((previous, login) =>


### PR DESCRIPTION
## Fixes

- Fixes #4143

## Proposed Changes/Todos

- [x] Replace `BindTo` with `Subscribe` method

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
