### PR TITLE
Fixes #4640. Images scenario is generating sixel data twice.

### DIFF
--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -167,12 +167,6 @@ public class Images : Scenario
 
     private void Win_SubViewsLaidOut (object sender, LayoutEventArgs e)
     {
-        if (_sixelImage is { } && _imageView.GetContentSize () != _sixelImageSize)
-        {
-            LayoutEventArgs args = new (_imageView.GetContentSize ());
-            SixelView_SubViewsLaidOut (sender, args);
-        }
-
         if (_winSize == e.OldContentSize)
         {
             return;
@@ -238,6 +232,8 @@ public class Images : Scenario
                 return;
             }
         }
+
+        _winSize = _win.Viewport.Size;
 
         GenerateSixelFire (true);
     }
@@ -582,6 +578,8 @@ public class Images : Scenario
 
             return;
         }
+
+        _sixelImageSize = _sixelView.Viewport.Size;
 
         GenerateSixelImage (true);
     }

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/ViewLayoutEventTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/ViewLayoutEventTests.cs
@@ -211,6 +211,7 @@ public class ViewLayoutEventTests
         container.Add (view);
         container.Layout ();
         Assert.Equal (25, view.Frame.Width);
+        Assert.Equal (widthInChangedEvent, view.Frame.Width);
     }
 
     [Fact]
@@ -232,6 +233,54 @@ public class ViewLayoutEventTests
         container.Add (view);
         container.Layout ();
         Assert.Equal (30, view.Frame.Height);
+        Assert.Equal (heightInChangedEvent, view.Frame.Height);
+    }
+
+    [Fact]
+    public void View_SubViewLayout_SubViewsLaidOut_Events_Fires_EvenWidthOrHeightIsZero ()
+    {
+        var container = new View () { Width = 20, Height = 10 };
+        var view = new View () { Width = Dim.Fill (), Height = Dim.Fill (), BorderStyle = LineStyle.Single };
+        container.Add (view);
+        bool eventSubViewLayoutFired = false;
+        bool eventSubViewsLaidOutFired = false;
+        Size? oldValue = null;
+
+        view.SubViewLayout += (_, args) =>
+                              {
+                                  eventSubViewLayoutFired = true;
+                                  oldValue = args.OldContentSize;
+                              };
+
+        view.SubViewsLaidOut += (_, args) =>
+                                {
+                                    eventSubViewsLaidOutFired = true;
+                                    oldValue = args.OldContentSize;
+                                };
+
+        container.Layout ();
+
+        Assert.True (eventSubViewLayoutFired);
+        Assert.True (eventSubViewsLaidOutFired);
+        Assert.Equal (new Size (18, 8), oldValue);
+
+        eventSubViewLayoutFired = false;
+        eventSubViewsLaidOutFired = false;
+        oldValue = null;
+
+        container.Width = 1;
+        Assert.True (eventSubViewLayoutFired);
+        Assert.True (eventSubViewsLaidOutFired);
+        Assert.Equal (new Size (0, 8), oldValue);
+
+        eventSubViewLayoutFired = false;
+        eventSubViewsLaidOutFired = false;
+        oldValue = null;
+
+        container.Height = 1;
+        Assert.True (eventSubViewLayoutFired);
+        Assert.True (eventSubViewsLaidOutFired);
+        Assert.Equal (new Size (0, 0), oldValue);
     }
 
     private class TestView : View


### PR DESCRIPTION
## Fixes

- Fixes #4640

## Proposed Changes/Todos

- [x] Define _winSize and _sixelImageSize on their respective buttons
- [x] Added unit tests for SubViewLayout and SubViewsLaidOut

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
