### PR TITLE
Fixes #4310. AddTimeout with time == TimeSpan.Zero isn't returning sometimes an expired timeout

### DIFF
--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -55,7 +55,13 @@ public class TimedEvents : ITimedEvents
     {
         // Convert Stopwatch ticks to TimeSpan ticks (100-nanosecond units)
         // Stopwatch.Frequency gives ticks per second, so we need to scale appropriately
-        return Stopwatch.GetTimestamp () * TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+        // To avoid overflow, we perform the operation in double precision first and then cast to long.
+        var ticks = (long)((double)Stopwatch.GetTimestamp () * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
+
+        // Ensure ticks is positive and not overflowed (very unlikely now)
+        Debug.Assert (ticks > 0);
+
+        return ticks;
     }
 
     /// <inheritdoc/>

--- a/Tests/UnitTests/Application/TimedEventsTests.cs
+++ b/Tests/UnitTests/Application/TimedEventsTests.cs
@@ -92,9 +92,12 @@ public class TimedEventsTests
             return false;
         });
 
+        Assert.True (timedEvents.Timeouts.Keys [0] > 0);
+
         // Should execute on first RunTimers call
         timedEvents.RunTimers ();
 
+        Assert.Empty (timedEvents.Timeouts);
         Assert.True (executed);
     }
 


### PR DESCRIPTION
## Fixes

- Fixes #4310

## Proposed Changes/Todos

- [x] GetTimestampTicks method must always return a positive value in every system.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
