### PR TITLE
Fixes #4449. Regression in IsLegacyConsole mode where dirty cells are not handled correctly

### DIFF
--- a/Terminal.Gui/Drivers/OutputBase.cs
+++ b/Terminal.Gui/Drivers/OutputBase.cs
@@ -101,10 +101,7 @@ public abstract class OutputBase
                             lastCol++;
                         }
 
-                        if (IsLegacyConsole)
-                        {
-                            SetCursorPositionImpl (lastCol, row);
-                        }
+                        SetCursorPositionImpl (lastCol, row);
 
                         continue;
                     }
@@ -291,8 +288,6 @@ public abstract class OutputBase
         }
         else
         {
-            SetCursorPositionImpl (lastCol, row);
-
             // Wrap URLs with OSC 8 hyperlink sequences using the new Osc8UrlLinker
             StringBuilder processed = Osc8UrlLinker.WrapOsc8 (output);
             Write (processed);

--- a/Tests/UnitTestsParallelizable/Drivers/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/OutputBaseTests.cs
@@ -151,7 +151,7 @@ public class OutputBaseTests
         Assert.False (buffer.Contents! [0, 2].IsDirty);
 
         // Verify SetCursorPositionImpl was invoked by WriteToConsole (cursor set to a written column)
-        Assert.Equal (new Point (0, 0), output.GetCursorPosition ());
+        Assert.Equal (new Point (2, 0), output.GetCursorPosition ());
     }
 
     [Theory]


### PR DESCRIPTION
## Fixes

- Fixes #4449

## Proposed Changes/Todos

- [x] Add separated cursor position handled for IsLegacyConsole

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
