### PR TITLE
Fixes #4720. CWPPropertyHelper isn't passing the sender parameter in the changed event

### DIFF
--- a/Terminal.Gui/App/CWP/CWPPropertyHelper.cs
+++ b/Terminal.Gui/App/CWP/CWPPropertyHelper.cs
@@ -110,8 +110,7 @@ public static class CWPPropertyHelper
         ValueChangedEventArgs<T> changedArgs = new (currentValue, finalValue);
         currentValue = finalValue;
         onChanged?.Invoke (changedArgs);
-        // BUGBUG: This should pass this not null; need to test
-        changedEvent?.Invoke (null, changedArgs);
+        changedEvent?.Invoke (sender, changedArgs);
 
         return true;
     }

--- a/Tests/UnitTestsParallelizable/ViewBase/IValueTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/IValueTests.cs
@@ -405,4 +405,22 @@ public class IValueTests
         Assert.NotNull (result);
         Assert.IsType<Color> (result);
     }
+
+    [Fact]
+    public void SenderOfEvents_IsCorrect ()
+    {
+        // Verify that the sender parameter of ValueChanging and ValueChanged events is the view raising the event
+        TestIntValueView view = new ();
+        object? changingSender = null;
+        object? changedSender = null;
+        view.ValueChanging += (sender, _) => changingSender = sender;
+        view.ValueChanged += (sender, _) => changedSender = sender;
+        view.Value = 42;
+
+        // Both events should have the view as sender
+        Assert.NotNull (changingSender);
+        Assert.NotNull (changedSender);
+        Assert.Equal (view, changingSender);
+        Assert.Equal (view, changedSender);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #4720

## Proposed Changes/Todos

- [x] Added unit test proving the bug.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
