### PR TITLE
Bump all GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/analyze-hang-dump.yml
+++ b/.github/workflows/analyze-hang-dump.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -53,7 +53,7 @@ jobs:
 
       - name: Download artifact from specified run
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_id != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.event.inputs.dump_artifact_name }}
           path: dump-artifacts
@@ -62,7 +62,7 @@ jobs:
 
       - name: Download artifact from triggering workflow
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: parallel_unittests-logs-macOS
           path: dump-artifacts
@@ -225,7 +225,7 @@ jobs:
           done
 
       - name: Upload analysis results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hang-dump-analysis
           path: analysis-results/

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'
@@ -41,15 +41,15 @@ jobs:
       continue-on-error: false
 
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
       
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: docfx/_site
        
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'

--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -9,6 +9,6 @@ jobs:
   check-duplicates:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run Duplicate Test Check
       run: pwsh -File ./Scripts/FindDuplicateTestMethodsInSameFileName.ps1 -solutionPath "$PWD"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -43,7 +43,7 @@ jobs:
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: csharp
@@ -51,7 +51,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           dotnet-quality: ga
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Integration Test Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration_tests-logs-${{ runner.os }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,24 +15,24 @@ jobs:
 
     steps:
     - name: Checkout ${{ github.ref_name }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # fetch-depth is needed for GitVersion https://github.com/GitTools/actions/blob/main/docs/cloning.md
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v3.1.11
+      uses: gittools/actions/gitversion/setup@v4.5.0
       with:
         versionSpec: '6.0.x'
 
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v3.1.11
+      uses: gittools/actions/gitversion/execute@v4.5.0
       with:
         useConfigFile: true
         updateAssemblyInfo: true
       id: gitversion # step id used as reference for output values
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'
@@ -84,7 +84,7 @@ jobs:
     
     - name: Trigger Terminal.Gui.templates update
       if: github.ref == 'refs/heads/main'
-      uses: peter-evans/repository-dispatch@v3
+      uses: peter-evans/repository-dispatch@v4
       with:
         token: ${{ secrets.TEMPLATE_REPO_TOKEN }}
         repository: gui-cs/Terminal.Gui.templates

--- a/.github/workflows/quick-build.yml
+++ b/.github/workflows/quick-build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'
@@ -34,7 +34,7 @@ jobs:
       run: dotnet build --configuration Debug --no-restore -property:NoWarn=0618%3B0612
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-build-artifacts
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -40,12 +40,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.1.11
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: '6.0.x'
 
       - name: Determine Version
-        uses: gittools/actions/gitversion/execute@v3.1.11
+        uses: gittools/actions/gitversion/execute@v4.5.0
         with:
           useConfigFile: true
           updateAssemblyInfo: true

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -21,10 +21,10 @@ jobs:
       DisableRealDriverIO: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           dotnet-quality: 'ga'
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload Test Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stress-test-logs-${{ runner.os }}
           path: |
@@ -64,10 +64,10 @@ jobs:
       DisableRealDriverIO: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           dotnet-quality: 'ga'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload UnitTestsParallelizable Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: parallel_unittests_stress-logs-${{ runner.os }}
           path: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload Test Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: non_parallel_unittests-logs-${{ runner.os }}
         path: |
@@ -83,10 +83,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
         dotnet-quality: 'ga'
@@ -119,7 +119,7 @@ jobs:
 
     - name: Upload UnitTestsParallelizable Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: parallel_unittests-logs-${{ runner.os }}
         path: |


### PR DESCRIPTION
Combines 10 individual Dependabot PRs into a single update:

| Action | Old | New | Dependabot PR |
|--------|-----|-----|---------------|
| \ctions/checkout\ | v3/v4 | v6 | #4945 |
| \ctions/setup-dotnet\ | v4 | v5 | #4946 |
| \ctions/download-artifact\ | v4 | v8 | #4944 |
| \ctions/upload-pages-artifact\ | v3 | v4 | #4943 |
| \gittools/actions\ | v3.1.11 | v4.5.0 | #4942 |
| \ctions/deploy-pages\ | v4 | v5 | #4941 |
| \ctions/configure-pages\ | v5 | v6 | #4940 |
| \ctions/upload-artifact\ | v4 | v7 | #4939 |
| \github/codeql-action\ | v2 | v4 | #4938 |
| \peter-evans/repository-dispatch\ | v3 | v4 | #4937 |

All 11 workflow files updated. Supersedes the individual Dependabot PRs listed above.