### PR TITLE
Fixes #4848. Set Console.OutputEncoding to UTF-8 in AnsiOutput

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -58,6 +58,13 @@ public class AnsiOutput : OutputBase, IOutput
 
         try
         {
+            // Ensure the console output code page is UTF-8 (65001). The ANSI driver writes
+            // UTF-8 encoded bytes via WriteFile; without this, a fresh Windows terminal uses
+            // its default OEM code page (e.g. 437), causing multi-byte UTF-8 characters
+            // (box-drawing glyphs, etc.) to be misinterpreted as garbled single-byte characters.
+            // See https://github.com/gui-cs/Terminal.Gui/issues/4848
+            Console.OutputEncoding = Encoding.UTF8;
+
             // Check if we have a real console first
             if (!IsAttachedToTerminal)
             {


### PR DESCRIPTION
- Fixes #4828

The ANSI driver writes UTF-8 encoded bytes via \WriteFile\ but never set the console output code page to 65001 (UTF-8). On a fresh Windows terminal with the default OEM code page (e.g. 437), multi-byte UTF-8 characters (box-drawing glyphs like ╔═╗║╚╝) were misinterpreted as multiple single-byte OEM characters, producing garbled borders and shifted text.

## Root Cause

\WindowsVTOutputHelper.Write()\ encodes output as UTF-8 via \Encoding.UTF8.GetBytes()\ and writes raw bytes via \WriteFile\. The console interprets those bytes according to its output code page. On a fresh terminal this is the system OEM code page (e.g. 437), not UTF-8.

## Why it didn't always repro

- **After running another TG app**: The DotNet driver (\NetOutput\) sets \Console.OutputEncoding = Encoding.UTF8\, which persists.
- **UICatalog**: Sets \Console.OutputEncoding = Encoding.Default\ (UTF-8 in .NET 6+) in \Main()\.
- **Windows/DotNet drivers**: Use \WriteConsoleW\ (UTF-16) which is code-page independent.

## Fix

Added \Console.OutputEncoding = Encoding.UTF8;\ to the \AnsiOutput\ constructor, matching what \NetOutput\ already does.