### PR TITLE
Add devcontainer config for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Terminal.Gui Development",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && dotnet restore",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit"
+      ]
+    }
+  },
+
+  "remoteEnv": {
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1"
+  },
+
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 _ReSharper.**
 *.[Rr]e[Ss]harper
 *.DotSettings.user
-.devcontainer/
 .vscode/
 .vs/
 


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json` with .NET 8.0, Node.js 20, and Claude Code CLI
- Removes `.devcontainer/` from `.gitignore` so config is shared with contributors
- Enables cloud-based development via GitHub Codespaces without local setup

## Test plan
- [ ] Open repository in GitHub Codespaces
- [ ] Verify `dotnet build` works
- [ ] Verify `claude` CLI is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)