### PR TITLE
Fixes #4959. Wire UICatalog File > Exit to RequestStop

### DIFF
--- a/Examples/UICatalog/UICatalogRunnable.cs
+++ b/Examples/UICatalog/UICatalogRunnable.cs
@@ -154,7 +154,8 @@ public sealed class UICatalogRunnable : Runnable
                                                              Title = Strings.cmdQuit,
                                                              HelpText = "Quit UI Catalog",
                                                              Key = Application.GetDefaultKey (Command.Quit),
-                                                             Action = RequestStop
+                                                             Action = RequestStop,
+                                                             Command = Command.Quit
                                                          }
                                                      ]),
                                    new MenuBarItem ("_Themes", CreateThemeMenuItems ()),

--- a/Examples/UICatalog/UICatalogRunnable.cs
+++ b/Examples/UICatalog/UICatalogRunnable.cs
@@ -150,15 +150,13 @@ public sealed class UICatalogRunnable : Runnable
                                    new MenuBarItem (Strings.menuFile,
                                                     [
                                                         new MenuItem
-                                                        {
-                                                            Title = Strings.cmdQuit,
-                                                            HelpText = "Quit UI Catalog",
-                                                            Key = Application.GetDefaultKey (Command.Quit),
-
-                                                            // By not specifying TargetView the Key Binding will be Application-level
-                                                            Command = Command.Quit
-                                                        }
-                                                    ]),
+                                                         {
+                                                             Title = Strings.cmdQuit,
+                                                             HelpText = "Quit UI Catalog",
+                                                             Key = Application.GetDefaultKey (Command.Quit),
+                                                             Action = RequestStop
+                                                         }
+                                                     ]),
                                    new MenuBarItem ("_Themes", CreateThemeMenuItems ()),
                                    new MenuBarItem ("Diag_nostics", CreateDiagnosticMenuItems ()),
                                    new MenuBarItem ("_Logging", CreateLoggingMenuItems ()!),


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>6f1f6067-fa57-4e0f-87e1-854ccc2b00b1</p></details>

Fixes #4959.

## Summary

- remove misleading application-level key binding comment
- Add explicit `Action = RequestStop` so Exit reliably quits