### PR TITLE
Fixes #4208. MainLoopSyncContext doesn't work with the v2 drivers

### DIFF
--- a/Terminal.Gui/App/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoopSyncContext.cs
@@ -11,15 +11,22 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     public override void Post (SendOrPostCallback d, object state)
     {
         // Queue the task
-        Application.MainLoop?.TimedEvents.Add (TimeSpan.Zero,
-                                                      () =>
-                                                      {
-                                                          d (state);
+        if (ApplicationImpl.Instance.IsLegacy)
+        {
+            Application.MainLoop?.TimedEvents.Add (TimeSpan.Zero,
+                                                   () =>
+                                                   {
+                                                       d (state);
 
-                                                          return false;
-                                                      }
-                                                     );
-        Application.MainLoop?.Wakeup ();
+                                                       return false;
+                                                   }
+                                                  );
+            Application.MainLoop?.Wakeup ();
+        }
+        else
+        {
+            ApplicationImpl.Instance.Invoke (() => { d (state); });
+        }
     }
 
     //_mainLoop.Driver.Wakeup ();


### PR DESCRIPTION
## Fixes

- Fixes #4208

## Proposed Changes/Todos

- [x] v2 drivers don't use MainLoop. Using only Invoke fix the issue

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
