### PR TITLE
Fixes #4956 - CPR response misinterpreted as F3

### DIFF
--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -330,24 +330,13 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
                 return false;
             }
 
-            if (HandleKeyboard)
-            {
-                AnsiKeyboardParserPattern? pattern = _keyboardParser.IsKeyboard (cur);
-
-                if (pattern != null)
-                {
-                    // See https://github.com/gui-cs/Terminal.Gui/issues/4587#issuecomment-3770132337 for why
-                    // we call ResetState first
-                    ResetState ();
-                    RaiseKeyboardEvent (pattern, cur);
-
-                    return false;
-                }
-            }
-
             lock (_lockExpectedResponses)
             {
-                // Look for an expected response for what is accumulated so far (since Esc)
+                // Expected responses take priority over keyboard pattern matching.
+                // A registered expectation is an explicit request from the app, and its
+                // response may collide with a keyboard pattern — e.g. a CPR reply
+                // "ESC[1;1R" looks identical to xterm's Shift/modifier F3 sequence
+                // "ESC[1;<n>R" and would otherwise be misdelivered as Key.F3 (#4956).
                 if (MatchResponse (cur, _expectedResponses, true, true))
                 {
                     return false;
@@ -362,6 +351,21 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
                 // Look for persistent requests
                 if (MatchResponse (cur, _persistentExpectations, true, false))
                 {
+                    return false;
+                }
+            }
+
+            if (HandleKeyboard)
+            {
+                AnsiKeyboardParserPattern? pattern = _keyboardParser.IsKeyboard (cur);
+
+                if (pattern != null)
+                {
+                    // See https://github.com/gui-cs/Terminal.Gui/issues/4587#issuecomment-3770132337 for why
+                    // we call ResetState first
+                    ResetState ();
+                    RaiseKeyboardEvent (pattern, cur);
+
                     return false;
                 }
             }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiResponseParserTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiResponseParserTests.cs
@@ -519,6 +519,31 @@ public class AnsiResponseParserTests (ITestOutputHelper output)
         Assert.Equal (Key.CursorUp.WithShift, keys [1]);
     }
 
+    // Claude - Opus 4.6
+    // Regression #4952 follow-up: A pending CPR request (terminator R) must not be
+    // stolen by CsiCursorPattern, which happens to match ESC[1;<col>R as "F3 with modifier".
+    // Before the fix, when the cursor was on row 1 the standard CPR response
+    // ESC[1;1R was dispatched as Key.F3 instead of routed to the expectation.
+    [Fact]
+    public void ExpectedCprResponse_IsNotMisinterpretedAsF3 ()
+    {
+        AnsiResponseParser parser = new (new SystemTimeProvider ());
+        parser.HandleKeyboard = true;
+
+        string? cprResponse = null;
+        List<Key> keys = [];
+
+        parser.Keyboard += (_, e) => keys.Add (e);
+        parser.ExpectResponse ("R", null, s => cprResponse = s, null, false);
+
+        // Standard CPR response when cursor is at row 1, col 1.
+        string released = parser.ProcessInput ("\u001b[1;1R");
+
+        Assert.Equal ("\u001b[1;1R", cprResponse);
+        Assert.Empty (keys);
+        Assert.Equal (string.Empty, released);
+    }
+
     public static IEnumerable<object []> ParserDetects_FunctionKeys_Cases ()
     {
         // These are VT100 escape codes for F1-4


### PR DESCRIPTION
## Fixes

- Fixes #4956 

## Summary
- Adds a failing regression test for #4956.
- After #4953 switched the inline-mode cursor query from DECXCPR (`CSI ?6n`) to standard CPR (`CSI 6n`), the response `ESC[1;1R` (cursor at row 1) is consumed by `CsiCursorPattern` as `Key.F3` with modifier — because `ESC[1;<n>R` is xterm's legitimate encoding for modified F3 (e.g. Shift+F3 = `ESC[1;2R`).
- In `AnsiResponseParserBase.HandleHeldContent`, keyboard patterns are matched **before** registered expected responses, so a pending CPR request loses the race. The CPR callback never fires and an F3 key event is dispatched instead — which UICatalog's Editor and Notepad scenarios bind to Save, producing a spurious Save on startup.
- The old DECXCPR response `ESC[?1;1R` didn't hit this because the leading `?` prevented the keyboard regex from matching.

This PR **only adds the failing test** so the regression is captured before the fix lands.

## Test plan
- [ ] `dotnet test --project Tests/UnitTestsParallelizable` — new test `ExpectedCprResponse_IsNotMisinterpretedAsF3` fails on `develop`.
- [ ] Once the fix lands, the test passes.

Refs #4956. Regression from #4953.