### PR TITLE
Fix DisableRealDriverIO not set for local test runs under MTP

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <PropertyGroup>
-    <RunSettingsFilePath>$(MSBuildThisFileDirectory)test.runsettings</RunSettingsFilePath>
-  </PropertyGroup>
+  <!-- test.runsettings only works with VSTest; MTP (Microsoft Testing Platform) ignores it. -->
+  <!-- Instead, we compile TestEnvironmentSetup.cs into every test project so its [ModuleInitializer] -->
+  <!-- sets DisableRealDriverIO=1 before any test code runs. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)TestEnvironmentSetup.cs" Link="TestEnvironmentSetup.cs" />
+  </ItemGroup>
 </Project>

--- a/Tests/TestEnvironmentSetup.cs
+++ b/Tests/TestEnvironmentSetup.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+///     Sets up the test environment for all test projects via Directory.Build.props.
+///     This module initializer runs before any test code executes, ensuring the
+///     <c>DisableRealDriverIO</c> environment variable is always set to <c>"1"</c>
+///     regardless of test runner (CLI, IDE, CI).
+/// </summary>
+internal static class TestEnvironmentSetup
+{
+    [ModuleInitializer]
+    [SuppressMessage ("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries")]
+    internal static void Initialize ()
+    {
+        // Disable real driver I/O in all test processes.
+        // This forces Driver.IsAttachedToTerminal() to return false,
+        // preventing tests from accessing actual console handles.
+        Environment.SetEnvironmentVariable ("DisableRealDriverIO", "1");
+    }
+}

--- a/Tests/test.runsettings
+++ b/Tests/test.runsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-  <RunConfiguration>
-    <EnvironmentVariables>
-      <DisableRealDriverIO>1</DisableRealDriverIO>
-    </EnvironmentVariables>
-  </RunConfiguration>
-</RunSettings>


### PR DESCRIPTION
## Summary

- **`test.runsettings` `<EnvironmentVariables>` is a VSTest-only feature** — since the project migrated to Microsoft Testing Platform (MTP) via `global.json`, the file was silently ignored, leaving `DisableRealDriverIO` unset for all local test runs.
- Replace with a `[ModuleInitializer]` in `Tests/TestEnvironmentSetup.cs`, compiled into every test project via `Directory.Build.props`. This sets `DisableRealDriverIO=1` at assembly load time, before any test code runs.
- Works universally: CLI (`dotnet test`), IDE (VS/Rider), and CI (GitHub Actions).

## Changes

- **`Tests/TestEnvironmentSetup.cs`** (new) — Module initializer that sets `DisableRealDriverIO=1`
- **`Tests/Directory.Build.props`** (modified) — Replaced non-functional `RunSettingsFilePath` with `<Compile Include>` linking `TestEnvironmentSetup.cs` into all test projects
- **`Tests/test.runsettings`** (deleted) — Dead code under MTP

## Test plan

- [x] `DisableRealDriverIO_EnvironmentVariable_IsSet` test passes (was failing before)
- [x] `IsAttachedToTerminal_ReturnsFalse_WhenDisableRealDriverIO_IsSet` test passes
- [x] UnitTestsParallelizable: 14,559 passed, 20 skipped, 0 failed
- [x] UnitTests: 999 passed, 18 skipped, 0 failed
- [x] IntegrationTests: 324 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)