### PR TITLE
Fixes #4971. Fix scrollbar button arrow direction

### DIFF
--- a/Terminal.Gui/Views/ScrollBar/ScrollBar.cs
+++ b/Terminal.Gui/Views/ScrollBar/ScrollBar.cs
@@ -42,7 +42,10 @@ public class ScrollBar : View, IOrientation, IDesignable, IValue<int>
 
         Height = Dim.Auto (DimAutoStyle.Content, Dim.Func (_ => Orientation == Orientation.Vertical ? SuperView?.Viewport.Height ?? 0 : 1));
 
-        _decreaseButton = new ScrollButton ();
+        _decreaseButton = new ScrollButton ()
+        {
+            Direction = NavigationDirection.Backward
+        };
         _decreaseButton.Accepting += OnDecreaseButtonOnAccept;
 
         Slider = new ScrollSlider
@@ -52,7 +55,10 @@ public class ScrollBar : View, IOrientation, IDesignable, IValue<int>
         Slider.Scrolled += SliderOnScroll;
         Slider.PositionChanged += SliderOnPositionChanged;
 
-        _increaseButton = new ScrollButton ();
+        _increaseButton = new ScrollButton ()
+        {
+            Direction = NavigationDirection.Forward
+        };
         _increaseButton.Accepting += OnIncreaseButtonOnAccept;
         Add (_decreaseButton, Slider, _increaseButton);
 

--- a/Tests/UnitTestsParallelizable/Views/ScrollBarTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ScrollBarTests.cs
@@ -271,6 +271,33 @@ public class ScrollBarTests
         Assert.Equal (0, scrollBar.GetSliderPosition ());
     }
 
+    // Copilot
+    [Fact]
+    public void Horizontal_ScrollBar_Buttons_Use_Left_And_Right_Arrows ()
+    {
+        ScrollBar scrollBar = new ()
+        {
+            Orientation = Orientation.Horizontal
+        };
+        ScrollButton decreaseButton = scrollBar.SubViews.OfType<ScrollButton> ().Single (button => button.Direction == NavigationDirection.Backward);
+        ScrollButton increaseButton = scrollBar.SubViews.OfType<ScrollButton> ().Single (button => button.Direction == NavigationDirection.Forward);
+
+        Assert.Equal (Glyphs.LeftArrow.ToString (), decreaseButton.Title);
+        Assert.Equal (Glyphs.RightArrow.ToString (), increaseButton.Title);
+    }
+
+    // Copilot
+    [Fact]
+    public void Vertical_ScrollBar_Buttons_Use_Up_And_Down_Arrows ()
+    {
+        ScrollBar scrollBar = new ();
+        ScrollButton decreaseButton = scrollBar.SubViews.OfType<ScrollButton> ().Single (button => button.Direction == NavigationDirection.Backward);
+        ScrollButton increaseButton = scrollBar.SubViews.OfType<ScrollButton> ().Single (button => button.Direction == NavigationDirection.Forward);
+
+        Assert.Equal (Glyphs.UpArrow.ToString (), decreaseButton.Title);
+        Assert.Equal (Glyphs.DownArrow.ToString (), increaseButton.Title);
+    }
+
     #endregion Orientation
 
     #region Size


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>c68adfa4-654d-469f-9654-8e0254942f31</p></details>

## Summary

- assign scrollbar decrease and increase buttons explicit backward/forward directions
- keep `ScrollButton` glyph selection logic unchanged so orientation still drives left/right vs up/down rendering
- add regression tests covering horizontal and vertical scrollbar button glyphs

## Testing

- `dotnet build Terminal.Gui\\Terminal.Gui.csproj --no-restore`
- `dotnet test --project Tests\\UnitTestsParallelizable\\UnitTests.Parallelizable.csproj --no-restore --filter-class "*ScrollButtonTests" -p:BuildProjectReferences=false`
- `dotnet test --project Tests\\UnitTestsParallelizable\\UnitTests.Parallelizable.csproj --no-restore --filter-class "*ScrollBarTests" -p:BuildProjectReferences=false`

Fixes #4971
