### PR TITLE
Fixes #4975. Clarify MessageBox default-button docs and signatures

### DIFF
--- a/Examples/UICatalog/Scenarios/ChineseUI.cs
+++ b/Examples/UICatalog/Scenarios/ChineseUI.cs
@@ -35,16 +35,15 @@ public class ChineseUI : Scenario
 
         btn.Accepting += (s, _) =>
                       {
-                          int? result = MessageBox.Query (
-                                                          (s as View)?.App!,
-                                                          "Confirm",
-                                                         "Are you sure you want to quit ui?",
-                                                         0,
-                                                         "Yes",
-                                                         "No"
-                                                        );
+                           int? result = MessageBox.Query (
+                                                           (s as View)?.App!,
+                                                           "Confirm",
+                                                           "Are you sure you want to quit ui?",
+                                                           "No",
+                                                           "Yes"
+                                                         );
 
-                          if (result == 0)
+                          if (result == 1)
                           {
                               win.RequestStop ();
                           }

--- a/Examples/UICatalog/Scenarios/MessageBoxes.cs
+++ b/Examples/UICatalog/Scenarios/MessageBoxes.cs
@@ -94,27 +94,6 @@ public class MessageBoxes : Scenario
             Width = Dim.Width (label),
             Height = 1,
             TextAlignment = Alignment.End,
-            Text = "_Default Button:"
-        };
-        frame.Add (label);
-
-        TextField defaultButtonEdit = new ()
-        {
-            X = Pos.Right (label) + 1,
-            Y = Pos.Top (label),
-            Width = 5,
-            Height = 1,
-            Text = "0"
-        };
-        frame.Add (defaultButtonEdit);
-
-        label = new Label
-        {
-            X = 0,
-            Y = Pos.Bottom (label),
-            Width = Dim.Width (label),
-            Height = 1,
-            TextAlignment = Alignment.End,
             Text = "St_yle:"
         };
         frame.Add (label);
@@ -162,7 +141,6 @@ public class MessageBoxes : Scenario
                                 try
                                 {
                                     int numButtons = int.Parse (numButtonsEdit.Text);
-                                    int defaultButton = int.Parse (defaultButtonEdit.Text);
 
                                     List<string> messageBoxButtons = [];
 
@@ -178,7 +156,6 @@ public class MessageBoxes : Scenario
                                                 MessageBox.Query (app,
                                                                   titleEdit.Text,
                                                                   messageEdit.Text,
-                                                                  defaultButton,
                                                                   ckbWrapMessage.Value == CheckState.Checked,
                                                                   messageBoxButtons.ToArray ())
                                             }";
@@ -190,7 +167,6 @@ public class MessageBoxes : Scenario
                                                 MessageBox.ErrorQuery (app,
                                                                        titleEdit.Text,
                                                                        messageEdit.Text,
-                                                                       defaultButton,
                                                                        ckbWrapMessage.Value == CheckState.Checked,
                                                                        messageBoxButtons.ToArray ())
                                             }";

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Terminal.Gui.Views;
 
 /// <summary>
@@ -12,13 +10,16 @@ namespace Terminal.Gui.Views;
 ///         All methods return <see langword="int?"/> where the value is the 0-based index of the button pressed,
 ///         or <see langword="null"/> if the user pressed <see cref="Application.GetDefaultKey"/> (typically Esc).
 ///     </para>
-///     <para>
-///         <see cref="Query(IApplication, string, string, string[])"/> uses the default Dialog color scheme.
-///         <see cref="ErrorQuery(IApplication, string, string, string[])"/> uses the Error color scheme.
-///     </para>
-///     <para>
-///         <b>Important:</b> All MessageBox methods require an <see cref="IApplication"/> instance to be passed.
-///         This enables proper modal dialog management and respects the application's lifecycle. Pass your
+    ///     <para>
+    ///         <see cref="Query(IApplication, string, string, string[])"/> uses the default Dialog color scheme.
+    ///         <see cref="ErrorQuery(IApplication, string, string, string[])"/> uses the Error color scheme.
+    ///     </para>
+    ///     <para>
+    ///         The last button provided is always the default button.
+    ///     </para>
+    ///     <para>
+    ///         <b>Important:</b> All MessageBox methods require an <see cref="IApplication"/> instance to be passed.
+    ///         This enables proper modal dialog management and respects the application's lifecycle. Pass your
 ///         application instance (from <see cref="Application.Create"/>) or use the legacy
 ///         <see cref="Application.Instance"/> if using the static Application pattern.
 ///     </para>
