### PR TITLE
fixes #4758 Selecting Prompt View in Themes Scenario Throws Exception

### DIFF
--- a/Examples/UICatalog/Scenarios/Themes.cs
+++ b/Examples/UICatalog/Scenarios/Themes.cs
@@ -203,14 +203,7 @@ public sealed class Themes : Scenario
             // use <object> or the original type if applicable
             foreach (Type arg in type.GetGenericArguments ())
             {
-                if (arg.IsValueType && Nullable.GetUnderlyingType (arg) == null)
-                {
-                    typeArguments.Add (arg);
-                }
-                else
-                {
-                    typeArguments.Add (typeof (object));
-                }
+                typeArguments.Add (GetSubstituteType (arg));
             }
 
             // And change what type we are instantiating from MyClass<T> to MyClass<object> or MyClass<T>
@@ -243,6 +236,34 @@ public sealed class Themes : Scenario
         view.Initialized += OnViewInitialized;
 
         return view;
+    }
+
+    private Type GetSubstituteType (Type genericParam)
+    {
+        // If it's a non-nullable value type, keep it as-is
+        if (genericParam.IsValueType && Nullable.GetUnderlyingType (genericParam) == null)
+        {
+            return genericParam;
+        }
+
+        // Check constraints (e.g., where TView : View, new())
+        Type [] constraints = genericParam.GetGenericParameterConstraints ();
+
+        // Find the most derived base class constraint (ignore interfaces)
+        Type? baseConstraint = constraints
+            .Where (c => c.IsClass)
+            .OrderByDescending (c => c.GetInterfaces ().Length) // rough heuristic for "most derived"
+            .FirstOrDefault ();
+
+        if (baseConstraint != null)
+        {
+            // If the constraint itself is abstract or doesn't have a
+            // parameterless constructor, this may still fail at activation
+            return baseConstraint;
+        }
+
+        // No class constraint — fall back to object
+        return typeof (object);
     }
 
     private void OnViewInitialized (object? sender, EventArgs e)


### PR DESCRIPTION
Replace inline logic that substituted reference types with a new GetSubstituteType helper and call it when building generic arguments. The helper preserves non-nullable value types, inspects generic parameter constraints to pick a class constraint (using a heuristic to prefer more-derived types), and falls back to object if none found. This centralizes substitution logic and makes the intent clearer; note it may still fail at activation if a chosen constraint is abstract or lacks a parameterless constructor.

## Fixes

- Fixes #4758 Selecting Prompt View in Themes Scenario Throws Exception

## Proposed Changes/Todos

- [x] Replace inline logic that substituted reference types with a new GetSubstituteType helper and call it when building generic arguments.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
