### PR TITLE
Fixes #4976. Preserve repeated ANSI printable keys

### DIFF
--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -223,16 +223,27 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
 
             kittyKeyboardDetector.Detect (result =>
                                           {
-                                              if (!result.IsSupported)
-                                              {
-                                                  Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
+                                               if (!result.IsSupported)
+                                               {
+                                                   if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
+                                                   {
+                                                       unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
+                                                   }
 
-                                                  return;
-                                              }
+                                                   Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
 
-                                              // Kitty is supported. Store the capabilities and set the flags we care about.
-                                              _driver?.SetKittyKeyboardCapabilities (result);
-                                              kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
+                                                   return;
+                                               }
+
+                                               // Kitty is supported. Store the capabilities and set the flags we care about.
+                                               _driver?.SetKittyKeyboardCapabilities (result);
+
+                                               if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
+                                               {
+                                                   supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
+                                               }
+
+                                               kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
 
                                               Trace.Lifecycle (app?.MainThreadId?.ToString (),
                                                                "KittyKeyboard",

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -83,8 +83,6 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     {
         if (string.IsNullOrEmpty (_pendingPrintableSuppression))
         {
-            _pendingPrintableSuppression = key.GetPrintableText ();
-
             return false;
         }
 

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,6 +39,7 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
+    private bool _isKittyKeyboardEnabled;
     private string _pendingPrintableSuppression = string.Empty;
 
     /// <inheritdoc/>
@@ -83,6 +84,16 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     {
         if (string.IsNullOrEmpty (_pendingPrintableSuppression))
         {
+            if (_isKittyKeyboardEnabled)
+            {
+                string fallbackPrintableText = key.GetPrintableText ();
+
+                if (!string.IsNullOrEmpty (fallbackPrintableText))
+                {
+                    _pendingPrintableSuppression = fallbackPrintableText;
+                }
+            }
+
             return false;
         }
 
@@ -92,6 +103,8 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
 
         return suppress;
     }
+
+    internal void SetKittyKeyboardEnabled (bool enabled) => _isKittyKeyboardEnabled = enabled;
 
     /// <inheritdoc/>
     public override void InjectKeyDownEvent (Key key)

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -227,9 +227,10 @@ public class KittyKeyboardPipelineTests
     [InlineData ("Ç", 199)]
     [InlineData ("º", 186)]
     [InlineData ("ª", 170)]
-    public void Pipeline_MixedKittyAndLegacyPrintable_PortugueseKeys_DoesNotRaiseDuplicateKeyDown (string printable, int kittyCode)
+    public void Pipeline_MixedKittyAndLegacyPrintable_PortugueseKeys_WhenKittySequencePresent_DoesNotRaiseDuplicateKeyDown (string printable, int kittyCode)
     {
-        // Issue #4918 (PT keyboard): kitty CSI-u plus legacy printable input for the same key should produce one KeyDown.
+        // Issue #4918 (PT keyboard): when kitty CSI-u and legacy printable input both arrive for the same keypress,
+        // the pipeline should raise only one KeyDown. This test is intentionally kitty-specific.
         var kittySequence = $"\x1b[{kittyCode}u";
         (List<Key> down, List<Key> up) = InjectRawSequence (kittySequence, printable);
 
@@ -252,6 +253,23 @@ public class KittyKeyboardPipelineTests
     }
 
     // Copilot
+    [Theory]
+    [InlineData ("«")]
+    [InlineData ("»")]
+    [InlineData ("ç")]
+    [InlineData ("Ç")]
+    [InlineData ("º")]
+    [InlineData ("ª")]
+    public void Pipeline_LegacyPrintable_PortugueseKeys_WhenKittySequenceNotPresent_DoesNotRaiseDuplicateKeyDown (string printable)
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence (printable);
+
+        Assert.Single (down);
+        Assert.Equal (printable, down [0].GetPrintableText ());
+        Assert.Empty (up);
+    }
+
+    // Copilot
     [Fact]
     public void Pipeline_RepeatedLegacyPrintableInput_DoesNotDropRepeatedCharacters ()
     {
@@ -259,6 +277,24 @@ public class KittyKeyboardPipelineTests
 
         Assert.Equal (12, down.Count);
         Assert.Equal ("111222333444", string.Concat (down.Select (key => key.GetPrintableText ())));
+        Assert.Empty (up);
+    }
+
+    // Copilot
+    [Theory]
+    [InlineData ("«")]
+    [InlineData ("»")]
+    [InlineData ("ç")]
+    [InlineData ("Ç")]
+    [InlineData ("º")]
+    [InlineData ("ª")]
+    public void Pipeline_RepeatedLegacyPrintable_PortugueseKeys_WithoutKittySequence_DoNotDropCharacters (string printable)
+    {
+        string input = printable + printable;
+        (List<Key> down, List<Key> up) = InjectRawSequence (input);
+
+        Assert.Equal (2, down.Count);
+        Assert.Equal (input, string.Concat (down.Select (key => key.GetPrintableText ())));
         Assert.Empty (up);
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -251,6 +251,17 @@ public class KittyKeyboardPipelineTests
         Assert.Empty (up);
     }
 
+    // Copilot
+    [Fact]
+    public void Pipeline_RepeatedLegacyPrintableInput_DoesNotDropRepeatedCharacters ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("111222333444");
+
+        Assert.Equal (12, down.Count);
+        Assert.Equal ("111222333444", string.Concat (down.Select (key => key.GetPrintableText ())));
+        Assert.Empty (up);
+    }
+
     #endregion
 
     #region Standalone Modifier Key Events

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -15,6 +15,16 @@ public class KittyKeyboardPipelineTests
     /// </summary>
     private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequence (params string [] sequences)
     {
+        return InjectRawSequenceCore (false, sequences);
+    }
+
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithKittyEnabled (params string [] sequences)
+    {
+        return InjectRawSequenceCore (true, sequences);
+    }
+
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (bool kittyKeyboardEnabled, params string [] sequences)
+    {
         VirtualTimeProvider timeProvider = new ();
         timeProvider.SetTime (new DateTime (2025, 1, 1, 12, 0, 0));
 
@@ -27,6 +37,7 @@ public class KittyKeyboardPipelineTests
         app.Keyboard.KeyUp += (_, key) => keyUpEvents.Add (key);
 
         IInputProcessor processor = app.Driver?.GetInputProcessor ()!;
+        ((AnsiInputProcessor)processor).SetKittyKeyboardEnabled (kittyKeyboardEnabled);
         ConcurrentQueue<char> queue = ((AnsiInputProcessor)processor).InputQueue;
 
         foreach (string seq in sequences)
@@ -221,18 +232,18 @@ public class KittyKeyboardPipelineTests
 
     // Copilot
     [Theory]
-    [InlineData ("«", 171)]
-    [InlineData ("»", 187)]
-    [InlineData ("ç", 231)]
-    [InlineData ("Ç", 199)]
-    [InlineData ("º", 186)]
-    [InlineData ("ª", 170)]
-    public void Pipeline_MixedKittyAndLegacyPrintable_PortugueseKeys_WhenKittySequencePresent_DoesNotRaiseDuplicateKeyDown (string printable, int kittyCode)
+    [InlineData ("«")]
+    [InlineData ("»")]
+    [InlineData ("ç")]
+    [InlineData ("Ç")]
+    [InlineData ("º")]
+    [InlineData ("ª")]
+    public void Pipeline_LegacyPrintable_PortugueseKeys_WhenKittyEnabled_DoesNotRaiseDuplicateKeyDown (string printable)
     {
-        // Issue #4918 (PT keyboard): when kitty CSI-u and legacy printable input both arrive for the same keypress,
-        // the pipeline should raise only one KeyDown. This test is intentionally kitty-specific.
-        var kittySequence = $"\x1b[{kittyCode}u";
-        (List<Key> down, List<Key> up) = InjectRawSequence (kittySequence, printable);
+        // Issue #4918 (PT keyboard): some glyphs may still arrive as duplicated legacy printable input
+        // even when kitty is enabled. A single keypress should still produce one KeyDown.
+        string duplicatedInput = printable + printable;
+        (List<Key> down, List<Key> up) = InjectRawSequenceWithKittyEnabled (duplicatedInput);
 
         Assert.Single (down);
         Assert.Equal (printable, down [0].GetPrintableText ());

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -288,7 +288,7 @@ public class KittyKeyboardPipelineTests
     [InlineData ("Ç")]
     [InlineData ("º")]
     [InlineData ("ª")]
-    public void Pipeline_RepeatedLegacyPrintable_PortugueseKeys_WithoutKittySequence_DoNotDropCharacters (string printable)
+    public void Pipeline_RepeatedLegacyPrintable_PortugueseKeys_WithoutKittySequence_DoesNotDropCharacters (string printable)
     {
         string input = printable + printable;
         (List<Key> down, List<Key> up) = InjectRawSequence (input);


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>61bf61e5-930c-4a8d-bf2c-723e6f1dc0ae</p></details>

## Summary

- preserve repeated ANSI legacy printable input on non-kitty terminals
- restore legacy glyph deduplication for kitty-enabled terminals where some PT glyphs still arrive as plain printable input
- propagate kitty capability state into `AnsiInputProcessor`
- replace flawed PT glyph coverage that assumed `«»çÇºª` always arrive as CSI-u

## Side-effects

- **Non-kitty terminals:** repeated printable keys like `111222` are no longer dropped
- **Kitty-enabled terminals:** fallback self-arming is restored only in kitty mode, so legacy-only duplicated glyphs like `«»çÇºª` can be deduped again
- **Watch point:** if a kitty-enabled terminal emits some other printable key only as legacy input instead of CSI-u, every second identical fallback character for that key may still be suppressed
- **Startup edge:** kitty mode is applied after startup detection, so input received before detection completes still behaves like non-kitty mode

## Testing

- `dotnet test --project Tests\UnitTestsParallelizable --filter-class "*KittyKeyboardPipelineTests"`
- `dotnet build --no-restore`
- `dotnet test --project Tests\UnitTestsParallelizable --no-build`
- `dotnet test --project Tests\UnitTests.NonParallelizable --no-build`