@@ -88,7 +89,8 @@ public static class MessageBox
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
+    ///     The MessageBox is centered and auto-sized based on title, message, and buttons. The last button is the
+    ///     default button.
     /// </remarks>
     public static int? ErrorQuery (IApplication app, string title, string message, params string [] buttons)
     {
@@ -97,18 +99,16 @@ public static class MessageBox
                            true,
                            title,
                            message,
-                           null,
                            true,
                            buttons);
     }
 
     /// <summary>
-    ///     Displays an auto-sized error <see cref="MessageBox"/> with a default button and word-wrap control.
+    ///     Displays an auto-sized error <see cref="MessageBox"/> with word-wrap control.
     /// </summary>
     /// <param name="app">The application instance. If <see langword="null"/>, uses <see cref="IApplication.TopRunnableView"/>.</param>
     /// <param name="title">Title for the MessageBox.</param>
     /// <param name="message">Message to display. May contain multiple lines.</param>
-    /// <param name="defaultButton">Index of the default button (0-based).</param>
     /// <param name="wrapMessage">
     ///     If <see langword="true"/>, word-wraps the message; otherwise displays as-is with multi-line
     ///     support.
@@ -119,17 +119,14 @@ public static class MessageBox
     ///     <see cref="Application.GetDefaultKey"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
-    /// </exception>
     /// <remarks>
-    ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
+    ///     The MessageBox is centered and auto-sized based on title, message, and buttons. The last button is the
+    ///     default button.
     /// </remarks>
     public static int? ErrorQuery (
         IApplication app,
         string title,
         string message,
-        int defaultButton = 0,
         bool wrapMessage = true,
         params string [] buttons
     )
@@ -139,7 +136,6 @@ public static class MessageBox
                            true,
                            title,
                            message,
-                           defaultButton,
                            wrapMessage,
                            buttons);
     }
@@ -160,7 +156,7 @@ public static class MessageBox
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
     /// <remarks>
     ///     Consider using <see cref="Query(IApplication, string, string, string[])"/> which automatically sizes the
-    ///     MessageBox.
+    ///     MessageBox. The last button is the default button.
     /// </remarks>
     public static int? Query (IApplication app, int width, int height, string title, string message, params string [] buttons)
     {
@@ -169,7 +165,6 @@ public static class MessageBox
                            false,
                            title,
                            message,
-                           null,
                            true,
                            buttons);
     }
@@ -187,7 +182,8 @@ public static class MessageBox
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
+    ///     The MessageBox is centered and auto-sized based on title, message, and buttons. The last button is the
+    ///     default button.
     /// </remarks>
     public static int? Query (IApplication app, string title, string message, params string [] buttons)
     {
@@ -196,49 +192,16 @@ public static class MessageBox
                            false,
                            title,
                            message,
-                           null,
                            true,
                            buttons);
     }
 
     /// <summary>
-    ///     Displays an auto-sized <see cref="MessageBox"/> with a default button.
-    /// </summary>
-    /// <param name="app">The application instance. If <see langword="null"/>, uses <see cref="IApplication.TopRunnableView"/>.</param>
-    /// <param name="title">Title for the MessageBox.</param>
-    /// <param name="message">Message to display. May contain multiple lines and will be word-wrapped.</param>
-    /// <param name="defaultButton">Index of the default button (0-based).</param>
-    /// <param name="buttons">Array of button labels.</param>
-    /// <returns>
-    ///     The index of the selected button, or <see langword="null"/> if the user pressed
-    ///     <see cref="Application.GetDefaultKey"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
-    /// </exception>
-    /// <remarks>
-    ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
-    /// </remarks>
-    public static int? Query (IApplication app, string title, string message, int defaultButton = 0, params string [] buttons)
-    {
-        return QueryFull (
-                           app,
-                           false,
-                           title,
-                           message,
-                           defaultButton,
-                           true,
-                           buttons);
-    }
-
-    /// <summary>
-    ///     Displays an auto-sized <see cref="MessageBox"/> with a default button and word-wrap control.
+    ///     Displays an auto-sized <see cref="MessageBox"/> with word-wrap control.
     /// </summary>
     /// <param name="app">The application instance. If <see langword="null"/>, uses <see cref="IApplication.TopRunnableView"/>.</param>
     /// <param name="title">Title for the MessageBox.</param>
     /// <param name="message">Message to display. May contain multiple lines.</param>
