### PR TITLE
Fixes #4738 - Incorrect window size on Windows terminals with non-default fonts

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
@@ -307,16 +307,29 @@ internal partial class WindowsOutput : OutputBase, IOutput
             throw new Win32Exception (Marshal.GetLastWin32Error ());
         }
 
-        WindowsConsole.Coord maxWinSize = GetLargestConsoleWindowSize (!IsLegacyConsole ? _outputHandle : _screenBuffer);
-        short newCols = Math.Min (cols, maxWinSize.X);
-        short newRows = Math.Min (rows, maxWinSize.Y);
+        // Try the requested size first. GetLargestConsoleWindowSize returns
+        // incorrect values in modern terminals (e.g. Windows Terminal with
+        // non-default font sizes), so clamping to it can shrink the buffer
+        // below the actual window size. Fall back to clamped if rejected.
+        short newCols = cols;
+        short newRows = rows;
         csbi.dwSize = new (newCols, Math.Max (newRows, (short)1));
         csbi.srWindow = new (0, 0, newCols, newRows);
         csbi.dwMaximumWindowSize = new (newCols, newRows);
 
         if (!SetConsoleScreenBufferInfoEx (!IsLegacyConsole ? _outputHandle : _screenBuffer, ref csbi))
         {
-            throw new Win32Exception (Marshal.GetLastWin32Error ());
+            WindowsConsole.Coord maxWinSize = GetLargestConsoleWindowSize (!IsLegacyConsole ? _outputHandle : _screenBuffer);
+            newCols = Math.Min (cols, maxWinSize.X);
+            newRows = Math.Min (rows, maxWinSize.Y);
+            csbi.dwSize = new (newCols, Math.Max (newRows, (short)1));
+            csbi.srWindow = new (0, 0, newCols, newRows);
+            csbi.dwMaximumWindowSize = new (newCols, newRows);
+
+            if (!SetConsoleScreenBufferInfoEx (!IsLegacyConsole ? _outputHandle : _screenBuffer, ref csbi))
+            {
+                throw new Win32Exception (Marshal.GetLastWin32Error ());
+            }
         }
 
         var winRect = new WindowsConsole.SmallRect (0, 0, (short)(newCols - 1), (short)Math.Max (newRows - 1, 0));
@@ -549,9 +562,11 @@ internal partial class WindowsOutput : OutputBase, IOutput
                 return Size.Empty;
             }
 
-            Size sz = new (
-                           csbi.srWindow.Right - csbi.srWindow.Left + 1,
-                           csbi.srWindow.Bottom - csbi.srWindow.Top + 1);
+            // Use Console.WindowWidth/Height instead of csbi.srWindow because
+            // GetConsoleScreenBufferInfoEx returns smaller srWindow dimensions
+            // than the actual window size in some terminals. The non-Ex API
+            // (used by Console class) returns the correct values.
+            Size sz = new (Console.WindowWidth, Console.WindowHeight);
 
             cursorPosition = csbi.dwCursorPosition;
 


### PR DESCRIPTION
## Fixes

Fixes #4738

## Proposed Changes/Todos

- [x] Change `GetWindowSize()` to use `Console.WindowWidth`/`Console.WindowHeight` instead of `GetConsoleScreenBufferInfoEx` srWindow values
- [x] Change `SetConsoleWindow()` to try the requested size first, falling back to `GetLargestConsoleWindowSize` clamping only if the API rejects it

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
