### PR TITLE
Fixes #4776. DriverTests.AllDriverTests.All_Drivers_LayoutAndDraw_Cross_Platform(driverName: "dotnet") fails on Unix

### DIFF
--- a/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
@@ -37,19 +37,18 @@ public class NetOutput : OutputBase, IOutput
     {
         try
         {
-            Size size = new (Console.WindowWidth, Console.WindowHeight);
-
             if (Console.IsInputRedirected || Console.IsOutputRedirected)
             {
                 return new Size (80, 25);
             }
+            Size size = new (Console.WindowWidth, Console.WindowHeight);
 
             return size.IsEmpty ? new Size (80, 25) : size;
         }
         catch (IOException)
         {
             // Not connected to a terminal; return a default size
-            return new (80, 25);
+            return new Size (80, 25);
         }
     }
 


### PR DESCRIPTION
## Fixes

- Fixes #4776

## Proposed Changes/Todos

- [x] Console.WindowWidth and Console.WindowHeight returns both a size of 1 using Unix, causing failures in output.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