-    /// <param name="defaultButton">Index of the default button (0-based).</param>
     /// <param name="wrapMessage">
     ///     If <see langword="true"/>, word-wraps the message; otherwise displays as-is with multi-line
     ///     support.
@@ -249,17 +212,14 @@ public static class MessageBox
     ///     <see cref="Application.GetDefaultKey"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
-    /// </exception>
     /// <remarks>
-    ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
+    ///     The MessageBox is centered and auto-sized based on title, message, and buttons. The last button is the
+    ///     default button.
     /// </remarks>
     public static int? Query (
         IApplication app,
         string title,
         string message,
-        int defaultButton = 0,
         bool wrapMessage = true,
         params string [] buttons
     )
@@ -269,7 +229,6 @@ public static class MessageBox
                            false,
                            title,
                            message,
-                           defaultButton,
                            wrapMessage,
                            buttons);
     }
@@ -279,7 +238,6 @@ public static class MessageBox
         bool useErrorScheme,
         string title,
         string message,
-        int? defaultButton,
         bool wrapMessage = true,
         params string [] buttons
     )
@@ -301,7 +259,7 @@ public static class MessageBox
         dialog.TextFormatter.MultiLine = !wrapMessage;
 
         dialog.Buttons = buttonList.ToArray ();
-        SetDefaultButton (dialog, defaultButton);
+        dialog.Buttons.FirstOrDefault (b => b.IsDefault)?.SetFocus ();
 
         dialog.Accepting += (sender, args) =>
                             {
@@ -318,35 +276,5 @@ public static class MessageBox
         int? result = app.Run (dialog) as int?;
 
         return result;
-    }
-
-    private static void SetDefaultButton (Dialog dialog, int? defaultButton)
-    {
-        Button [] dialogButtons = dialog.Buttons;
-
-        if (!defaultButton.HasValue)
-        {
-            dialogButtons.FirstOrDefault (button => button.IsDefault)?.SetFocus ();
-
-            return;
-        }
-
-        ValidateDefaultButton (defaultButton.Value, dialogButtons.Length);
-
-        foreach (Button button in dialogButtons)
-        {
-            button.IsDefault = false;
-        }
-
-        Button defaultDialogButton = dialogButtons [defaultButton.Value];
-        defaultDialogButton.IsDefault = true;
-        dialog.DefaultAcceptView = defaultDialogButton;
-        defaultDialogButton.SetFocus ();
-    }
-
-    private static void ValidateDefaultButton (int defaultButton, int buttonCount)
-    {
-        ArgumentOutOfRangeException.ThrowIfNegative (defaultButton, nameof (defaultButton));
-        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual (defaultButton, buttonCount, nameof (defaultButton));
     }
 }

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -93,12 +93,13 @@ public static class MessageBox
     public static int? ErrorQuery (IApplication app, string title, string message, params string [] buttons)
     {
         return QueryFull (
-                          app,
-                          true,
-                          title,
-                          message,
-                          true,
-                          buttons);
+                           app,
+                           true,
+                           title,
+                           message,
+                           null,
+                           true,
+                           buttons);
     }
 
     /// <summary>
@@ -118,6 +119,9 @@ public static class MessageBox
     ///     <see cref="Application.GetDefaultKey"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
+    /// </exception>
     /// <remarks>
     ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
     /// </remarks>
@@ -131,12 +135,13 @@ public static class MessageBox
     )
     {
         return QueryFull (
-                          app,
-                          true,
-                          title,
-                          message,
-                          wrapMessage,
-                          buttons);
+                           app,
+                           true,
+                           title,
+                           message,
+                           defaultButton,
+                           wrapMessage,
+                           buttons);
     }
 
     /// <summary>
@@ -160,12 +165,13 @@ public static class MessageBox
     public static int? Query (IApplication app, int width, int height, string title, string message, params string [] buttons)
     {
         return QueryFull (
-                          app,
-                          false,
-                          title,
-                          message,
-                          true,
-                          buttons);
+                           app,
+                           false,
+                           title,
+                           message,
+                           null,
+                           true,
+                           buttons);
     }
 
     /// <summary>
