### PR TITLE
fix imports in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ dotnet run --project Examples/UICatalog/UICatalog.csproj
 # Simple Example
 
 ```csharp
-using Terminal.Gui;
+using Terminal.Gui.App;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
 
 using IApplication app = Application.Create ();
 app.Init ();


### PR DESCRIPTION
## Fixes

The example code in the README did not compile, since it was still using the pre-#4109 namespace.

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