@@ -186,12 +192,13 @@ public static class MessageBox
     public static int? Query (IApplication app, string title, string message, params string [] buttons)
     {
         return QueryFull (
-                          app,
-                          false,
-                          title,
-                          message,
-                          true,
-                          buttons);
+                           app,
+                           false,
+                           title,
+                           message,
+                           null,
+                           true,
+                           buttons);
     }
 
     /// <summary>
@@ -207,18 +214,22 @@ public static class MessageBox
     ///     <see cref="Application.GetDefaultKey"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
+    /// </exception>
     /// <remarks>
     ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
     /// </remarks>
     public static int? Query (IApplication app, string title, string message, int defaultButton = 0, params string [] buttons)
     {
         return QueryFull (
-                          app,
-                          false,
-                          title,
-                          message,
-                          true,
-                          buttons);
+                           app,
+                           false,
+                           title,
+                           message,
+                           defaultButton,
+                           true,
+                           buttons);
     }
 
     /// <summary>
@@ -238,6 +249,9 @@ public static class MessageBox
     ///     <see cref="Application.GetDefaultKey"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     Thrown if <paramref name="defaultButton"/> is outside valid button index range.
+    /// </exception>
     /// <remarks>
     ///     The MessageBox is centered and auto-sized based on title, message, and buttons.
     /// </remarks>
@@ -251,12 +265,13 @@ public static class MessageBox
     )
     {
         return QueryFull (
-                          app,
-                          false,
-                          title,
-                          message,
-                          wrapMessage,
-                          buttons);
+                           app,
+                           false,
+                           title,
+                           message,
+                           defaultButton,
+                           wrapMessage,
+                           buttons);
     }
 
     private static int? QueryFull (
@@ -264,6 +279,7 @@ public static class MessageBox
         bool useErrorScheme,
         string title,
         string message,
+        int? defaultButton,
         bool wrapMessage = true,
         params string [] buttons
     )
@@ -285,7 +301,7 @@ public static class MessageBox
         dialog.TextFormatter.MultiLine = !wrapMessage;
 
         dialog.Buttons = buttonList.ToArray ();
-        dialog.Buttons.FirstOrDefault (b => b.IsDefault)?.SetFocus ();
+        SetDefaultButton (dialog, defaultButton);
 
         dialog.Accepting += (sender, args) =>
                             {
@@ -302,5 +318,35 @@ public static class MessageBox
         int? result = app.Run (dialog) as int?;
 
         return result;
+    }
+
+    private static void SetDefaultButton (Dialog dialog, int? defaultButton)
+    {
+        Button [] dialogButtons = dialog.Buttons;
+
+        if (!defaultButton.HasValue)
+        {
+            dialogButtons.FirstOrDefault (button => button.IsDefault)?.SetFocus ();
+
+            return;
+        }
+
+        ValidateDefaultButton (defaultButton.Value, dialogButtons.Length);
+
+        foreach (Button button in dialogButtons)
+        {
+            button.IsDefault = false;
+        }
+
+        Button defaultDialogButton = dialogButtons [defaultButton.Value];
+        defaultDialogButton.IsDefault = true;
+        dialog.DefaultAcceptView = defaultDialogButton;
+        defaultDialogButton.SetFocus ();
+    }
+
+    private static void ValidateDefaultButton (int defaultButton, int buttonCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative (defaultButton, nameof (defaultButton));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual (defaultButton, buttonCount, nameof (defaultButton));
     }
 }

--- a/Tests/UnitTestsParallelizable/Views/MessageBoxTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/MessageBoxTests.cs
@@ -100,6 +100,135 @@ public class MessageBoxTests
         yield return [Key.Space];
     }
 
+    // Copilot
+    [Fact]
+    public void Query_With_Default_Button_Index_Sets_Default_Button_And_Focus ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        try
+        {
+            int? result = null;
+            var iteration = 0;
+
+            app.Iteration += OnApplicationOnIteration;
+            result = MessageBox.Query (app, "hey", "IsDefault", 0, Strings.btnNo, Strings.btnYes);
+            app.Iteration -= OnApplicationOnIteration;
+
+            Assert.Null (result);
+
+            void OnApplicationOnIteration (object? sender, EventArgs<IApplication?> args)
+            {
+                iteration++;
+
+                if (iteration != 1)
+                {
+                    return;
+                }
+
+                Dialog dialog = (Dialog)app.TopRunnableView!;
+                Button [] buttons = dialog.Buttons;
+
+                Assert.True (buttons [0].IsDefault);
+                Assert.False (buttons [1].IsDefault);
+                Assert.Same (buttons [0], dialog.DefaultAcceptView);
+                Assert.True (buttons [0].HasFocus);
+
+                app.RequestStop ();
+            }
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
+    // Copilot
+    [Fact]
+    public void ErrorQuery_With_Default_Button_Index_Sets_Default_Button_And_Focus ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        try
+        {
+            int? result = null;
+            var iteration = 0;
+
+            app.Iteration += OnApplicationOnIteration;
+            result = MessageBox.ErrorQuery (app, "Error", "Message", 0, true, Strings.btnNo, Strings.btnYes);
+            app.Iteration -= OnApplicationOnIteration;
+
+            Assert.Null (result);
+
+            void OnApplicationOnIteration (object? sender, EventArgs<IApplication?> args)
+            {
+                iteration++;
+
+                if (iteration != 1)
+                {
+                    return;
+                }
+
+                Dialog dialog = (Dialog)app.TopRunnableView!;
+                Button [] buttons = dialog.Buttons;
+
+                Assert.True (buttons [0].IsDefault);
+                Assert.False (buttons [1].IsDefault);
+                Assert.Same (buttons [0], dialog.DefaultAcceptView);
+                Assert.True (buttons [0].HasFocus);
+
+                app.RequestStop ();
+            }
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
+    // Copilot
+    [Theory]
+    [MemberData (nameof (AcceptingKeys))]
+    public void Enter_Or_Space_Returns_Explicit_Default_Button_Index (Key key)
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        try
+        {
+            app.Iteration += OnApplicationOnIteration;
+            int? result = MessageBox.Query (app, "hey", "IsDefault", 0, Strings.btnNo, Strings.btnYes);
+            app.Iteration -= OnApplicationOnIteration;
+
+            Assert.Equal (0, result);
+
+            void OnApplicationOnIteration (object? sender, EventArgs<IApplication?> args) => Assert.True (app.Keyboard.RaiseKeyDownEvent (key));
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
+    // Copilot
+    [Fact]
+    public void Query_With_Out_Of_Range_Default_Button_Throws ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        try
+        {
+            Assert.Throws<ArgumentOutOfRangeException> (() => MessageBox.Query (app, "hey", "IsDefault", 2, Strings.btnNo, Strings.btnYes));
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
     // Claude - Opus 4.5
     [Fact]
     public void Query_Sets_Dialog_SchemeName ()

--- a/Tests/UnitTestsParallelizable/Views/MessageBoxTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/MessageBoxTests.cs
@@ -26,7 +26,7 @@ public class MessageBoxTests
                 switch (iteration)
                 {
                     case 1:
-                        result = MessageBox.Query (app, string.Empty, string.Empty, 0, false, "btn0", "btn1");
+                        result = MessageBox.Query (app, string.Empty, string.Empty, false, "btn0", "btn1");
                         app.RequestStop ();
 
                         break;
@@ -102,7 +102,7 @@ public class MessageBoxTests
 
     // Copilot
     [Fact]
-    public void Query_With_Default_Button_Index_Sets_Default_Button_And_Focus ()
+    public void Query_Uses_Last_Button_As_Default ()
     {
         IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
@@ -113,7 +113,7 @@ public class MessageBoxTests
             var iteration = 0;
 
             app.Iteration += OnApplicationOnIteration;
-            result = MessageBox.Query (app, "hey", "IsDefault", 0, Strings.btnNo, Strings.btnYes);
+            result = MessageBox.Query (app, "hey", "IsDefault", Strings.btnNo, Strings.btnYes);
             app.Iteration -= OnApplicationOnIteration;
 
             Assert.Null (result);
@@ -130,10 +130,10 @@ public class MessageBoxTests
                 Dialog dialog = (Dialog)app.TopRunnableView!;
                 Button [] buttons = dialog.Buttons;
 
-                Assert.True (buttons [0].IsDefault);
-                Assert.False (buttons [1].IsDefault);
-                Assert.Same (buttons [0], dialog.DefaultAcceptView);
-                Assert.True (buttons [0].HasFocus);
+                Assert.False (buttons [0].IsDefault);
+                Assert.True (buttons [1].IsDefault);
+                Assert.Same (buttons [1], dialog.DefaultAcceptView);
+                Assert.True (buttons [1].HasFocus);
 
                 app.RequestStop ();
             }
@@ -146,7 +146,7 @@ public class MessageBoxTests
 
     // Copilot
     [Fact]
-    public void ErrorQuery_With_Default_Button_Index_Sets_Default_Button_And_Focus ()
+    public void ErrorQuery_Uses_Last_Button_As_Default ()
     {
         IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
@@ -157,7 +157,7 @@ public class MessageBoxTests
             var iteration = 0;
 
             app.Iteration += OnApplicationOnIteration;
-            result = MessageBox.ErrorQuery (app, "Error", "Message", 0, true, Strings.btnNo, Strings.btnYes);
+            result = MessageBox.ErrorQuery (app, "Error", "Message", Strings.btnNo, Strings.btnYes);
             app.Iteration -= OnApplicationOnIteration;
 
             Assert.Null (result);
@@ -174,54 +174,13 @@ public class MessageBoxTests
                 Dialog dialog = (Dialog)app.TopRunnableView!;
                 Button [] buttons = dialog.Buttons;
 
-                Assert.True (buttons [0].IsDefault);
-                Assert.False (buttons [1].IsDefault);
-                Assert.Same (buttons [0], dialog.DefaultAcceptView);
-                Assert.True (buttons [0].HasFocus);
+                Assert.False (buttons [0].IsDefault);
+                Assert.True (buttons [1].IsDefault);
+                Assert.Same (buttons [1], dialog.DefaultAcceptView);
+                Assert.True (buttons [1].HasFocus);
 
                 app.RequestStop ();
             }
-        }
-        finally
-        {
-            app.Dispose ();
-        }
-    }
-
-    // Copilot
-    [Theory]
-    [MemberData (nameof (AcceptingKeys))]
-    public void Enter_Or_Space_Returns_Explicit_Default_Button_Index (Key key)
-    {
-        IApplication app = Application.Create ();
-        app.Init (DriverRegistry.Names.ANSI);
-
-        try
-        {
-            app.Iteration += OnApplicationOnIteration;
-            int? result = MessageBox.Query (app, "hey", "IsDefault", 0, Strings.btnNo, Strings.btnYes);
-            app.Iteration -= OnApplicationOnIteration;
-
-            Assert.Equal (0, result);
-
-            void OnApplicationOnIteration (object? sender, EventArgs<IApplication?> args) => Assert.True (app.Keyboard.RaiseKeyDownEvent (key));
-        }
-        finally
-        {
-            app.Dispose ();
-        }
-    }
-
-    // Copilot
-    [Fact]
-    public void Query_With_Out_Of_Range_Default_Button_Throws ()
-    {
-        IApplication app = Application.Create ();
-        app.Init (DriverRegistry.Names.ANSI);
-
-        try
-        {
-            Assert.Throws<ArgumentOutOfRangeException> (() => MessageBox.Query (app, "hey", "IsDefault", 2, Strings.btnNo, Strings.btnYes));
         }
         finally
         {


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>894256a0-c83e-487e-9244-a975e8cfca7b</p></details>
Fixes #4975.

## Root cause
`MessageBox` intentionally uses the last added button as the default button. That behavior comes from the dialog button flow: `MessageBox` creates buttons from text, assigns them through `dialog.Buttons = ...`, and `Dialog.AddButton` makes the last added button the dialog's `DefaultAcceptView` and marks it `IsDefault`.

The misleading part was the API surface and docs. Some `MessageBox.Query` / `MessageBox.ErrorQuery` signatures and XML docs still implied callers could choose a default button with a `defaultButton` parameter, even though intended runtime behavior was to keep the last button as default.

## Fix
- remove misleading `defaultButton` overloads from `MessageBox.Query` / `MessageBox.ErrorQuery`
- update `MessageBox` docs to state that the last button is the default button
- update affected examples and tests to match the intended API and behavior
- keep regression coverage focused on the last-button-default behavior

## Validation
- `dotnet build --no-restore`
- `dotnet test --project Tests\UnitTestsParallelizable --no-build --filter-class "*MessageBoxTests"`
- `dotnet test --project Tests\UnitTestsParallelizable --no-build`
- `dotnet test --project Tests\UnitTests.NonParallelizable --no-build`
